### PR TITLE
docs: add transformer shooting head and dead-entity masking to foundation backlog

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -133,6 +133,8 @@ the current one finishes.
 #### Foundation (cross-cutting, slotted into milestones as needed)
 
 - [ ] Positional encoding for transformer network
+- [ ] Transformer shooting head: structural alignment between opponent tokens and target selection (avoid relying on learned implicit index correspondence via a single linear head)
+- [ ] Attention masking for dead entities: prevent dead model tokens from diluting attention signal and wasting network capacity learning to ignore them
 - [ ] Hyperparameter sweep tooling (Wandb Sweeps or Optuna)
 - [ ] Improved metrics & dashboards (win rate, avg turns, reward breakdown, group violation rate)
 


### PR DESCRIPTION
## Summary

Add two foundation backlog items to PROJECT.md for future transformer architecture improvements:
- Pointer-style shooting head for structural alignment between opponent tokens and target selection
- Attention masking for dead entities to prevent diluted attention signal

## Changes

- `.planning/PROJECT.md`: two new Foundation items in the cross-cutting backlog