### PR TITLE
Enforce group coherency legality for moves

### DIFF
--- a/examples/env_config/1_model_1_objective.yaml
+++ b/examples/env_config/1_model_1_objective.yaml
@@ -3,3 +3,4 @@ number_of_objectives: 1
 objective_radius_size: 3
 board_width: 50
 board_height: 50
+group_max_distance: 3

--- a/examples/env_config/3_models_2_objectives.yaml
+++ b/examples/env_config/3_models_2_objectives.yaml
@@ -5,3 +5,4 @@ objective_radius_size: 3
 board_width: 60
 board_height: 44
 max_groups: 1
+group_max_distance: 3

--- a/examples/env_config/4_models_2_objectives.yaml
+++ b/examples/env_config/4_models_2_objectives.yaml
@@ -5,3 +5,4 @@ objective_radius_size: 3
 board_width: 60
 board_height: 44
 max_groups: 2
+group_max_distance: 3

--- a/examples/env_config/4_models_2_objectives_custom_stats.yaml
+++ b/examples/env_config/4_models_2_objectives_custom_stats.yaml
@@ -5,6 +5,7 @@ objective_radius_size: 3
 board_width: 60
 board_height: 44
 max_groups: 2
+group_max_distance: 3
 
 # Attributes only (no x/y) — models are placed randomly but with
 # explicit group assignments and wound pools.

--- a/examples/env_config/4_models_2_objectives_fixed.yaml
+++ b/examples/env_config/4_models_2_objectives_fixed.yaml
@@ -5,6 +5,7 @@ objective_radius_size: 3
 board_width: 60
 board_height: 44
 max_groups: 2
+group_max_distance: 3
 
 models:
   - { x: 5, y: 10, group_id: 0 }

--- a/examples/env_config/4_models_2_objectives_fixed_phased.yaml
+++ b/examples/env_config/4_models_2_objectives_fixed_phased.yaml
@@ -5,6 +5,7 @@ objective_radius_size: 3
 board_width: 60
 board_height: 44
 max_groups: 2
+group_max_distance: 3
 
 models:
   - { x: 5, y: 10, group_id: 0 }

--- a/examples/env_config/4v4_scripted_opponent_fixed_objectives.yaml
+++ b/examples/env_config/4v4_scripted_opponent_fixed_objectives.yaml
@@ -6,6 +6,7 @@ objective_radius_size: 3
 board_width: 60
 board_height: 44
 max_groups: 2
+group_max_distance: 3
 turn_order: random
 
 deployment_zone: [0, 0, 20, 44]

--- a/examples/env_config/4v4_scripted_opponent_fixed_objectives_2_reward_phases.yaml
+++ b/examples/env_config/4v4_scripted_opponent_fixed_objectives_2_reward_phases.yaml
@@ -6,6 +6,7 @@ objective_radius_size: 3
 board_width: 60
 board_height: 44
 max_groups: 2
+group_max_distance: 3
 turn_order: random
 
 deployment_zone: [0, 0, 20, 44]

--- a/examples/env_config/example.yaml
+++ b/examples/env_config/example.yaml
@@ -4,3 +4,4 @@ objective_radius_size: 5
 board_width: 100
 board_height: 74
 max_groups: 100
+group_max_distance: 3

--- a/examples/env_config/set_deployments/corner_quadrants.yaml
+++ b/examples/env_config/set_deployments/corner_quadrants.yaml
@@ -5,6 +5,7 @@ objective_radius_size: 3
 board_width: 60
 board_height: 44
 max_groups: 2
+group_max_distance: 3
 
 deployment_zone: [0, 22, 30, 44]
 opponent_deployment_zone: [30, 0, 60, 22]

--- a/examples/env_config/set_deployments/diagonal_offset.yaml
+++ b/examples/env_config/set_deployments/diagonal_offset.yaml
@@ -5,6 +5,7 @@ objective_radius_size: 3
 board_width: 60
 board_height: 44
 max_groups: 2
+group_max_distance: 3
 
 deployment_zone: [0, 0, 24, 44]
 opponent_deployment_zone: [36, 0, 60, 44]

--- a/examples/env_config/set_deployments/diagonal_triangles.yaml
+++ b/examples/env_config/set_deployments/diagonal_triangles.yaml
@@ -5,6 +5,7 @@ objective_radius_size: 3
 board_width: 60
 board_height: 44
 max_groups: 2
+group_max_distance: 3
 
 deployment_zone: [0, 22, 30, 44]
 opponent_deployment_zone: [30, 0, 60, 22]

--- a/examples/env_config/set_deployments/horizontal_strips.yaml
+++ b/examples/env_config/set_deployments/horizontal_strips.yaml
@@ -5,6 +5,7 @@ objective_radius_size: 3
 board_width: 60
 board_height: 44
 max_groups: 2
+group_max_distance: 3
 
 deployment_zone: [0, 32, 60, 44]
 opponent_deployment_zone: [0, 0, 60, 12]

--- a/examples/env_config/set_deployments/opposing_corners.yaml
+++ b/examples/env_config/set_deployments/opposing_corners.yaml
@@ -5,6 +5,7 @@ objective_radius_size: 3
 board_width: 60
 board_height: 44
 max_groups: 2
+group_max_distance: 3
 
 deployment_zone: [30, 26, 60, 44]
 opponent_deployment_zone: [0, 0, 30, 18]

--- a/examples/env_config/set_deployments/vertical_strips.yaml
+++ b/examples/env_config/set_deployments/vertical_strips.yaml
@@ -5,6 +5,7 @@ objective_radius_size: 3
 board_width: 60
 board_height: 44
 max_groups: 2
+group_max_distance: 3
 
 deployment_zone: [0, 0, 18, 44]
 opponent_deployment_zone: [42, 0, 60, 44]

--- a/examples/env_config/with_opponents/2v2_fixed_positions.yaml
+++ b/examples/env_config/with_opponents/2v2_fixed_positions.yaml
@@ -6,6 +6,7 @@ objective_radius_size: 3
 board_width: 40
 board_height: 30
 max_groups: 1
+group_max_distance: 3
 turn_order: opponent
 
 deployment_zone: [0, 0, 12, 30]

--- a/examples/env_config/with_opponents/4v4_random_opponent.yaml
+++ b/examples/env_config/with_opponents/4v4_random_opponent.yaml
@@ -6,6 +6,7 @@ objective_radius_size: 3
 board_width: 60
 board_height: 44
 max_groups: 2
+group_max_distance: 3
 turn_order: player
 
 opponent_policy:

--- a/examples/env_config/with_opponents/4v4_scripted_opponent.yaml
+++ b/examples/env_config/with_opponents/4v4_scripted_opponent.yaml
@@ -6,6 +6,7 @@ objective_radius_size: 3
 board_width: 60
 board_height: 44
 max_groups: 2
+group_max_distance: 3
 turn_order: random
 
 deployment_zone: [0, 0, 20, 44]

--- a/tests/test_group_coherency_legality.py
+++ b/tests/test_group_coherency_legality.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import numpy as np
+
+from wargame_rl.wargame.envs.env_components.actions import ActionHandler
+from wargame_rl.wargame.envs.types import WargameEnvAction, WargameEnvConfig
+from wargame_rl.wargame.envs.types.config import ModelConfig, ObjectiveConfig
+from wargame_rl.wargame.envs.wargame import WargameEnv
+
+
+def _base_config(*, enforce_flag: bool) -> WargameEnvConfig:
+    return WargameEnvConfig(
+        render_mode=None,
+        board_width=10,
+        board_height=10,
+        number_of_wargame_models=2,
+        number_of_objectives=1,
+        objective_radius_size=1,
+        number_of_battle_rounds=5,
+        # Keep movement discretisation stable for the action we pick below.
+        n_movement_angles=16,
+        n_speed_bins=6,
+        max_move_speed=6.0,
+        group_max_distance=1.0,
+        enforce_group_coherency_legality=enforce_flag,
+        models=[
+            ModelConfig(x=0, y=0, group_id=0),
+            ModelConfig(x=0, y=1, group_id=0),
+        ],
+        objectives=[ObjectiveConfig(x=9, y=9)],
+        # Default skip_phases makes each env.step() cover the movement phase.
+    )
+
+
+def _north_move_action(*, handler: ActionHandler, speed_idx: int) -> int:
+    """Return an action moving "north" for the given speed bin index."""
+    # With the default 16 movement angles, index 4 corresponds to pi/2 (north).
+    angle_idx = 4
+    return handler.encode_action(angle_idx=angle_idx, speed_idx=speed_idx)
+
+
+def test_illegal_move_reverts_to_previous_location_when_enabled() -> None:
+    cfg = _base_config(enforce_flag=True)
+    env = WargameEnv(config=cfg)
+    env.reset(seed=0)
+
+    assert np.array_equal(env.wargame_models[0].location, [0, 0])
+    assert np.array_equal(env.wargame_models[1].location, [0, 1])
+
+    handler = ActionHandler(cfg)
+    move_far_north = _north_move_action(handler=handler, speed_idx=4)  # dy=5
+
+    env.step(WargameEnvAction(actions=[move_far_north, 0]))  # model 1 stays
+
+    # dy=5 breaks coherency with group_max_distance=1.0, so the move is reverted.
+    assert np.array_equal(env.wargame_models[0].location, [0, 0])
+    assert np.array_equal(env.wargame_models[1].location, [0, 1])
+
+
+def test_illegal_move_does_not_revert_when_disabled() -> None:
+    cfg = _base_config(enforce_flag=False)
+    env = WargameEnv(config=cfg)
+    env.reset(seed=0)
+
+    handler = ActionHandler(cfg)
+    move_far_north = _north_move_action(handler=handler, speed_idx=4)  # dy=5
+
+    env.step(WargameEnvAction(actions=[move_far_north, 0]))  # model 1 stays
+
+    # With the legality check disabled, the move should apply normally.
+    assert np.array_equal(env.wargame_models[0].location, [0, 5])
+    assert np.array_equal(env.wargame_models[1].location, [0, 1])
+
+
+def test_legal_move_is_allowed_when_enabled() -> None:
+    cfg = _base_config(enforce_flag=True)
+    env = WargameEnv(config=cfg)
+    env.reset(seed=0)
+
+    handler = ActionHandler(cfg)
+    move_north_by_1 = _north_move_action(handler=handler, speed_idx=0)  # dy=1
+
+    env.step(WargameEnvAction(actions=[move_north_by_1, 0]))  # model 1 stays
+
+    # dy=1 results in overlapping positions, which is coherent (distance 0).
+    assert np.array_equal(env.wargame_models[0].location, [0, 1])
+    assert np.array_equal(env.wargame_models[1].location, [0, 1])

--- a/wargame_rl/wargame/envs/env_components/actions.py
+++ b/wargame_rl/wargame/envs/env_components/actions.py
@@ -111,6 +111,11 @@ class ActionHandler:
     def __init__(
         self, config: WargameEnvConfig, *, n_models: int | None = None
     ) -> None:
+        self._enforce_group_coherency_legality: bool = (
+            config.enforce_group_coherency_legality
+        )
+        self._group_max_distance: float = float(config.group_max_distance)
+
         self._n_models = (
             n_models if n_models is not None else config.number_of_wargame_models
         )
@@ -231,3 +236,35 @@ class ActionHandler:
                 [0, 0],
                 [board_width - 1, board_height - 1],
             )
+
+            # Optionally enforce "group coherency" as a hard movement legality
+            # constraint: after each tentative move, verify the moved model's
+            # `group_id` peers still have a same-group neighbor within
+            # `group_max_distance`. If not, revert this model to its previous
+            # location (effectively treating it like `stay`).
+            if self._enforce_group_coherency_legality and not np.all(displacement == 0):
+                if not self._is_group_coherent(wargame_models, model.group_id):
+                    if model.previous_location is None:
+                        raise RuntimeError(
+                            "previous_location was not set before applying action"
+                        )
+                    model.location = model.previous_location.copy()
+
+    def _is_group_coherent(self, wargame_models: list[Any], group_id: int) -> bool:
+        """Check that every model in `group_id` has a same-group peer nearby.
+
+        Rule implemented here matches the existing reward criteria semantics:
+        - A group with 0-1 models is always coherent.
+        - Otherwise, every model must have at least one same-group member at
+          distance <= `group_max_distance` (Euclidean / L2).
+        """
+        group_models = [m for m in wargame_models if m.group_id == group_id]
+        if len(group_models) <= 1:
+            return True
+
+        locs = np.array([m.location for m in group_models], dtype=np.float64)
+        deltas = locs[:, np.newaxis, :] - locs[np.newaxis, :, :]
+        dists = np.linalg.norm(deltas, axis=2, ord=2)  # (n, n)
+        np.fill_diagonal(dists, np.inf)
+        min_dists = dists.min(axis=1)
+        return bool((min_dists <= self._group_max_distance).all())

--- a/wargame_rl/wargame/envs/types/config.py
+++ b/wargame_rl/wargame/envs/types/config.py
@@ -197,8 +197,8 @@ class WargameEnvConfig(BaseModel):
     )
     group_max_distance: float = Field(
         gt=0,
-        default=10.0,
-        description="Max distance (L2) for group-aware placement on reset: models in the same group spawn within this distance. Reward phases use their own group_cohesion params.",
+        default=3.0,
+        description="Max distance (L2) for group-aware placement on reset: models in the same group spawn within this distance (default 3). Reward phases use their own group_cohesion params.",
     )
     enforce_group_coherency_legality: bool = Field(
         default=False,

--- a/wargame_rl/wargame/envs/types/config.py
+++ b/wargame_rl/wargame/envs/types/config.py
@@ -200,6 +200,15 @@ class WargameEnvConfig(BaseModel):
         default=10.0,
         description="Max distance (L2) for group-aware placement on reset: models in the same group spawn within this distance. Reward phases use their own group_cohesion params.",
     )
+    enforce_group_coherency_legality: bool = Field(
+        default=False,
+        description=(
+            "If true, movement attempts that would break group coherency are "
+            "treated as physically illegal for that model: its move is "
+            "reverted to `previous_location` (effectively becoming `stay`). "
+            "Uses `group_max_distance` as the coherency threshold."
+        ),
+    )
     max_groups: int = Field(
         gt=0,
         default=100,


### PR DESCRIPTION
## Summary
Enforces group coherency as a physical movement legality constraint (optional via config flag).

## Changes
- env: add enforce_group_coherency_legality to WargameEnvConfig
- env: in ActionHandler.apply, optionally revert illegal group-breaking moves
- tests: add tests/test_group_coherency_legality.py