### PR TITLE
fix: use paths-filter so docs-only PRs still report ci-passed

### DIFF
--- a/.github/workflows/main-validate.yaml
+++ b/.github/workflows/main-validate.yaml
@@ -3,20 +3,34 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
   pull_request:
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
 
 defaults:
   run:
     shell: bash
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**.py'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - '.github/workflows/**'
+              - 'Justfile'
+              - 'examples/env_config/**'
+
   lint:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -49,6 +63,8 @@ jobs:
         run: just lint
 
   test:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -87,7 +103,7 @@ jobs:
           pytest-xml-coverage-path: coverage.xml
 
   ci-passed:
-    needs: [lint, test]
+    needs: [changes, lint, test]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Fix docs-only PRs being permanently blocked because `paths-ignore` skips the entire workflow, so the required `ci-passed` check never reports.

Replaces `paths-ignore` with `dorny/paths-filter` inside the workflow. The workflow now always triggers, but lint and test jobs only run when code files change (`.py`, `pyproject.toml`, `uv.lock`, workflows, `Justfile`, env configs). The `ci-passed` guardian job always runs and reports green for docs-only PRs.

Follows the same pattern established in PR #99 but fixes the branch-protection interaction.

## Changes

- `.github/workflows/main-validate.yaml`:
  - Remove `paths-ignore` from `push` and `pull_request` triggers
  - Add `changes` job using `dorny/paths-filter@v3` to detect code changes
  - Gate `lint` and `test` jobs on `needs.changes.outputs.code == 'true'`
  - `ci-passed` guardian always runs, so branch protection is always satisfied