### PR TITLE
ci: add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  ci-passed:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Format check
+        run: uv run ruff format --check
+
+      - name: Lint
+        run: uv run ruff check
+
+      - name: Type check
+        run: uv run mypy --ignore-missing-imports --install-types --non-interactive wargame_rl/ tests/
+
+      - name: Test
+        run: uv run pytest -n auto --verbose --color=yes --cov=wargame_rl --cov-report=term-missing tests


### PR DESCRIPTION
## Summary

Add a GitHub Actions CI workflow so the `ci-passed` required status check actually runs. Without this, PRs are permanently blocked because no workflow reports the check.

## Changes

- `.github/workflows/ci.yml`: new workflow triggered on PRs to `main` and pushes to `main`
  - Format check (`ruff format --check`)
  - Lint (`ruff check`)
  - Type check (`mypy`)
  - Tests (`pytest` with coverage)
- Job is named `ci-passed` to match the branch protection required status check