### PR TITLE
feat: canonical game state snapshot with enriched fields (v9-01)

### DIFF
--- a/.planning/phases/v9-01-canonical-state-model/v9-01-RESEARCH.md
+++ b/.planning/phases/v9-01-canonical-state-model/v9-01-RESEARCH.md
@@ -1,0 +1,539 @@
+# Phase v9-01: Canonical State Model & Export — Research
+
+**Researched:** 2026-05-23
+**Domain:** Pydantic state serialisation, game state capture, numpy→JSON conversion
+**Confidence:** HIGH
+
+## Summary
+
+This phase creates a `GameStateSnapshot` Pydantic model that captures the full game state at any point during an episode and exports it to JSON. The codebase already has all the data internally — it just needs a parallel output path that reads from `BattleView` and domain objects, converts numpy arrays to native Python types at construction, and exposes the result as a Pydantic model.
+
+The critical technical findings are: (1) the snapshot model **must not contain numpy arrays** — Pydantic v2's `model_json_schema()` throws `PydanticInvalidForJsonSchema` on `np.ndarray` fields even with `@field_serializer`, so all numpy data must be converted to `list[int]`/`list[float]` at construction time; (2) `ShootingResult` lacks attacker-target pairing — the `_resolve_shooting_action` method knows the mapping but discards it; (3) opponent actions are produced by `_opponent_policy.select_action()` and immediately applied without recording; (4) reward breakdown and phase name are available on `phase_manager` but not surfaced outside the env.
+
+**Primary recommendation:** Build `GameStateSnapshot` and sub-models using only native Python types (no numpy). Convert at construction in a factory function `build_snapshot(view, ...)` that reads `BattleView` properties and `.tolist()` all arrays. Add `to_snapshot()` on `WargameEnv` as the public API.
+
+<phase_requirements>
+## Phase Requirements
+
+| ID | Description | Research Support |
+|----|-------------|------------------|
+| SGS-01 | Canonical programmatic game-state model exists, sourced from domain/read-only views | §Architecture Patterns: `GameStateSnapshot` as BattleView consumer in `envs/state/` |
+| SGS-04 | Default encoding is JSON; codec interface for additional formats | §Standard Stack: Pydantic v2 `model_dump_json()`; codec pattern via `Encoder` protocol |
+| SGS-11 | Combat results include attacker-target pairing and analytical context | §Code Examples: `CombatResultSnapshot` with `attacker_idx`, `target_idx`; modify `_resolve_shooting_action` |
+| SGS-12 | Opponent actions recorded before application and available in state output | §Code Examples: Store `opp_action` in `_apply_opponent_action` before applying |
+| SGS-14 | Reward breakdown and active reward phase name included in state output | §Code Examples: Read from `phase_manager.last_reward_breakdown` and `current_phase_name` |
+</phase_requirements>
+
+## Project Constraints (from .cursor/rules/)
+
+Directives extracted from `.cursor/rules/` and `CLAUDE.md` that constrain this phase:
+
+- **DDD architecture** (`docs/ddd-envs.md`): New state module lives at `envs/state/`, depends on `BattleView` + `types/` only. Domain layer must not import from `state/`. [VERIFIED: ddd-envs.md]
+- **BattleView protocol**: State export is a read-only consumer. Add properties to BattleView only if needed (additive, non-breaking). [VERIFIED: battle_view.py]
+- **Pydantic + pydantic-yaml for structured data**: The snapshot model uses Pydantic BaseModel. [VERIFIED: codebase convention]
+- **Type hints required**: All public functions typed; `from __future__ import annotations`. [VERIFIED: CLAUDE.md]
+- **Backward compat**: New config fields must default to no-op. Existing YAML configs must keep working. [VERIFIED: CLAUDE.md]
+- **`just validate` before pushing**: Format, lint, test must pass. [VERIFIED: CLAUDE.md]
+- **Registry pattern for extensible subsystems**: If codec interface is added, use string-keyed registry matching reward/criteria/opponent/mission registries. [VERIFIED: reward/calculators/registry.py pattern]
+- **Keep runtime simple**: Prefer validation at construction time, push complexity to startup. [VERIFIED: CLAUDE.md]
+- **No numpy in JSON schema**: `model_json_schema()` on Pydantic models with `np.ndarray` fields raises `PydanticInvalidForJsonSchema`. Use native Python types. [VERIFIED: tested locally with Pydantic 2.11.10]
+
+## Architectural Responsibility Map
+
+| Capability | Primary Tier | Secondary Tier | Rationale |
+|------------|-------------|----------------|-----------|
+| Snapshot model definition | `envs/state/` (new) | — | State serialisation is an adapter concern, peer of `renders/` |
+| Numpy→Python conversion | `envs/state/` factory | — | Conversion happens at snapshot construction time, not in domain |
+| Combat result capture (attacker-target) | `envs/wargame.py` (facade) | `domain/shooting.py` (return type) | Facade orchestrates shooting; pairing info is available in `_resolve_shooting_action` |
+| Opponent action recording | `envs/wargame.py` (facade) | — | Facade calls opponent policy and applies action; recording is a facade concern |
+| Reward breakdown exposure | `envs/wargame.py` (facade) | `reward/phase_manager.py` | Already stored on env; snapshot reads it |
+| Objective control computation | `envs/env_components/distance_cache.py` | — | `objective_ownership_from_norms_offset()` already exists; snapshot calls it |
+| Schema versioning | `envs/state/` | — | Metadata field on the snapshot model |
+| `to_snapshot()` public API | `envs/wargame.py` (facade) | — | Env facade assembles the snapshot from its own state |
+
+## Standard Stack
+
+### Core
+
+| Library | Version | Purpose | Why Standard |
+|---------|---------|---------|--------------|
+| Pydantic | 2.11.10 | Snapshot model, JSON serialisation, schema generation | Already the config/types standard; `model_dump_json()` and `model_json_schema()` for free [VERIFIED: installed] |
+
+### Supporting
+
+No additional packages needed. This phase uses only existing dependencies (pydantic, numpy).
+
+## Package Legitimacy Audit
+
+No new packages required. All dependencies are already in the project.
+
+## Architecture Patterns
+
+### System Architecture Diagram
+
+```
+WargameEnv.step()
+  ├── [existing] build_observation(view) → tensors → RL networks
+  │
+  └── [NEW] to_snapshot()
+        ├── reads BattleView properties (models, objectives, clock, VP)
+        ├── reads env-level ephemeral state (reward, actions, shooting)
+        ├── converts numpy → native Python at construction
+        └── returns GameStateSnapshot (Pydantic BaseModel)
+              ├── .model_dump_json() → JSON string
+              ├── .model_dump() → Python dict
+              └── .model_json_schema() → JSON Schema document
+```
+
+### Recommended Project Structure
+
+```
+wargame_rl/wargame/envs/
+├── state/                      # NEW — snapshot models and factory
+│   ├── __init__.py             # Re-exports GameStateSnapshot, build_snapshot
+│   └── snapshot.py             # Pydantic models + build_snapshot() factory
+├── domain/                     # UNCHANGED
+├── env_components/             # UNCHANGED
+├── reward/                     # UNCHANGED
+├── renders/                    # UNCHANGED
+├── types/                      # UNCHANGED
+└── wargame.py                  # ADD: to_snapshot() method, combat pairing, opponent recording
+```
+
+Minimal file count — a single `snapshot.py` is sufficient for Phase 1. The `state/` package can grow in later phases (formatters, event log, replay).
+
+### Pattern 1: Snapshot as BattleView Consumer
+
+**What:** `GameStateSnapshot` is constructed by a factory function that reads from `BattleView` properties and env-level fields, converting all numpy arrays to native Python types at construction time.
+
+**When to use:** Any time the full game state needs to be serialised (after step, after reset, on demand).
+
+**Why not on the model itself:** The snapshot model is a pure data carrier (Pydantic BaseModel). The factory function does the adaptation work (reading BattleView, converting types). This separates the "what" (model shape) from the "how" (construction from live env state).
+
+### Pattern 2: Native Python Types Only (No Numpy in Pydantic)
+
+**What:** All snapshot model fields use `list[int]`, `list[float]`, `tuple[int, ...]`, etc. — never `np.ndarray`. Conversion happens in the factory.
+
+**Why:** Pydantic v2's `model_json_schema()` throws `PydanticInvalidForJsonSchema` on `np.ndarray` fields. Using native types enables `model_dump_json()`, `model_dump()`, and `model_json_schema()` to all work without workarounds. [VERIFIED: tested locally]
+
+### Pattern 3: Extended ShootingResult with Pairing
+
+**What:** Introduce `CombatResultSnapshot` that pairs attacker index, target index, weapon profile, and `ShootingResult` outcome. This is a Pydantic model in `state/snapshot.py` constructed from data available inside `_resolve_shooting_action`.
+
+**Why not modify ShootingResult directly:** `ShootingResult` is a domain value object (frozen dataclass) used by the shooting resolution engine. Adding attacker/target indices to it would leak facade-level concerns (model indexing) into the domain. Instead, the facade wraps `ShootingResult` + pairing info into a higher-level `CombatResultSnapshot`.
+
+### Anti-Patterns to Avoid
+
+- **numpy in Pydantic fields:** Breaks `model_json_schema()`. Always convert to native Python at construction.
+- **Modifying BattleView for snapshot data:** Combat results, opponent actions, and reward breakdowns are env-level ephemeral state, not BattleView concerns. Pass them to the factory function as arguments, don't add them to the protocol.
+- **Lazy serialisation:** Don't store numpy arrays and convert in a `@field_serializer`. Convert at construction time so the model is always JSON-ready. This follows the project convention of "push complexity to startup, keep runtime simple."
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| JSON serialisation | Custom `to_dict()` methods | Pydantic `model_dump_json()` | Handles nested models, optional fields, enums automatically |
+| JSON Schema generation | Manual schema dict | Pydantic `model_json_schema()` | Auto-generates from type annotations; stays in sync with model |
+| Numpy array conversion | Custom recursive converter | `.tolist()` at construction | Built into numpy; converts to native Python recursively |
+| Objective control | Custom distance logic | `objective_ownership_from_norms_offset()` | Already exists in `distance_cache.py`; used by VP calculator and renderer |
+
+## Common Pitfalls
+
+### Pitfall 1: numpy in Pydantic breaks JSON Schema
+
+**What goes wrong:** Using `np.ndarray` as a Pydantic field type causes `model_json_schema()` to throw `PydanticInvalidForJsonSchema`, even with `ConfigDict(arbitrary_types_allowed=True)` and `@field_serializer`.
+**Why it happens:** Pydantic v2 needs to map every field to a JSON Schema type. `np.ndarray` has no JSON Schema equivalent.
+**How to avoid:** Use `list[int]`, `list[float]`, etc. for all fields. Convert numpy arrays at snapshot construction time via `.tolist()`.
+**Warning signs:** `arbitrary_types_allowed=True` in snapshot model config — this is the wrong approach.
+
+### Pitfall 2: Stale Shooting Results After Phase Advance
+
+**What goes wrong:** After the player's action, `run_after_player_action` may advance through opponent phases, overwriting `_last_opponent_shooting_results`. If the snapshot is captured at the wrong point, it might reflect only the final phase's results.
+**Why it happens:** The env resets `_last_player_shooting_results` and `_last_opponent_shooting_results` at the start of each `step()` call, then populates them during action resolution. By the time `step()` returns, they contain the correct per-step results.
+**How to avoid:** Capture the snapshot at the end of `step()` (after all action resolution and phase advancement complete). The `to_snapshot()` method reads the current state of `_last_*_shooting_results` which is correct at that point.
+**Warning signs:** Snapshot showing empty combat results when shooting occurred.
+
+### Pitfall 3: Opponent Action Not Recorded
+
+**What goes wrong:** The opponent action is produced by `self._opponent_policy.select_action()` and immediately fed to `_opponent_action_handler.apply()` or `_resolve_shooting_action()`. After application, the action object is garbage collected.
+**Why it happens:** The env was designed for RL training where opponent actions don't matter to the agent's learning signal.
+**How to avoid:** Store the `WargameEnvAction` returned by `select_action()` as `self._last_opponent_action` before applying it. The snapshot reads this field.
+**Warning signs:** Snapshot's `opponent_actions` always `None`.
+
+### Pitfall 4: Numpy Scalar Types in JSON
+
+**What goes wrong:** `np.int32(42)` is not `int` — `json.dumps()` raises `TypeError: Object of type int32 is not JSON serializable`.
+**Why it happens:** Numpy scalars from array indexing retain their numpy dtype.
+**How to avoid:** Use `.tolist()` on arrays (converts recursively), `int(x)` for individual scalars, or `float(x)` for floats. The factory function must handle this consistently.
+**Warning signs:** JSON serialisation errors mentioning `int32`, `int64`, `float64`.
+
+### Pitfall 5: Objective Control Requires Distance Recomputation
+
+**What goes wrong:** Objective ownership needs both player and opponent distance caches, but the env's `DistanceCache` (computed in `step()`) only covers player models.
+**Why it happens:** `compute_distances()` in `step()` is called for player models only. VP scoring computes a separate opponent cache on demand.
+**How to avoid:** The snapshot factory computes opponent distances when needed, using the same `compute_distances()` and `objective_ownership_from_norms_offset()` functions. This is cheap (vectorised numpy) and matches the VP calculator's approach.
+**Warning signs:** Missing or incorrect objective control in snapshot.
+
+## Code Examples
+
+### Snapshot Model Shape (Verified from Codebase Analysis)
+
+```python
+# Source: analysis of BattleView properties, entities, and env-level fields
+
+class ModelSnapshot(BaseModel):
+    """Serialisable snapshot of one WargameModel."""
+    location: list[int]  # [x, y]
+    previous_location: list[int] | None
+    group_id: int
+    alive: bool
+    current_wounds: int
+    max_wounds: int
+    toughness: int
+    save: int
+    advanced_this_turn: bool
+
+class ObjectiveSnapshot(BaseModel):
+    """Serialisable snapshot of one WargameObjective."""
+    location: list[int]  # [x, y]
+    radius_size: int
+
+class ClockSnapshot(BaseModel):
+    """Serialisable snapshot of GameClock state."""
+    game_phase: str      # "setup" | "battle" | "complete"
+    battle_round: int | None
+    active_player: str | None  # "player_1" | "player_2"
+    battle_phase: str | None   # "command" | "movement" | "shooting" | ...
+
+class CombatResultSnapshot(BaseModel):
+    """One model's shooting result with attacker-target pairing."""
+    attacker_idx: int
+    target_idx: int
+    hits: int
+    wounds: int
+    unsaved: int
+    damage_dealt: int
+
+class RewardSnapshot(BaseModel):
+    """Reward breakdown for the current step."""
+    total: float | None
+    breakdown: dict[str, float]
+    phase_name: str
+    phase_index: int
+
+class GameStateSnapshot(BaseModel):
+    """Complete, serialisable game state at one point in time."""
+    schema_version: str
+
+    # Timing
+    step: int
+    max_steps: int
+    clock: ClockSnapshot
+    n_rounds: int
+
+    # Board
+    board_width: int
+    board_height: int
+
+    # Entities
+    player_models: list[ModelSnapshot]
+    opponent_models: list[ModelSnapshot]
+    objectives: list[ObjectiveSnapshot]
+
+    # Zones
+    deployment_zone: tuple[int, int, int, int]
+    opponent_deployment_zone: tuple[int, int, int, int]
+
+    # Scoring
+    player_vp: int
+    opponent_vp: int
+    player_vp_delta: int
+    opponent_vp_delta: int
+    objective_control: list[str]  # per-objective: "player" | "opponent" | "contested" | "none"
+
+    # Actions taken this step
+    player_actions: list[int] | None
+    opponent_actions: list[int] | None
+
+    # Combat results this step
+    player_combat_results: list[CombatResultSnapshot]
+    opponent_combat_results: list[CombatResultSnapshot]
+
+    # Reward
+    reward: RewardSnapshot
+
+    # Episode status
+    is_terminated: bool
+    is_truncated: bool
+```
+
+### Converting WargameModel to ModelSnapshot
+
+```python
+# Source: WargameModel entity fields (domain/entities.py)
+
+def _model_to_snapshot(model: WargameModel) -> ModelSnapshot:
+    return ModelSnapshot(
+        location=model.location.tolist(),
+        previous_location=(
+            model.previous_location.tolist()
+            if model.previous_location is not None
+            else None
+        ),
+        group_id=model.group_id,
+        alive=model.is_alive,
+        current_wounds=model.stats["current_wounds"],
+        max_wounds=model.stats["max_wounds"],
+        toughness=model.stats["toughness"],
+        save=model.stats["save"],
+        advanced_this_turn=model.advanced_this_turn,
+    )
+```
+
+### Recording Attacker-Target Pairing
+
+The pairing is available in `_resolve_shooting_action` but currently discarded:
+
+```python
+# Source: wargame.py lines 326-369 (_resolve_shooting_action)
+# Current code iterates (i, act) and computes target_idx = act - shooting_slice.start
+# but only returns ShootingResult (no pairing info).
+
+# Fix: return list of (attacker_idx, target_idx, ShootingResult) tuples.
+# Or: store pairing alongside results on the env.
+
+# Concrete approach — add a dataclass for the paired result:
+@dataclass(frozen=True, slots=True)
+class PairedShootingResult:
+    attacker_idx: int
+    target_idx: int
+    result: ShootingResult
+
+# Modify _resolve_shooting_action to return list[PairedShootingResult]
+# and store as self._last_player_shooting_results / _last_opponent_shooting_results.
+```
+
+Here is the exact code path for the pairing. In `_resolve_shooting_action`, the loop already has `i` (attacker index) and `target_idx`:
+
+```python
+# Current (wargame.py:341-348):
+for i, act in enumerate(action.actions):
+    # ... validity checks ...
+    target_idx = act - shooting_slice.start
+    # ... resolve_shooting() ...
+    results.append(result)  # <-- loses i and target_idx
+
+# Proposed:
+    results.append(PairedShootingResult(
+        attacker_idx=i,
+        target_idx=target_idx,
+        result=result,
+    ))
+```
+
+### Recording Opponent Actions
+
+The opponent action is produced and immediately applied in `_apply_opponent_action`:
+
+```python
+# Source: wargame.py:391-418 (_apply_opponent_action)
+# Current:
+opp_action = self._opponent_policy.select_action(...)
+# immediately applied, opp_action is lost after method returns
+
+# Fix: store before applying
+self._last_opponent_action = opp_action  # ADD this line
+# then apply as before
+```
+
+The stored `_last_opponent_action` is read by `to_snapshot()`.
+
+### Objective Control Computation
+
+```python
+# Source: distance_cache.py objective_ownership_from_norms_offset()
+# VP calculator already uses this. Snapshot factory reuses it.
+
+from wargame_rl.wargame.envs.env_components.distance_cache import (
+    compute_distances,
+    objective_ownership_from_norms_offset,
+)
+
+def _compute_objective_control(view: BattleView) -> list[str]:
+    player_alive = alive_mask_for(view.player_models)
+    player_cache = compute_distances(view.player_models, view.objectives, alive_mask=player_alive)
+
+    if view.opponent_models:
+        opp_alive = alive_mask_for(view.opponent_models)
+        opp_cache = compute_distances(view.opponent_models, view.objectives, alive_mask=opp_alive)
+        opp_norms = opp_cache.model_obj_norms_offset
+    else:
+        opp_norms = np.zeros((0, len(view.objectives)), dtype=np.float64)
+
+    p_ctrl, o_ctrl = objective_ownership_from_norms_offset(
+        player_cache.model_obj_norms_offset, opp_norms, player_cache.obj_radii
+    )
+    # Derive per-objective label
+    result = []
+    for i in range(len(view.objectives)):
+        p_any = np.any(player_cache.model_obj_norms_offset[:, i] <= player_cache.obj_radii[i])
+        o_any = np.any(opp_norms[:, i] <= player_cache.obj_radii[i]) if opp_norms.shape[0] > 0 else False
+        if p_any and o_any:
+            result.append("contested")
+        elif p_ctrl[i]:
+            result.append("player")
+        elif o_ctrl[i]:
+            result.append("opponent")
+        else:
+            result.append("none")
+    return result
+```
+
+### Codec / Encoder Interface (SGS-04)
+
+```python
+# Minimal encoder protocol for future format extensibility.
+# Phase 1 only implements JSON; the protocol enables Phase 4 additions.
+
+class SnapshotEncoder(Protocol):
+    """Encodes a GameStateSnapshot to a specific format."""
+
+    def encode(self, snapshot: GameStateSnapshot) -> str | bytes: ...
+    def content_type(self) -> str: ...
+
+class JsonEncoder:
+    """Default JSON encoder using Pydantic's built-in serialisation."""
+
+    def encode(self, snapshot: GameStateSnapshot) -> str:
+        return snapshot.model_dump_json(indent=2)
+
+    def content_type(self) -> str:
+        return "application/json"
+```
+
+### to_snapshot() on WargameEnv
+
+```python
+# Source: architecture analysis — env facade assembles snapshot from its state
+
+def to_snapshot(self) -> GameStateSnapshot:
+    """Return a serialisable snapshot of the current game state."""
+    clock = self._game_clock.state
+    return build_snapshot(
+        view=self,
+        clock_state=clock,
+        step=self.current_turn,
+        max_steps=self.max_turns,
+        player_action=self._last_player_action,
+        opponent_action=self._last_opponent_action,
+        player_combat_results=self._last_player_shooting_results,
+        opponent_combat_results=self._last_opponent_shooting_results,
+        reward_total=self.last_reward,
+        reward_breakdown=self.last_reward_breakdown,
+        reward_phase_name=self.phase_manager.current_phase_name,
+        reward_phase_index=self.phase_manager.current_phase_index,
+        is_terminated=...,  # from last step context
+        is_truncated=False,
+    )
+```
+
+## State of the Art
+
+| Old Approach | Current Approach | When Changed | Impact |
+|--------------|------------------|--------------|--------|
+| `ConfigDict(arbitrary_types_allowed=True)` for numpy | Native Python types in Pydantic models | Pydantic v2 | `model_json_schema()` only works with JSON-native types |
+| `model_dump()` + `json.dumps()` | `model_dump_json()` directly | Pydantic v2 | Faster, handles nested models and enums automatically |
+| Manual schema writing | `model_json_schema()` | Pydantic v2 | Auto-generated JSON Schema from type annotations |
+
+## Assumptions Log
+
+| # | Claim | Section | Risk if Wrong |
+|---|-------|---------|---------------|
+| A1 | `schema_version` as a simple string field ("1.0") is sufficient versioning for Phase 1 | Code Examples | Low — can migrate to SemVer or integer later without breaking consumers |
+| A2 | Objective control can be recomputed cheaply in `to_snapshot()` | Pitfalls §5 | Low — numpy vectorised ops on 4-8 models × 3 objectives is sub-microsecond |
+| A3 | `PairedShootingResult` dataclass in domain is appropriate for the shooting return type change | Code Examples | Medium — could be a named tuple or placed in `state/` instead of domain; planner should decide |
+
+## Open Questions
+
+1. **Where should `PairedShootingResult` live?**
+   - What we know: It extends `ShootingResult` with `attacker_idx` and `target_idx`. The data is computed in the facade (`_resolve_shooting_action`), not in the domain's `resolve_shooting()`.
+   - What's unclear: Should it live in `domain/shooting.py` (alongside `ShootingResult`), `envs/wargame.py` (local to the facade), or `state/snapshot.py` (with the snapshot models)?
+   - Recommendation: Place it in `domain/shooting.py` as a peer of `ShootingResult`. It's still a shooting-resolution value object, just with context. This keeps the domain pure and avoids the facade importing from `state/`.
+
+2. **Should `to_snapshot()` accept a `DistanceCache` parameter?**
+   - What we know: Objective control requires distance computation. The env already computes a `DistanceCache` in `step()` but it's player-only. VP scoring computes a separate opponent cache on demand.
+   - What's unclear: Should `to_snapshot()` recompute from scratch (simple but redundant), accept the existing player cache (efficient but couples to step internals), or compute only when objective control is requested?
+   - Recommendation: Recompute from scratch. The cost is negligible (sub-microsecond for typical scenarios) and keeps `to_snapshot()` self-contained and callable at any point (after reset, mid-step, on demand).
+
+3. **Should the snapshot include weapon profiles per model?**
+   - What we know: Weapon stats (attacks, BS, strength, AP, damage, range) are in `ModelConfig` and exposed in `WargameModelObservation`. An LLM evaluator needs them to interpret combat.
+   - What's unclear: Include in `ModelSnapshot` (larger model, more fields) or reference by config (smaller, but consumer needs config + snapshot)?
+   - Recommendation: Include essential weapon stats in `ModelSnapshot`. An LLM evaluator reading the JSON should have all context in one document without needing the config file.
+
+## Validation Architecture
+
+### Test Framework
+
+| Property | Value |
+|----------|-------|
+| Framework | pytest (installed, configured) |
+| Config file | `pyproject.toml` `[tool.pytest.ini_options]` |
+| Quick run command | `just test` |
+| Full suite command | `just validate` |
+
+### Phase Requirements → Test Map
+
+| Req ID | Behaviour | Test Type | Automated Command | File Exists? |
+|--------|----------|-----------|-------------------|-------------|
+| SGS-01 | `to_snapshot()` returns `GameStateSnapshot` with all expected fields | integration | `uv run pytest tests/test_snapshot.py::test_to_snapshot_has_all_fields -x` | ❌ Wave 0 |
+| SGS-04 | `model_dump_json()` produces valid JSON; `model_json_schema()` produces JSON Schema | unit | `uv run pytest tests/test_snapshot.py::test_json_serialisation -x` | ❌ Wave 0 |
+| SGS-11 | Combat results have attacker-target pairing | integration | `uv run pytest tests/test_snapshot.py::test_combat_results_have_pairing -x` | ❌ Wave 0 |
+| SGS-12 | Opponent actions recorded before application | integration | `uv run pytest tests/test_snapshot.py::test_opponent_actions_recorded -x` | ❌ Wave 0 |
+| SGS-14 | Reward breakdown and phase name in snapshot | integration | `uv run pytest tests/test_snapshot.py::test_reward_breakdown_in_snapshot -x` | ❌ Wave 0 |
+
+### Sampling Rate
+
+- **Per task commit:** `uv run pytest tests/test_snapshot.py -x`
+- **Per wave merge:** `just test`
+- **Phase gate:** `just validate`
+
+### Wave 0 Gaps
+
+- [ ] `tests/test_snapshot.py` — covers SGS-01, SGS-04, SGS-11, SGS-12, SGS-14
+- [ ] `tests/conftest.py` — may need a fixture for env-with-opponents-and-shooting (already has `env` but without opponents)
+
+## Sources
+
+### Primary (HIGH confidence)
+
+- Direct codebase analysis — all findings verified against source code:
+  - `wargame.py` (env lifecycle, reset/step, shooting resolution, opponent action application)
+  - `domain/battle.py`, `domain/entities.py`, `domain/game_clock.py`, `domain/value_objects.py` (state inventory)
+  - `domain/shooting.py` (`ShootingResult`, `resolve_shooting()`, `wound_roll_threshold()`)
+  - `domain/battle_view.py` (`BattleView` protocol — all properties available)
+  - `env_components/actions.py` (`ActionHandler`, `ActionRegistry`, `ActionSlice`, `_decode_action()`)
+  - `env_components/distance_cache.py` (`compute_distances()`, `objective_ownership_from_norms_offset()`)
+  - `mission/vp_calculator.py` (`DefaultVPCalculator.compute_vp()` — objective control pattern)
+  - `reward/phase_manager.py` (`RewardPhaseManager`, `last_reward_breakdown`, `current_phase_name`)
+  - `reward/step_context.py` (`StepContext` fields)
+  - `types/config.py` (`WargameEnvConfig`, `ModelConfig`, `WeaponProfile`)
+  - `types/env_info.py` (`WargameEnvInfo` — existing Pydantic info model)
+  - `types/env_observation.py`, `types/model_observation.py` (observation structure)
+  - `types/game_timing.py` (`GameState`, `BattlePhase`, `GamePhase`, `PlayerSide` enums)
+  - `docs/ddd-envs.md` (architecture guide)
+- Local testing of Pydantic v2.11.10 numpy behaviour
+
+### Secondary (MEDIUM confidence)
+
+- `.planning/research/v9-SUMMARY.md`, `v9-STATE-REPRESENTATION.md`, `v9-ARCHITECTURE.md`, `v9-LLM-REPRESENTATION.md` — upstream research findings verified against codebase
+
+## Metadata
+
+**Confidence breakdown:**
+- Standard stack: HIGH — Pydantic v2 already in use, capabilities verified locally
+- Architecture: HIGH — DDD layers, BattleView protocol, registry pattern all well-established; new layer fits naturally
+- Pitfalls: HIGH — numpy/Pydantic interaction verified by testing; combat pairing and opponent recording gaps verified by code reading
+- Field inventory: HIGH — every field traced to its source in the codebase
+
+**Research date:** 2026-05-23
+**Valid until:** 2026-06-23 (stable domain; no external dependencies)

--- a/.planning/research/v9-ARCHITECTURE.md
+++ b/.planning/research/v9-ARCHITECTURE.md
@@ -1,0 +1,389 @@
+# Architecture Research: v9.0 — Structured Game State & LLM-Readable Representation
+
+**Focus:** Dependency patterns and architectural constraints for the new state/serialisation layer
+**Researched:** 2026-05-23
+**Confidence:** HIGH (all findings based on direct codebase analysis)
+
+---
+
+## 1. DDD Architecture Summary (from `docs/ddd-envs.md`)
+
+The environment follows a three-layer DDD structure:
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  WargameEnv (facade)                                            │
+│  Implements BattleView protocol · wires layers · Gym API        │
+├──────────────────────────────────────────────────────────────────┤
+│  env_components/  │  reward/  │  renders/  │  mission/  │ opp/  │
+│  (adapters)       │           │            │            │       │
+│  Actions,         │ Phases,   │ Human      │ VP         │ Scr.  │
+│  observation,     │ calcs,    │ renderer   │ calcs      │ pol.  │
+│  distance cache   │ criteria  │            │            │       │
+├──────────────────────────────────────────────────────────────────┤
+│  domain/                                                         │
+│  Battle (aggregate) · entities · value_objects · GameClock       │
+│  placement · termination · turn_execution · LOS · shooting       │
+├──────────────────────────────────────────────────────────────────┤
+│  types/                                                          │
+│  Config (Pydantic) · game_timing · observation types · actions   │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+**Dependency direction (strict, enforced by convention):**
+- **domain/** → `types/` only. No imports from `env_components`, `reward`, `renders`.
+- **reward/** and **renders/** → `BattleView` protocol + `types/`. No import of `WargameEnv` or `Battle`.
+- **env_components/** → domain + types.
+- **WargameEnv** → everything (it's the composition root).
+
+**Key insight:** `BattleView` is the architectural seam. It's a read-only Protocol that exposes battle state without mutation capability. Every external consumer (renderers, reward calculators, VP calculators, observation builder) depends on this protocol, not on the env or aggregate directly.
+
+---
+
+## 2. BattleView Consumer Map
+
+### Who reads BattleView today?
+
+| Consumer | File | How it uses BattleView |
+|----------|------|----------------------|
+| **Renderer** (abstract) | `renders/renderer.py` | `setup(view)`, `render(view)` — reads models, objectives, board dimensions, clock state for visual display |
+| **HumanRender** | `renders/human.py` | Accesses `view.player_models`, `view.opponent_models`, `view.objectives`, `view.config`, `view.game_clock_state`, `view.player_vp`, `view.opponent_vp`, `view.deployment_zone`, `view.board_width`/`board_height` |
+| **RewardPhaseManager** | `reward/phase_manager.py` | `calculate_reward(view, ctx)`, `check_success(view, ctx)` — reads `view.player_models` for alive filtering |
+| **PerModelRewardCalculator** | `reward/calculators/base.py` | `calculate(model_idx, model, view, ctx)` — per-model + view access |
+| **GlobalRewardCalculator** | `reward/calculators/base.py` | `calculate(view, ctx)` — full view access |
+| **SuccessCriteria** | `reward/criteria/base.py` | `is_successful(view, ctx)` |
+| **VPCalculator** | `mission/vp_calculator.py` | `compute_vp(view, scoring_side, round, player_side)` — reads models, objectives, computes distances |
+| **Observation builder** | `env_components/observation_builder.py` | `build_observation(view, ...)`, `build_info(view)` — reads all BattleView properties to construct `WargameEnvObservation` |
+| **WargameEnv itself** | `envs/wargame.py` | Passes `self` (which implements BattleView) to all of the above |
+
+### What does a "state exporter" look like as a consumer?
+
+A state exporter would be another `BattleView` consumer, exactly like the renderer or observation builder. It reads the view and produces a different output format (JSON, text, events) instead of Pygame surfaces or tensor-ready observations.
+
+**It fits naturally as a peer of renderers and observation builder** — same dependency direction, same protocol contract.
+
+---
+
+## 3. Where Should the State Serialisation Layer Live?
+
+### Recommended: New `state/` package at `envs/state/`
+
+```
+wargame_rl/wargame/envs/
+├── state/                      # NEW — state export, serialisation, events
+│   ├── __init__.py
+│   ├── exporter.py             # StateExporter protocol + base
+│   ├── snapshot.py             # Full state snapshot model (Pydantic)
+│   ├── delta.py                # State delta / change model
+│   ├── event.py                # Event types for append-only log
+│   ├── event_log.py            # EventLog accumulator
+│   ├── formatters/             # Pluggable output formats
+│   │   ├── __init__.py
+│   │   ├── json_formatter.py   # Default JSON
+│   │   ├── text_formatter.py   # LLM-readable text
+│   │   └── registry.py         # Formatter registry
+│   └── replay.py               # Deterministic replay from event log
+├── domain/                     # Unchanged
+├── env_components/             # Unchanged
+├── reward/                     # Unchanged
+├── renders/                    # Unchanged
+└── ...
+```
+
+**Rationale:**
+- **Same dependency level as `renders/` and `reward/`**: depends on `BattleView` + `types/`, not on `WargameEnv`.
+- **Does not pollute domain/**: the domain stays rule-focused; serialisation is an adapter concern.
+- **Does not pollute env_components/**: env_components is about Gym machinery (actions, observation spaces, distance cache). State export is a different concern.
+- **Parallel to renders/**: just as `renders/` produces visual output from BattleView, `state/` produces data output from BattleView.
+
+### Dependency position in the graph
+
+```
+domain/  →  types/  (only)
+                ↑
+    ┌───────────┼───────────────────────┐
+    │           │                       │
+reward/     renders/     state/ (NEW)   env_components/
+    │           │           │               │
+    └───────────┴───────────┴───────────────┘
+                        ↑
+                   WargameEnv (facade)
+```
+
+`state/` depends on `BattleView` and `types/` — identical dependency direction to `reward/` and `renders/`.
+
+---
+
+## 4. Registry Pattern Analysis
+
+The codebase uses a consistent registry pattern across four subsystems:
+
+| Subsystem | Registry file | Pattern | Key → Class mapping |
+|-----------|--------------|---------|-------------------|
+| Reward calculators | `reward/calculators/registry.py` | Module-level `dict[str, type]`, `build_calculator(type_name, weight, params)` | `"closest_objective"` → `ClosestObjectiveCalculator` |
+| Success criteria | `reward/criteria/registry.py` | Module-level `dict[str, type]`, `build_criteria(type_name, params)` | `"all_at_objectives"` → `AllAtObjectivesCriteria` |
+| Opponent policies | `opponent/registry.py` | Module-level `dict`, `register_policy(name, cls)`, `build_opponent_policy(config, env)` + `_auto_register()` via importlib | `"random"` → `RandomPolicy` |
+| VP calculators | `mission/registry.py` | Module-level `dict[str, type]`, `build_vp_calculator(type_name, params)` | `"default"` → `DefaultVPCalculator` |
+
+### Common pattern
+
+```python
+REGISTRY: dict[str, type[BaseClass]] = {
+    "key": ConcreteClass,
+    ...
+}
+
+def build_thing(type_name: str, **kwargs) -> BaseClass:
+    cls = REGISTRY.get(type_name)
+    if cls is None:
+        raise ValueError(f"Unknown type '{type_name}'. Available: ...")
+    return cls(**kwargs)
+```
+
+### Can state exporters/formatters use this pattern?
+
+**Yes, directly.** A formatter registry would follow the exact same shape:
+
+```python
+FORMATTER_REGISTRY: dict[str, type[StateFormatter]] = {
+    "json": JSONFormatter,
+    "text": TextFormatter,
+}
+
+def build_formatter(type_name: str, params: dict[str, Any]) -> StateFormatter:
+    cls = FORMATTER_REGISTRY.get(type_name)
+    if cls is None:
+        raise ValueError(...)
+    return cls(**params)
+```
+
+This enables YAML configuration of which formatters are active, just like reward calculators:
+
+```yaml
+state_exporters:
+  - type: json
+    params: { indent: 2, schema_version: 1 }
+  - type: text
+    params: { include_combat_stats: true }
+```
+
+The opponent policy registry's `_auto_register()` pattern (lazy import via importlib) is also reusable if formatters are contributed as plugins.
+
+---
+
+## 5. Backward Compatibility Constraints
+
+### What must NOT break
+
+| Surface | Constraint | Impact on state layer |
+|---------|-----------|---------------------|
+| **Gym API** (`step()` → obs, reward, done, truncated, info) | Return signature is fixed by Gymnasium 1.x | State export is a *side channel*, not a replacement for the Gym return tuple |
+| **`WargameEnvObservation`** dataclass | Shape consumed by `observation_to_tensor()`, then by TransformerNetwork/MLPNetwork | State export produces a *separate* representation; observation pipeline is untouched |
+| **`WargameEnvConfig` (Pydantic + YAML)** | Existing YAML configs must keep working with defaults | New config fields must default to no-op (e.g. `state_exporters: []` or `state_exporters: None`) |
+| **`BattleView` protocol** | Adding properties is additive (new `@property` methods). Removing/renaming breaks all consumers | State layer can read existing properties. If it needs new data, add to BattleView (additive, non-breaking) |
+| **Training pipeline** (`train.py` → Lightning → Agent → env) | The pipeline calls `env.reset()` and `env.step()` only. It never sees raw state. | State export hooks are invisible to the training pipeline unless explicitly enabled |
+| **`observation_to_tensor()` tensor pipeline** | Fixed 5-tensor output: game_features, objectives, player_models, opponent_models, action_mask | State I/O is a parallel pathway. The tensor pipeline is the RL-facing contract; state export is the human/LLM-facing contract |
+| **Checkpoint format** | Lightning checkpoints contain model weights + optimizer state, not env state | State export doesn't affect checkpoints |
+
+### Safe extension points
+
+1. **New optional field on `WargameEnvConfig`** (e.g. `state_exporters: list[StateExporterConfig] | None = None`) — existing YAML untouched because default is `None`.
+2. **New properties on `BattleView`** — additive protocol extension. Existing implementors (`WargameEnv`) just need the new `@property`.
+3. **New package `envs/state/`** — no existing code references it, so adding it has zero impact.
+4. **Hook methods on `WargameEnv`** (e.g. `_notify_exporters()`) — private, internal wiring only.
+
+---
+
+## 6. RL Pipeline vs State Export: Parallel Paths
+
+### Current RL observation flow
+
+```
+WargameEnv.step()
+    → build_observation(view, cache, registry)
+        → WargameEnvObservation (dataclass)
+            → observation_to_tensor(obs, device)
+                → 5 torch.Tensors
+                    → TransformerNetwork.forward(...)
+```
+
+**Key characteristics:**
+- `observation_to_tensor()` in `model/common/observation.py` consumes `WargameEnvObservation` (a flat dataclass with model/objective lists, action masks, game state scalars).
+- It produces **normalised numeric tensors** — positions in [-1,1], one-hot groups, normalised wounds, etc.
+- This is a lossy, RL-optimised representation. It discards entity names, weapon descriptions, deployment zone semantics, round context, etc.
+
+### Proposed state export flow (separate path)
+
+```
+WargameEnv.step()
+    → [existing] build_observation(view) → WargameEnvObservation → tensors → RL
+    → [NEW]      export_state(view)      → GameStateSnapshot → JSON/text → LLM/API
+```
+
+**State export does NOT replace or modify the observation pipeline.** They serve different consumers:
+- Tensor pipeline → RL networks (numeric, compressed, GPU-bound)
+- State export → LLMs, APIs, replay systems, debugging (human-readable, complete, CPU-bound)
+
+The `observation_to_tensor()` function and Lightning modules remain completely untouched.
+
+---
+
+## 7. State Export Hook Attachment Points
+
+### Where in the env lifecycle should export happen?
+
+| Hook point | When | What to export | Use case |
+|-----------|------|---------------|----------|
+| **After `reset()`** | Episode start, before first action | Full snapshot (initial board state) | Episode start event, replay anchor |
+| **After `step()`** | Each agent action resolved | Delta (action taken, new positions, damage, VP changes) + optional full snapshot | Step-by-step logging, streaming API |
+| **On demand** | External call | Full snapshot at current moment | LLM query ("what's the current state?"), API polling |
+| **At episode end** | Terminal step detected | Terminal snapshot + episode summary | Replay packaging, training analytics |
+
+### Recommended hook design
+
+```python
+class StateExporter(Protocol):
+    """Receives BattleView snapshots at lifecycle points."""
+    def on_reset(self, view: BattleView, episode_id: str) -> None: ...
+    def on_step(self, view: BattleView, action: WargameEnvAction,
+                reward: float, terminated: bool) -> None: ...
+    def get_snapshot(self, view: BattleView) -> GameStateSnapshot: ...
+```
+
+**Attachment:** `WargameEnv` holds an optional list of exporters (like it holds an optional renderer). At `reset()` and `step()`, after all domain logic completes, it notifies registered exporters. This mirrors how `self.renderer.render(self)` is called at the end of `reset()` and in `render()`.
+
+### Env integration (minimal wiring)
+
+In `wargame.py`:
+- `__init__`: accept optional `state_exporters: list[StateExporter]` (default empty)
+- End of `reset()`: `for exp in self._state_exporters: exp.on_reset(self, episode_id)`
+- End of `step()`: `for exp in self._state_exporters: exp.on_step(self, action, reward, terminated)`
+
+This is 5-10 lines of wiring in the facade. No domain changes. No observation pipeline changes.
+
+---
+
+## 8. What Data is Available from BattleView?
+
+Everything needed for a complete game state snapshot is already on the protocol:
+
+| BattleView property | Type | Content |
+|-------------------|------|---------|
+| `board_width`, `board_height` | `int` | Board dimensions |
+| `config` | `WargameEnvConfig` | Full configuration (models, objectives, phases, rules) |
+| `player_models` | `list[WargameModel]` | All player units: location, stats (wounds), group, alive status |
+| `opponent_models` | `list[WargameModel]` | All opponent units (same shape) |
+| `objectives` | `list[WargameObjective]` | Objective locations + radii |
+| `deployment_zone`, `opponent_deployment_zone` | `np.ndarray` | Zone bounds |
+| `current_turn` | `int` | Step counter |
+| `game_clock_state` | `GameState` | Round, phase, active player, game phase |
+| `n_rounds` | `int` | Total rounds |
+| `player_vp`, `opponent_vp` | `int` | Cumulative VP |
+| `player_vp_delta`, `opponent_vp_delta` | `int` | Per-step VP change |
+| `last_reward` | `float \| None` | Most recent reward |
+| `has_line_of_sight_between_cells(...)` | method | LOS query |
+
+**What's NOT on BattleView but may be needed for full state export:**
+- **Action that was just taken** — available in `step()` as a parameter, can be passed to exporters
+- **Reward breakdown** — available as `phase_manager.last_reward_breakdown` on the env
+- **Episode ID** — not currently tracked; would need a simple counter or UUID on reset
+- **Shooting results** — available as `_last_player_shooting_results` / `_last_opponent_shooting_results` on the env (private)
+- **Previous model locations** — available as `model.previous_location` on each `WargameModel`
+
+For shooting results and reward breakdown, the exporter can either:
+1. Accept them as extra parameters in `on_step()`, or
+2. Get them from a small `StepResult` carrier alongside `BattleView`
+
+---
+
+## 9. Existing Extension Patterns and Dev Guides
+
+### docs/ file inventory
+
+| File | Covers |
+|------|--------|
+| `docs/ddd-envs.md` | **Main extension guide.** Covers adding entities, value objects, placement rules, termination, reward/criteria, rendering, actions/phases. Clear "where to add X" patterns. |
+| `docs/reward-phases.md` | Reward calculator/criteria registration, YAML configuration, phase config schema |
+| `docs/opponent-policies.md` | Opponent policy registration, YAML config, observation impact table |
+| `docs/missions-and-vp.md` | VP calculator system, mission config |
+| `docs/shooting.md` | Shooting rules, domain design |
+| `docs/movement.md` | Movement system |
+| `docs/tabletop-rules-reference.md` | Full rules reference |
+| `docs/goals-and-roadmap.md` | Historical roadmap (v0-era) |
+| `docs/multi-run-training.md` | Parallel training configuration |
+
+**No dedicated "how to add a new subsystem" guide exists** — `ddd-envs.md` covers adding to existing subsystems (entities, reward, rendering) but doesn't cover adding an entirely new subsystem like `state/`. The pattern to follow is clear though: mirror how `renders/` was set up (protocol + concrete implementations + optional wiring in the facade).
+
+---
+
+## 10. Snapshot Model Shape (Recommended)
+
+Based on what BattleView exposes, a canonical snapshot would look like:
+
+```python
+@dataclass(frozen=True)
+class GameStateSnapshot:
+    schema_version: int
+    episode_id: str
+    step: int
+
+    # Board
+    board_width: int
+    board_height: int
+
+    # Timing
+    game_phase: str
+    battle_round: int | None
+    active_player: str | None
+    battle_phase: str | None
+    n_rounds: int
+
+    # Entities
+    player_models: list[ModelSnapshot]
+    opponent_models: list[ModelSnapshot]
+    objectives: list[ObjectiveSnapshot]
+
+    # Scoring
+    player_vp: int
+    opponent_vp: int
+    player_vp_delta: int
+    opponent_vp_delta: int
+
+    # Zones
+    deployment_zone: tuple[int, int, int, int]
+    opponent_deployment_zone: tuple[int, int, int, int]
+```
+
+All fields are derived from BattleView properties with no additional domain logic needed.
+
+---
+
+## 11. Summary of Architectural Constraints
+
+1. **State export is a BattleView consumer** — same architectural role as renderers and reward calculators. It reads the view, it doesn't mutate it.
+
+2. **Lives in `envs/state/`** — parallel to `envs/renders/`, same dependency direction (→ BattleView, → types/).
+
+3. **Registry pattern for formatters** — identical to reward/criteria/mission/opponent registries. Enables YAML-driven configuration.
+
+4. **Zero impact on RL pipeline** — `observation_to_tensor()`, Lightning modules, `train.py`, and checkpoints are completely untouched. State export is a parallel output path.
+
+5. **Zero impact on existing YAML configs** — new config fields default to disabled (`None` or empty list).
+
+6. **BattleView already exposes enough** — the protocol has all the data needed for a complete game state snapshot. Minor additions (shooting results, reward breakdown) can be passed as step-level context.
+
+7. **Hooks attach after `reset()` and `step()`** — same pattern as the renderer. The facade notifies exporters after domain logic completes.
+
+8. **The event log is an exporter concern** — `EventLog` accumulates events from `on_reset` / `on_step` calls. Replay reads the log. Neither touches domain or env internals.
+
+---
+
+## 12. Risks and Open Questions
+
+| Risk/Question | Impact | Mitigation |
+|--------------|--------|-----------|
+| **Performance overhead of serialisation on every step during training** | Could slow training if JSON serialisation is heavy | Make exporters optional and disabled by default. Only activate for inference/debugging/API serving. |
+| **Schema versioning strategy** | Breaking changes to snapshot format affect downstream LLM prompts and APIs | Include `schema_version` field from day one. Maintain a version changelog. |
+| **Delta encoding complexity** | Computing minimal diffs between states could be complex | Start with full snapshots. Add delta optimisation in a later phase once the snapshot model is stable. |
+| **Event ordering in multi-phase turns** | Opponent turn events happen between player `step()` calls | The exporter sees the result after opponent execution. Sub-step events (opponent shooting results) need a richer hook or event granularity. |
+| **Thread safety for streaming consumers** | If state is streamed over WebSocket while training runs | Training is single-threaded. Streaming consumers (v8.0 web viewer) can consume from a thread-safe queue filled by the exporter. |

--- a/.planning/research/v9-LLM-REPRESENTATION.md
+++ b/.planning/research/v9-LLM-REPRESENTATION.md
@@ -1,0 +1,592 @@
+# v9.0 Research: Structured Game State & LLM-Readable Representation
+
+**Milestone:** v9.0 — Structured Game State & LLM-Readable Representation
+**Researched:** 2026-05-23
+**Confidence:** HIGH (primary source: direct codebase analysis)
+
+## Executive Summary
+
+This document maps the current internal representations of actions, observations, rewards, and combat results in the wargame_rl codebase, and identifies what an LLM evaluator would need to interpret the RL agent's behaviour. The goal is to enable an LLM to read a structured step summary and judge whether the trained RL model is making good or bad decisions.
+
+The codebase has rich structured data at every step — action indices that can be decoded to human-readable descriptions, full combat narratives in `ShootingResult`, detailed reward breakdowns, and game timing state. However, none of this is currently surfaced as text. The Pygame renderer's tooltip and south panel are the closest to human-readable output, but they only show a fraction of available data and are visual-only.
+
+---
+
+## 1. Action Encoding & Decoding
+
+### Action Space Structure
+
+Actions are encoded as a single integer per model, managed by `ActionHandler` and partitioned by `ActionRegistry` into contiguous slices:
+
+| Slice | Indices | Valid Phases | Meaning |
+|-------|---------|--------------|---------|
+| `stay` | `0` | All phases | No action (pass) |
+| `movement` | `1 .. N×S` | Movement only | Polar coordinate move |
+| `shooting` | `N×S+1 .. N×S+T` | Shooting only | Target selection (conditional on opponents existing) |
+
+**Default configuration:** `n_movement_angles=16`, `n_speed_bins=6` → 96 movement actions. With 4 opponents: 101 total (1 stay + 96 movement + 4 shooting).
+
+### Movement Action Decoding
+
+Movement actions encode `(angle_idx, speed_idx)` pairs:
+
+```
+action 0          → STAY (dx=0, dy=0)
+action 1..N×S     → move_idx = action - 1
+                     angle_idx = move_idx // n_speed_bins
+                     speed_idx = move_idx % n_speed_bins
+```
+
+**Angles:** `n_movement_angles` evenly-spaced directions starting at 0 rad (east/+x), counter-clockwise:
+- With 16 angles: 0°, 22.5°, 45°, 67.5°, 90° (N), 112.5°, 135°, 157.5°, 180° (W), 202.5°, 225°, 247.5°, 270° (S), 292.5°, 315°, 337.5°
+
+**Speeds:** Linearly spaced from `max_move_speed / n_speed_bins` up to `max_move_speed`:
+- With `max_move_speed=6, n_speed_bins=6`: speeds = [1, 2, 3, 4, 5, 6]
+
+**Displacement:** The continuous (angle × speed) vector is rounded to nearest integer cell. Pre-computed in `_displacements[angle_idx, speed_idx]` → `(dx, dy)` as int.
+
+### Shooting Action Decoding
+
+```
+target_idx = action - shooting_slice.start
+```
+
+Target index K maps to opponent model K in the observation. Positional alignment is a critical invariant.
+
+### Human-Readable Action Description
+
+To convert an action integer to text, the LLM representation layer needs:
+
+```
+action 0 → "Stay (no action)"
+action 1-96 → "Move {direction_name} at speed {speed} (dx={dx}, dy={dy})"
+action 97-100 → "Shoot at opponent model {target_idx}"
+```
+
+**Key method:** `ActionHandler._decode_action(action) → np.ndarray([dx, dy])` already exists. For LLM narration, we also need the angle/speed decomposition from `encode_action`/decoding logic, and compass direction mapping.
+
+**What exists today:**
+- `_decode_action()` returns `(dx, dy)` displacement
+- `encode_action(angle_idx, speed_idx)` encodes back
+- `best_action_toward(dx, dy)` finds closest action to a direction
+- No human-readable text generation exists
+
+**What's needed for LLM:**
+- `describe_action(action_int, model_idx, phase) → str` that produces e.g. "Model 0 moves NE at speed 4 (dx=3, dy=3)" or "Model 2 shoots at opponent 1"
+- Phase context matters: same action index means different things in movement vs shooting phase
+
+---
+
+## 2. Observation Structure
+
+### `WargameEnvObservation` (what the agent sees)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `current_turn` | int | Step counter |
+| `wargame_models` | list[WargameModelObservation] | Player model states |
+| `objectives` | list[WargameEnvObjectiveObservation] | Objective locations |
+| `board_width` / `board_height` | int | Board dimensions |
+| `opponent_models` | list[WargameModelObservation] | Opponent model states |
+| `action_mask` | np.ndarray (n_models, n_actions) | Valid action mask |
+| `battle_round` | int | Current round (1-based) |
+| `battle_phase_index` | int | Phase index (0=command, 1=movement, 2=shooting, 3=charge, 4=fight) |
+| `n_rounds` | int | Total rounds |
+| `player_vp` / `opponent_vp` | int | Cumulative victory points |
+| `player_vp_delta` | int | VP gained this step |
+
+### `WargameModelObservation` (per-model)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `location` | np.ndarray (2,) | (x, y) grid position |
+| `distances_to_objectives` | np.ndarray | Delta vectors to each objective |
+| `group_id` | int | Unit group assignment |
+| `max_groups` | int | Max groups (for one-hot) |
+| `alive` | float | 1.0 alive, 0.0 dead |
+| `current_wounds` / `max_wounds` | int | Wound pool |
+| `weapon_attacks` | int | Number of hit rolls per shot |
+| `weapon_ballistic_skill` | int | D6 roll needed to hit (e.g. 3 = 3+) |
+| `weapon_strength` | int | For wound roll comparison |
+| `weapon_ap` | int | Armour penetration |
+| `weapon_damage` | int | Wounds per failed save |
+| `toughness` | int | Defensive stat |
+| `save_stat` | int | Base armour save |
+
+### `WargameEnvObjectiveObservation`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `location` | np.ndarray (2,) | (x, y) grid position |
+
+### `WargameEnvInfo` (extra info dict)
+
+Superset of observation data plus:
+- `deployment_zone` / `opponent_deployment_zone`: (x_min, y_min, x_max, y_max) tuples
+- `player_vp_delta` / `opponent_vp_delta`: VP changes for both sides
+
+### Tensor Pipeline
+
+`observation_to_tensor()` produces 5 tensors:
+1. **game_features** `(6,)`: placeholder, normalized_round, normalized_phase, player_vp, opponent_vp, player_vp_delta
+2. **objectives** `(n_obj, 2)`: normalized locations
+3. **player_models** `(n_models, feature_dim)`: normalized location, distances, group one-hot, closest same-group distance, alive, wound_ratio, max_wounds, 7 combat stats, expected_damage per opponent
+4. **opponent_models** `(n_opponents, feature_dim)`: same structure + zero padding
+5. **action_mask** `(n_models, n_actions)`: boolean
+
+The tensor pipeline computes `expected_damage` per player-opponent pair using the analytical formula — this is already an interpretable combat metric.
+
+---
+
+## 3. Step Summary Requirements for LLM Evaluator
+
+An LLM evaluator needs a structured summary per step. Based on the data available:
+
+### State Before Action
+
+```
+Round: {battle_round}/{n_rounds}  Phase: {phase_name}  Step: {current_turn}/{max_turns}
+VP: Player {player_vp} | Opponent {opponent_vp}
+
+Player Models:
+  Model 0 (group 0): ({x}, {y}) — {current_wounds}/{max_wounds} HP — weapon: {attacks}A BS{bs}+ S{str} AP-{ap} D{dmg} range {range}"
+  Model 1 (group 0): ({x}, {y}) — {current_wounds}/{max_wounds} HP — DEAD
+  ...
+
+Opponent Models:
+  Model 0 (group 0): ({x}, {y}) — {current_wounds}/{max_wounds} HP — weapon: ...
+  ...
+
+Objectives:
+  Objective 0: ({x}, {y}) — radius {r} — controlled by: {player/opponent/contested/none}
+
+Distances: Model 0 → Obj 0: {dist}, Model 0 → Obj 1: {dist}, ...
+```
+
+### Action Taken (decoded)
+
+```
+Actions:
+  Model 0: Move NE at speed 4 (dx=3, dy=3) — new position: ({x'}, {y'})
+  Model 1: Stay (dead, forced)
+  Model 2: Shoot at opponent model 1
+  Model 3: Move E at speed 6 (dx=6, dy=0) — new position: ({x'}, {y'})
+```
+
+### Combat Results (shooting phase)
+
+The `ShootingResult` dataclass provides full narrative:
+
+```python
+@dataclass(frozen=True, slots=True)
+class ShootingResult:
+    hits: int       # successful hit rolls
+    wounds: int     # successful wound rolls
+    unsaved: int    # wounds that got past armour
+    damage_dealt: int  # total damage inflicted
+```
+
+Plus combat resolution context:
+- Wound roll threshold computed from `weapon.strength` vs `defender.toughness`
+- Modified save = `defender.save + weapon.ap`
+- Damage = `unsaved × weapon.damage`
+
+**Narrative example:**
+```
+Model 2 fires at Opponent 1 (range 8, weapon: 2A BS3+ S4 AP-1 D1):
+  Hit rolls: 2 attacks → 1 hit (need 3+)
+  Wound rolls: 1 → 1 wound (S4 vs T3, need 3+)
+  Save rolls: 1 → 0 saved (4+ save, AP-1 = need 5+)
+  Result: 1 unsaved wound → 1 damage dealt
+  Opponent 1: 2/3 → 1/3 HP
+```
+
+**Currently stored:** `_last_player_shooting_results` and `_last_opponent_shooting_results` on `WargameEnv` — lists of `ShootingResult`, one per model that fired. These are available during the step but not persisted into observations or info.
+
+**Gap:** Individual dice rolls are NOT stored — only aggregate counts (hits, wounds, unsaved, damage_dealt). The RNG is used in `resolve_shooting()` but results are summarized. For full dice narration, we'd need to either store the rolls or re-derive probabilities.
+
+### Reward Breakdown
+
+`WargameEnv` already tracks:
+- `last_reward`: float total reward
+- `last_reward_breakdown`: dict[str, float] with keys like `"closest_objective"`, `"group_cohesion"`, `"vp_gain"`, `"terminal_success_bonus"`, sub-components like `"closest_objective/distance_delta"`, `"closest_objective/base_penalty"`, `"closest_objective/best_distance_bonus"`
+- `episode_reward_breakdown`: cumulative across episode
+
+**Narrative example:**
+```
+Reward: -0.450
+  closest_objective: -0.300 (avg across models)
+    distance_delta: +0.015 (got further from objective)
+    base_penalty: -0.330
+    best_distance_bonus: 0.000
+  group_cohesion: -0.150 (models too far apart, excess 3.0 beyond max_distance 5.0)
+  vp_gain: 0.000 (no VP scored this step)
+```
+
+### State After
+
+Same format as "State Before" with updated positions, wounds, VP.
+
+### Opponent Turn Summary
+
+The opponent's full turn is auto-executed between player steps. Currently this is invisible — the player just sees the result in the next observation. For LLM evaluation, the opponent's actions and results should also be narrated.
+
+**Gap:** Opponent actions are applied but not stored. `_apply_opponent_action()` calls the policy and applies the action, but doesn't record what action was taken. Only opponent shooting results are stored in `_last_opponent_shooting_results`.
+
+---
+
+## 4. Existing Human-Readable Output
+
+### Pygame Renderer South Panel
+
+Displays (text rendered on screen, not logged):
+- Round / Phase / Step
+- Reward (3 decimal places)
+- Player VP (+delta) | Opponent VP (+delta)
+- Epoch (if set)
+
+### Pygame Tooltip (hover/click on model)
+
+Shows for player models:
+- Location: (x, y)
+- Group ID
+- Closest objective reward (from `ModelRewards`)
+- Group distance violation penalty
+- Total reward
+
+**Note:** `ModelRewards` is a legacy Pydantic model that only tracks `closest_objective_reward` and `group_distance_violation_penalty`. It doesn't reflect the full reward breakdown from the phase manager.
+
+### Logging
+
+Loguru is used but primarily for:
+- Reward phase advancement: "Reward phase advanced: 'reach_objectives' -> 'win_by_vp' (success_rate=0.95, epoch=42)"
+- No per-step logging of actions, observations, or combat results
+
+### What's Missing
+
+| Data | Available Internally | Surfaced to User |
+|------|---------------------|-----------------|
+| Action description (decoded) | `_decode_action()` exists | No |
+| Movement direction name | Angles computed | No |
+| Shooting target + result | `ShootingResult` stored per step | No |
+| Wound roll math | `wound_roll_threshold()` exists | No |
+| Reward breakdown | `last_reward_breakdown` dict | Tooltip (partial, legacy) |
+| Opponent actions | Applied but not stored | No |
+| VP scoring reason | Computed in `_on_before_advance` | No |
+| Objective control | Computed for rendering | No (visual only) |
+| Phase description | `BattlePhase` enum | South panel (visual) |
+| Game clock state | Full `GameState` | Round/phase in south panel |
+
+---
+
+## 5. Game Concepts Needing Natural Language Descriptions
+
+### Battle Phases
+
+```python
+class BattlePhase(str, Enum):
+    command = "command"      # VP scoring happens here (end of phase, round 2+)
+    movement = "movement"    # Models move using polar-coordinate actions
+    shooting = "shooting"    # Models select targets and resolve attacks
+    charge = "charge"        # Future: melee charge declarations
+    fight = "fight"          # Future: melee combat resolution
+```
+
+Default `skip_phases` skips all non-movement phases. When shooting is enabled, command/charge/fight are typically skipped.
+
+### Objectives & Control
+
+- Objectives are circular zones with a `radius_size` (in grid cells)
+- A model is "at" an objective if its distance (offset by radius) ≤ 0
+- **Control:** determined by `objective_ownership_from_norms_offset()` — the side with at least one alive model within radius controls the objective; if both sides have models, it's contested (neither controls)
+- Control is computed for rendering (fill color) and VP scoring but not included in observations directly
+
+### VP Scoring (Mission System)
+
+- **Default mission:** Score VP at the end of the command phase from round 2+
+- `vp_per_objective` (default 5) × number of controlled objectives, capped at `cap_per_turn` (default 15)
+- VP is cumulative; tracked as `player_vp`, `opponent_vp`
+- `player_vp_delta` is the VP gained in the current step (observable to the agent)
+- Success criteria `player_vp_min` checks if player VP at end of episode ≥ fraction of theoretical max
+
+### Weapon Profiles
+
+Each model can have weapons with these stats:
+
+| Stat | Field | Description | Example |
+|------|-------|-------------|---------|
+| Range | `range` | Max range in grid cells | 12 |
+| Attacks | `attacks` | Number of hit dice | 2 |
+| Ballistic Skill | `ballistic_skill` | D6 roll needed to hit | 3 (= 3+) |
+| Strength | `strength` | For wound comparison | 4 |
+| AP | `ap` | Worsens target save | 1 |
+| Damage | `damage` | Wounds per unsaved | 1 |
+
+### Shooting Resolution Sequence
+
+Full attack sequence per model (tabletop rules):
+1. **Hit Roll:** Roll `attacks` D6s. Hit on `ballistic_skill`+. Nat 1 always fails, nat 6 always hits.
+2. **Wound Roll:** Roll `hits` D6s. Threshold from strength vs toughness:
+   - S ≥ 2×T → 2+ | S > T → 3+ | S = T → 4+ | S < T → 5+ | T ≥ 2×S → 6+
+3. **Save Roll:** Roll `wounds` D6s. Target needs `save + AP`+ to save. Nat 1 always fails.
+4. **Damage:** `unsaved × damage` total damage applied to target's wound pool.
+
+### Wounds & Elimination
+
+- Models have `current_wounds` / `max_wounds`
+- When `current_wounds` hits 0, model is dead (`is_alive → False`)
+- Dead models are forced to `STAY_ACTION` only
+- Damage applied via `take_damage(amount)` — clamped to 0, no overkill tracking
+
+### Deployment Zones
+
+- Rectangular areas `(x_min, y_min, x_max, y_max)` where models spawn
+- Player zone typically left side, opponent zone right side
+- Models are placed randomly within zone (or at fixed positions if configured)
+
+### Turn Order
+
+- `player` / `opponent` / `random` (coin-flip each reset)
+- Within a round, both sides take all phases in sequence
+- Opponent's full turn (all phases) is auto-executed between player steps
+
+---
+
+## 6. Combat Narrative Data (`ShootingResult`)
+
+### What Exists
+
+```python
+@dataclass(frozen=True, slots=True)
+class ShootingResult:
+    hits: int          # number of successful hit rolls
+    wounds: int        # number of successful wound rolls
+    unsaved: int       # wounds that penetrated armour
+    damage_dealt: int  # total damage = unsaved × weapon.damage
+```
+
+**Stored per step on `WargameEnv`:**
+- `_last_player_shooting_results: list[ShootingResult]` — one per player model that fired
+- `_last_opponent_shooting_results: list[ShootingResult]` — one per opponent model that fired
+
+**Available but not stored:**
+- Which model fired at which target (action → target_idx mapping in `_resolve_shooting_action`)
+- Individual dice rolls (consumed by numpy, only aggregates kept)
+- Wound threshold used (computable from `wound_roll_threshold(weapon.strength, defender.toughness)`)
+- Modified save value (computable from `defender.save + weapon.ap`)
+
+### Expected Damage (Analytical)
+
+`expected_damage(weapon, defender) → float` provides closed-form expected damage. Already computed per player-opponent pair in the tensor pipeline as an observation feature. This is directly useful for LLM evaluation: "Model 0 has expected damage of 0.67 against Opponent 1 vs 1.33 against Opponent 0 — choosing Opponent 1 was suboptimal."
+
+### What's Missing for Full Narration
+
+1. **Attacker-target pairing per result:** Currently `_last_player_shooting_results` is a flat list. Need to store `(attacker_idx, target_idx, result)` tuples.
+2. **Dice roll details:** Individual rolls are consumed by numpy and not stored. For LLM narration, either store rolls or reconstruct probabilities. Storing probabilities (hit chance, wound threshold, modified save) is more useful than individual dice.
+3. **Opponent action recording:** Opponent shooting results exist but opponent movement actions are not stored.
+
+---
+
+## 7. Reward System Details for LLM Interpretation
+
+### Reward Calculators (what generates the signal)
+
+| Calculator | Type | What it rewards/penalizes |
+|------------|------|--------------------------|
+| `closest_objective` | per-model | Penalty when model doesn't get closer to nearest objective. 0 when improving. Optional bonus for new best distance. |
+| `group_cohesion` | per-model | Penalty proportional to excess distance beyond `group_max_distance` from nearest same-group model. 0 when within range. |
+| `vp_gain` | global | Reward = player_vp_delta / cap_per_turn. Max 1.0 per step when scoring full cap. |
+
+### Terminal Bonuses
+
+- `terminal_success_bonus`: Added at episode end when all models at objectives. Scaled by remaining turns fraction (faster = bigger bonus).
+- `terminal_vp_bonus`: Added at episode end when player VP meets threshold.
+
+### Breakdown Structure
+
+`last_reward_breakdown` dict keys:
+- `"closest_objective"` → weighted average across models
+- `"closest_objective/distance_delta"` → sub-component average
+- `"closest_objective/base_penalty"` → sub-component average
+- `"closest_objective/best_distance_bonus"` → sub-component average
+- `"group_cohesion"` → weighted average across models
+- `"vp_gain"` → global value
+- `"terminal_success_bonus"` → one-time bonus at termination
+- `"terminal_vp_bonus"` → one-time bonus at termination
+
+### Curriculum Phases
+
+The reward function changes during training via `RewardPhaseManager`. An LLM evaluator needs to know which phase is active to interpret rewards correctly:
+
+```
+Phase 0 "reach_objectives": closest_objective(1.0) + group_cohesion(0.5)
+  → Evaluate: Is model moving toward objectives while staying grouped?
+
+Phase 1 "win_by_vp": vp_gain(1.0) + closest_objective(0.1) + group_cohesion(0.5)
+  → Evaluate: Is model scoring VP? Still roughly moving toward objectives?
+
+Phase 2 "win_only_by_vp": vp_gain(1.0) + group_cohesion(0.5)
+  → Evaluate: Is model maximizing VP score?
+```
+
+---
+
+## 8. Implementation Recommendations
+
+### Step Summary Data Structure
+
+A new structured step summary should capture:
+
+```python
+@dataclass
+class StepSummary:
+    # Timing
+    step: int
+    battle_round: int
+    n_rounds: int
+    phase: str  # "movement" / "shooting"
+
+    # Scores
+    player_vp: int
+    opponent_vp: int
+    player_vp_delta: int
+    opponent_vp_delta: int
+
+    # Actions taken (decoded)
+    player_actions: list[ActionDescription]  # per-model
+    opponent_actions: list[ActionDescription] | None  # when available
+
+    # Combat results
+    player_shooting: list[CombatNarrative]
+    opponent_shooting: list[CombatNarrative]
+
+    # Reward
+    reward: float
+    reward_breakdown: dict[str, float]
+    reward_phase_name: str
+
+    # State snapshot (before/after or just after)
+    player_models: list[ModelSnapshot]
+    opponent_models: list[ModelSnapshot]
+    objectives: list[ObjectiveSnapshot]
+
+@dataclass
+class ActionDescription:
+    model_idx: int
+    action_int: int
+    action_type: str  # "stay" / "move" / "shoot"
+    description: str  # "Move NE at speed 4 (dx=3, dy=3)" or "Shoot at opponent 1"
+    # Movement-specific
+    direction: str | None  # "NE", "E", etc.
+    speed: int | None
+    displacement: tuple[int, int] | None
+    # Shooting-specific
+    target_idx: int | None
+
+@dataclass
+class CombatNarrative:
+    attacker_idx: int
+    target_idx: int
+    weapon_profile: str  # "2A BS3+ S4 AP-1 D1"
+    hit_chance: float  # probability
+    wound_threshold: int  # e.g. 3 for "3+"
+    modified_save: int  # e.g. 5 for "5+"
+    result: ShootingResult  # hits, wounds, unsaved, damage_dealt
+    target_wounds_before: int
+    target_wounds_after: int
+    target_eliminated: bool
+```
+
+### Text Serialization
+
+For LLM consumption, serialize as structured text (not JSON — too verbose). Example:
+
+```
+=== Step 15 | Round 3/5 | Movement Phase ===
+VP: Player 10 | Opponent 5
+
+Player Actions:
+  Model 0 (group 0, at 25,12, 3/3 HP): Move E at speed 5 → (30,12)
+  Model 1 (group 0, at 22,14, 3/3 HP): Move ENE at speed 4 → (25,12)
+  Model 2 (group 1, at 18,30, 2/3 HP): Move NE at speed 6 → (22,26)
+  Model 3 (group 1, at 20,28, 3/3 HP): Move NE at speed 3 → (22,26)
+
+Reward: -0.150
+  closest_objective: -0.100 (models 0,1 getting closer; model 2 slightly further)
+  group_cohesion: -0.050 (group 1 models 2.0 beyond max distance 5.0)
+
+Objectives: Obj 0 at (30,6) [player controlled] | Obj 1 at (30,22) [contested] | Obj 2 at (30,38) [opponent controlled]
+```
+
+### Key Data Sources for Each Component
+
+| Summary Component | Source in Codebase | Gap |
+|---|---|---|
+| Action description | `ActionHandler._decode_action()` + angle/speed decomposition | Need text formatting layer |
+| Model state | `WargameModelObservation` or `WargameModel` | Available, need serialization |
+| Objective control | `objective_ownership_from_norms_offset()` | Computed for render, not stored in obs |
+| Shooting result | `ShootingResult` + env fields | Need attacker-target pairing |
+| Reward breakdown | `last_reward_breakdown` dict | Available, need text formatting |
+| VP scoring | `_on_before_advance()` + `VPCalculator` | Reasons not stored |
+| Opponent actions | `_apply_opponent_action()` | Actions not recorded |
+| Expected damage | `expected_damage()` in tensor pipeline | Available, good LLM signal |
+| Wound math | `wound_roll_threshold()` | Available as function |
+
+### Implementation Priority
+
+1. **Action decoder to text** — simplest, most impactful. Add `describe_action()` method to `ActionHandler`.
+2. **Step summary data structure** — new file in `envs/types/` or `envs/narration/`.
+3. **Store attacker-target pairing** — modify `_resolve_shooting_action` to return `(model_idx, target_idx, result)` tuples.
+4. **Record opponent actions** — store the `WargameEnvAction` from opponent policy before applying it.
+5. **Objective control in observations** — add to `WargameEnvInfo` or summary.
+6. **Text serialization** — format the step summary as structured text for LLM consumption.
+
+### Architectural Notes
+
+- The LLM representation layer should depend on `BattleView` (read-only protocol), not `WargameEnv` directly.
+- Step summaries should be optional — don't slow down training. Enable via config flag or only during evaluation/simulation.
+- Consider a `StepNarrator` class that takes `BattleView` + `StepContext` + decoded actions and produces text.
+- The reward phase name from `RewardPhaseManager.current_phase_name` is essential context for the LLM — without it, reward values are uninterpretable.
+
+---
+
+## 9. Compass Direction Mapping
+
+For human-readable movement narration, map angle indices to compass directions:
+
+| Angles (16) | Direction | Degrees |
+|-------------|-----------|---------|
+| 0 | E (East) | 0° |
+| 1 | ENE | 22.5° |
+| 2 | NE | 45° |
+| 3 | NNE | 67.5° |
+| 4 | N (North) | 90° |
+| 5 | NNW | 112.5° |
+| 6 | NW | 135° |
+| 7 | WNW | 157.5° |
+| 8 | W (West) | 180° |
+| 9 | WSW | 202.5° |
+| 10 | SW | 225° |
+| 11 | SSW | 247.5° |
+| 12 | S (South) | 270° |
+| 13 | SSE | 292.5° |
+| 14 | SE | 315° |
+| 15 | ESE | 337.5° |
+
+**Note:** The grid convention is +x = East, +y = South (screen coordinates). The angle system starts at East and goes counter-clockwise, so angle_idx=4 (90°) is actually North (-y direction in screen coords). The narration layer needs to handle this coordinate system correctly.
+
+---
+
+## 10. Summary of Gaps
+
+| Gap | Severity | Fix Complexity |
+|-----|----------|---------------|
+| No text representation of actions | High | Low — decode + format |
+| Shooting results lack attacker-target pairing | High | Low — modify return type |
+| Opponent actions not recorded | Medium | Low — store before applying |
+| Objective control not in observations | Medium | Low — add to info dict |
+| No step summary data structure | High | Medium — new types + assembly |
+| Individual dice rolls not stored | Low | Medium — optional recording |
+| Reward phase context not in step output | Medium | Low — add phase name to info |
+| VP scoring reasons not recorded | Low | Low — log controlled count |
+| Coordinate system documentation | Medium | Low — document in narration code |

--- a/.planning/research/v9-STATE-IO.md
+++ b/.planning/research/v9-STATE-IO.md
@@ -1,0 +1,511 @@
+# v9 Research: Structured Game State & Bidirectional State I/O
+
+**Researched:** 2026-05-23
+**Confidence:** HIGH (based entirely on codebase analysis)
+
+---
+
+## 1. How `Battle` Is Currently Constructed
+
+### Path: Config → Battle
+
+```
+WargameEnvConfig (Pydantic YAML)
+  └─ battle_factory.from_config(config) → Battle
+       ├─ _build_models(n, model_configs, n_objectives, max_groups) → list[WargameModel]
+       │     - Locations initialised to np.zeros(2) — **not placed yet**
+       │     - Stats: max_wounds, current_wounds (= max_wounds), toughness, save
+       │     - distances_to_objectives: np.zeros([n_objectives, 2]) — **placeholder**
+       │     - group_id: from config or computed from index
+       ├─ _build_objectives(config) → list[WargameObjective]
+       │     - Locations initialised to np.zeros(2) — **not placed yet**
+       │     - radius_size: per-objective or global
+       ├─ BoardDimensions(width, height)
+       ├─ DeploymentZone (player, opponent)
+       └─ Battle(board_dimensions, player_models, opponent_models,
+                 objectives, deployment_zone, opponent_deployment_zone)
+             - _player_vp = 0, _opponent_vp = 0
+             - _player_vp_delta = 0, _opponent_vp_delta = 0
+```
+
+**Key observation:** `Battle` is a structural shell at construction time. Entities have zero-locations and zero-distances. Real state comes from placement (in `reset()`).
+
+### `WargameEnv.__init__()` additionally creates:
+
+- `ActionHandler` (config-derived, immutable after init)
+- `GameClock(n_rounds=config.number_of_battle_rounds)`
+- `RewardPhaseManager` (from reward_phases config — stateful, tracks curriculum phase)
+- `VPCalculator` (from mission config)
+- `OpponentPolicy` (if opponents configured)
+- `_combat_rng` (re-seeded each episode)
+- Bookkeeping: `current_turn`, `last_reward`, `last_reward_breakdown`, etc.
+
+---
+
+## 2. How `reset()` Initialises State
+
+The `reset()` method follows this exact sequence:
+
+```
+1. super().reset(seed=seed)              → sets self.np_random (Gym-managed RNG)
+2. Re-seed combat RNG                    → self._combat_rng = default_rng(seed)
+3. Clear shooting results
+4. Reset bookkeeping:
+   - current_turn = 0
+   - last_reward = None
+   - last_step_context = None
+   - last_reward_breakdown = {}
+   - episode_reward_breakdown = {}
+   - episode_reward_steps = 0
+5. self._battle.reset_for_episode()      → clears VP, resets all model episode state
+6. self._resolve_player_side()           → sets _player_side (deterministic or random)
+7. self._game_clock.reset()              → setup phase, round 1, step 0
+8. self._game_clock.skip_setup()         → transition to battle (round 1, player_1, command)
+9. place_for_episode(battle, config, rng) → sets locations on all entities
+10. run_until_player_phase(...)           → auto-execute opponent if they go first
+11. compute_distances + build_observation → first obs
+12. renderer.setup + render (if renderer)
+```
+
+### What `Battle.reset_for_episode()` does:
+
+- Zeroes VP counters (player, opponent, deltas)
+- Calls `model.reset_for_episode()` on every player and opponent model
+
+### What `WargameModel.reset_for_episode()` does:
+
+- `previous_location = None`
+- `previous_closest_objective_distance = None`
+- `best_closest_objective_distance = None`
+- `current_wounds = max_wounds` (restore to full health)
+- `model_rewards_history.clear()`
+- `advanced_this_turn = False`
+
+### Complete list of state that must be valid after reset:
+
+| Component | State Set By | Required |
+|-----------|-------------|----------|
+| `np_random` | `super().reset(seed=)` | Yes (Gym contract) |
+| `_combat_rng` | seeded from np_random | Yes (shooting determinism) |
+| `current_turn` | `= 0` | Yes |
+| `_player_side` | `_resolve_player_side()` | Yes |
+| `_game_clock` | `.reset()` then `.skip_setup()` | Yes |
+| Model locations | `place_for_episode()` | Yes |
+| Objective locations | `place_for_episode()` | Yes |
+| Model wounds | `reset_for_episode()` | Yes |
+| Model distances_to_objectives | `compute_distances()` | Yes (observation) |
+| VP counters | `reset_for_episode()` | Yes |
+| `last_reward` / `last_step_context` | `= None` | Yes (sentinel) |
+| Reward breakdown accumulators | `= {}` / `= 0` | Yes |
+| Shooting results | `= []` | Yes |
+
+---
+
+## 3. What "Inject State" Would Mean
+
+### 3a. Constructing a Battle from a Snapshot
+
+A state snapshot must provide enough to construct a **mid-episode** `Battle` (or `WargameEnv`) without going through the normal `reset()` → `place_for_episode()` flow.
+
+**Minimum fields for entity-level state injection:**
+
+```python
+# Per player/opponent model:
+{
+    "location": [x, y],          # int32 pair, within board bounds
+    "current_wounds": int,       # 0 ≤ cw ≤ max_wounds
+    "max_wounds": int,           # from config
+    "group_id": int,
+    "toughness": int,
+    "save": int,
+}
+
+# Per objective:
+{
+    "location": [x, y],
+    "radius_size": int,
+}
+
+# Battle-level:
+{
+    "player_vp": int,
+    "opponent_vp": int,
+}
+
+# Clock state:
+{
+    "game_phase": "battle",       # or "setup" / "complete"
+    "battle_round": int,          # 1..n_rounds
+    "active_player": "player_1",  # or "player_2"
+    "phase": "movement",          # BattlePhase enum value
+    "total_steps": int,           # optional for correctness
+}
+
+# Env-level:
+{
+    "current_turn": int,
+    "player_side": "player_1",    # which side the RL agent controls
+}
+```
+
+### 3b. Can we bypass placement?
+
+**Yes.** The current architecture already supports this conceptually:
+
+1. `Battle` models start at `np.zeros(2)` after `from_config()`
+2. `place_for_episode()` just sets `.location` on each entity
+3. `fixed_wargame_model_placement()` already does direct location assignment
+
+So bypassing placement is just: create the `Battle` from config, then directly set locations on each entity.
+
+### 3c. Invariants That Must Hold
+
+1. **Locations on grid**: `0 ≤ x < board_width`, `0 ≤ y < board_height` (int32)
+2. **No duplicate locations** (placement logic prevents this, but not enforced elsewhere)
+3. **Wounds**: `0 ≤ current_wounds ≤ max_wounds`
+4. **VP**: non-negative integers
+5. **Clock consistency**: `battle_round ∈ [1, n_rounds]`, `phase ∈ BattlePhase`, `active_player ∈ PlayerSide`
+6. **Game phase consistency**: if `game_phase == "battle"`, all battle fields must be set
+7. **Entity counts match config**: n_models, n_objectives, n_opponent_models
+8. **distances_to_objectives**: must be recomputed from locations (derived, not injected)
+9. **Action handler**: immutable, derived from config — no injection needed
+10. **Reward history per model**: `previous_closest_objective_distance` and `best_closest_objective_distance` are reward-shaping state; should be `None` for injected states (or computable from the snapshot)
+
+### 3d. Derived State (Recomputable, Don't Inject)
+
+These should be recomputed after injection, not stored in the snapshot:
+
+- `distances_to_objectives` (per model) — computed by `compute_distances()`
+- `DistanceCache` — computed each step
+- `action_mask` — computed each observation build
+- `previous_location` — only needed for rendering, `None` is safe
+- `model_rewards_history` — empty list for injected states
+- VP deltas — can be zeroed (they're per-step)
+
+---
+
+## 4. GameClock Initialisation and Reset
+
+### Construction
+
+```python
+GameClock(n_rounds=5, first_player=PlayerSide.player_1)
+```
+
+Sets: `_game_phase = GamePhase.setup`, `_setup_idx = 0`, `_round = 1`, `_phase_idx = 0`, `_total_steps = 0`.
+
+### Reset
+
+`clock.reset()` → identical to construction state (setup phase, round 1, step 0).
+
+### Can It Be Set to an Arbitrary Phase/Round?
+
+**Not directly.** The clock has no `set_state()` method. Its internal fields are all private (`_round`, `_phase_idx`, `_game_phase`, `_active_player`).
+
+**Options for arbitrary state injection:**
+
+1. **Add a `set_state()` method** (recommended):
+   ```python
+   def set_state(self, game_phase, round, active_player, phase_idx, total_steps):
+       self._game_phase = game_phase
+       self._round = round
+       self._active_player = active_player
+       self._phase_idx = phase_idx
+       self._total_steps = total_steps
+   ```
+
+2. **Replay advances** (fragile, O(n) in rounds×phases):
+   Call `skip_setup()` then `advance_phase()` repeatedly until reaching the target state.
+
+3. **Direct attribute assignment** (hacky, breaks encapsulation):
+   ```python
+   clock._round = 3
+   clock._phase_idx = 1  # movement
+   ```
+
+**Recommendation:** Add a `GameClock.from_state()` classmethod or `set_state()` method. It should validate the state is consistent (round in range, phase_idx in range, game_phase matches).
+
+### Internal Fields to Set
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `_game_phase` | `GamePhase` | `setup`, `battle`, or `complete` |
+| `_round` | `int` | 1..n_rounds |
+| `_active_player` | `PlayerSide` | `player_1` or `player_2` |
+| `_phase_idx` | `int` | 0..4 (index into BATTLE_PHASE_ORDER) |
+| `_total_steps` | `int` | cumulative steps |
+| `_n_rounds` | `int` | immutable after init (from config) |
+| `_first_player` | `PlayerSide` | immutable after init |
+| `_second_player` | `PlayerSide` | derived from first_player |
+
+---
+
+## 5. Mutable vs Construction-Time State
+
+### Mutable During an Episode
+
+| Entity | Field | Mutated By |
+|--------|-------|-----------|
+| `WargameModel` | `location` | `ActionHandler.apply()` |
+| `WargameModel` | `previous_location` | `ActionHandler.apply()` |
+| `WargameModel` | `stats["current_wounds"]` | `take_damage()` |
+| `WargameModel` | `distances_to_objectives` | `update_distances_to_objectives()` |
+| `WargameModel` | `previous_closest_objective_distance` | reward calculator |
+| `WargameModel` | `best_closest_objective_distance` | reward calculator |
+| `WargameModel` | `model_rewards_history` | reward calculator |
+| `WargameModel` | `advanced_this_turn` | charge phase tracking |
+| `Battle` | `_player_vp` / `_opponent_vp` | `add_player_vp()` / `add_opponent_vp()` |
+| `Battle` | `_player_vp_delta` / `_opponent_vp_delta` | VP scoring, reset each step |
+| `WargameEnv` | `current_turn` | `step()` |
+| `WargameEnv` | `last_reward` | `step()` |
+| `WargameEnv` | `last_step_context` | `step()` |
+| `WargameEnv` | `episode_reward_breakdown` | `step()` |
+| `WargameEnv` | `_last_player_shooting_results` | `step()` |
+| `WargameEnv` | `_last_opponent_shooting_results` | `step()` |
+| `GameClock` | `_round`, `_phase_idx`, `_active_player`, `_game_phase` | `advance_phase()` etc. |
+
+### Fixed at Construction (Immutable During Episode)
+
+| Entity | Field | Set By |
+|--------|-------|--------|
+| `WargameModel` | `stats["max_wounds"]` | `battle_factory._build_models()` |
+| `WargameModel` | `stats["toughness"]` | `battle_factory._build_models()` |
+| `WargameModel` | `stats["save"]` | `battle_factory._build_models()` |
+| `WargameModel` | `group_id` | `battle_factory._build_models()` |
+| `WargameObjective` | `radius_size` | `battle_factory._build_objectives()` |
+| `Battle` | `_board_dimensions` | constructor |
+| `Battle` | `_deployment_zone` / `_opponent_deployment_zone` | constructor |
+| `GameClock` | `_n_rounds` | constructor |
+| `GameClock` | `_first_player` / `_second_player` | constructor |
+| `WargameEnv` | `config` | constructor |
+| `WargameEnv` | `_action_handler` | constructor |
+| `WargameEnv` | `phase_manager` | constructor (stateful for curriculum, but phase index is training-session-level, not episode-level) |
+
+### Special: Training-Session-Level State (Not Per-Episode)
+
+| Entity | Field | Notes |
+|--------|-------|-------|
+| `RewardPhaseManager` | `_current_phase_index` | Curriculum phase — advances across episodes, not within |
+| `RewardPhaseManager` | `_consecutive_above` | Counter for phase advancement threshold |
+
+---
+
+## 6. Validation Requirements for a Valid State
+
+### Hard Constraints (Must Fail Loudly if Violated)
+
+1. **Model locations in bounds**: `0 ≤ x < board_width`, `0 ≤ y < board_height`, dtype int32
+2. **Objective locations in bounds**: same as models
+3. **Wound bounds**: `0 ≤ current_wounds ≤ max_wounds`
+4. **VP non-negative**: `player_vp ≥ 0`, `opponent_vp ≥ 0`
+5. **Clock phase valid**: `phase_idx` in `[0, len(BATTLE_PHASE_ORDER))`
+6. **Clock round valid**: `round` in `[1, n_rounds]` when `game_phase == battle`
+7. **Entity count match**: model/objective lists match config counts
+8. **Board dimensions match config**: width/height from snapshot must equal env config
+
+### Soft Constraints (Warn But Allow)
+
+1. **No overlapping model locations**: placement prevents this, but mid-game movement could theoretically overlap (clipping doesn't check). Not currently enforced.
+2. **VP delta consistency**: deltas should be ≤ cap_per_turn (but mid-step state could have any value)
+3. **Objective locations outside deployment zones**: placement enforces this, but it's a placement rule, not a game rule
+
+### Constraints That Don't Apply to Injected State
+
+1. **Group max distance**: this is a placement constraint, not a game-state invariant
+2. **`previous_closest_objective_distance`**: can be `None` (signals first step for reward shaping)
+
+---
+
+## 7. How Tests Set Up State — Patterns for Constructing Specific Game States
+
+### Pattern 1: Config with Fixed Positions (Most Common)
+
+Tests create `WargameEnvConfig` with explicit `models=[ModelConfig(x=..., y=...)]` and `objectives=[ObjectiveConfig(x=..., y=...)]`, then call `env.reset()`. This uses `fixed_wargame_model_placement()` internally.
+
+```python
+# From test_wounds.py
+config = WargameEnvConfig(
+    board_width=20, board_height=20,
+    number_of_wargame_models=2,
+    models=[ModelConfig(x=5, y=5, max_wounds=2), ModelConfig(x=10, y=10, max_wounds=2)],
+    objectives=[ObjectiveConfig(x=10, y=10, radius_size=2)],
+)
+env = WargameEnv(config=config)
+env.reset(seed=42)
+```
+
+### Pattern 2: Post-Reset Mutation (Common for Testing Specific States)
+
+Tests call `env.reset()` first, then directly mutate entity state:
+
+```python
+# Moving models to specific positions after reset
+env.reset()
+env.wargame_models[0].location = np.array([5, 5])
+env.objectives[0].location = np.array([10, 10])
+
+# Inflicting damage
+env.wargame_models[0].take_damage(2)
+
+# Adding VP
+env._battle.add_player_vp(20)
+```
+
+This pattern is used extensively in `test_reward_phases.py` (location mutation) and `test_wounds.py` (damage + elimination).
+
+### Pattern 3: Standalone Entity Construction (Unit Tests)
+
+Tests create `WargameModel` directly for isolated unit tests:
+
+```python
+# From test_wounds.py
+def _make_model(max_wounds, current_wounds=None):
+    return WargameModel(
+        location=np.array([0, 0], dtype=np.int32),
+        stats={"max_wounds": max_wounds, "current_wounds": cw},
+        distances_to_objectives=np.zeros((1, 2), dtype=np.int32),
+        group_id=0,
+    )
+```
+
+### Pattern 4: SimpleNamespace Fakes (Reward Testing)
+
+Tests use `SimpleNamespace` to mock `BattleView` for reward calculators:
+
+```python
+# From test_reward_phases.py
+view = SimpleNamespace(player_vp_delta=5, config=SimpleNamespace(mission=...))
+```
+
+### Missing Pattern: No Tests Construct Mid-Episode State
+
+No test currently:
+- Sets the GameClock to a specific round/phase
+- Injects a complete state snapshot into a running env
+- Creates a Battle from a serialised representation
+
+This confirms v9 is genuinely new capability.
+
+---
+
+## 8. Architectural Recommendations for State I/O
+
+### 8a. State Representation Schema
+
+A `GameState` dataclass/Pydantic model for serialisation:
+
+```python
+class GameSnapshot:
+    board_width: int
+    board_height: int
+
+    player_models: list[ModelSnapshot]  # location, wounds, group_id, stats
+    opponent_models: list[ModelSnapshot]
+    objectives: list[ObjectiveSnapshot]  # location, radius
+
+    player_vp: int
+    opponent_vp: int
+
+    clock: ClockSnapshot  # game_phase, round, active_player, phase, total_steps
+    current_turn: int
+    player_side: str  # "player_1" or "player_2"
+```
+
+### 8b. Serialization (State → Snapshot)
+
+**Straightforward.** All mutable state is directly readable via properties or public attributes:
+- `battle.player_models[i].location`, `.stats["current_wounds"]`, etc.
+- `battle.player_vp`, `battle.opponent_vp`
+- `game_clock.state` (returns `GameState` dataclass)
+- `env.current_turn`
+
+No private internals need exposure for serialisation — `GameClock.state` already returns an immutable `GameState` snapshot.
+
+### 8c. Deserialization (Snapshot → State)
+
+**This is the hard part.** The current design has no "set state" path. Steps needed:
+
+1. **`GameClock.set_state()` or `from_state()`**: new method to set internal clock position
+2. **`Battle.set_vp()`** or direct injection: set VP counters
+3. **Model state injection**: set location, wounds on existing model objects
+4. **Objective location injection**: set locations on existing objective objects
+5. **`WargameEnv.load_state(snapshot)`**: orchestration method that:
+   - Sets clock state
+   - Sets entity positions/wounds
+   - Sets VP
+   - Recomputes derived state (distances, distances_to_objectives)
+   - Clears per-step accumulators (reward breakdown, shooting results)
+   - Sets `current_turn`
+   - Builds initial observation
+
+### 8d. Two Levels of State Injection
+
+| Level | Use Case | What Gets Set |
+|-------|----------|--------------|
+| **Entity-level** | "Place these models here" | Locations, wounds only |
+| **Full snapshot** | "Resume from this exact game state" | Everything: clock, VP, wounds, locations, turn count |
+
+Entity-level injection is a subset of full snapshot — implement full snapshot and entity-level comes for free.
+
+### 8e. Validation Layer
+
+A `validate_snapshot(snapshot, config)` function that checks all hard constraints from section 6. Should be called before applying the snapshot.
+
+---
+
+## 9. Risks and Concerns
+
+### 9a. Reward Shaping State Discontinuity
+
+`previous_closest_objective_distance` and `best_closest_objective_distance` are used by `ClosestObjectiveCalculator` for reward shaping. When injecting mid-episode state, these will be `None`, meaning the first step after injection will return 0 reward (as if it were the first step of an episode). This is actually the safest behaviour — the alternative (computing from snapshot) would require knowing what the "previous" state was.
+
+### 9b. Opponent Policy State
+
+The opponent policy is stateless (selects actions based on current board state only). No concerns for state injection.
+
+### 9c. ActionHandler State
+
+`ActionHandler` is fully derived from config and immutable. No concerns.
+
+### 9d. RewardPhaseManager State
+
+The curriculum phase index is a training-session-level concern, not a per-episode concern. State injection doesn't need to touch it.
+
+### 9e. RNG State
+
+For full reproducibility after injection, the `_combat_rng` and `np_random` states would need to be serialised. For practical purposes (LLM-readable state, scenario setup), RNG state can be omitted and re-seeded.
+
+### 9f. Clock `total_steps` Tracking
+
+`GameClock._total_steps` is incremented during phase advances but isn't used for any game logic — it's purely diagnostic. For injected states, setting it to 0 or to a computed value is fine.
+
+---
+
+## 10. Summary: What Needs to Change
+
+### New Code Needed
+
+1. **`GameClock.set_state()`** — method to set clock to arbitrary position
+2. **`GameSnapshot` schema** — Pydantic model for the full state representation
+3. **`Battle.from_snapshot()` or `Battle.apply_snapshot()`** — inject entity state into Battle
+4. **`WargameEnv.load_state(snapshot)`** — top-level injection orchestrator
+5. **`WargameEnv.to_snapshot()`** — serialise current state
+6. **`validate_snapshot()`** — validation against config
+
+### No Changes Needed
+
+- `ActionHandler` (immutable, config-derived)
+- `RewardPhaseManager` (session-level state)
+- `VPCalculator` (stateless computation)
+- `OpponentPolicy` (stateless)
+- `DistanceCache` / `compute_distances()` (recomputed each step)
+- `BattleView` protocol (already read-only, works as-is)
+- Observation builder (already uses BattleView)
+
+### Existing Patterns to Leverage
+
+- `fixed_wargame_model_placement()` — precedent for direct location setting
+- `WargameModel.reset_for_episode()` — precedent for resetting per-episode state
+- `GameClock.state` property — already produces `GameState` snapshot (read side)
+- `Battle.reset_for_episode()` — precedent for clearing episode state
+- Test patterns (Pattern 2: post-reset mutation) — shows direct mutation works

--- a/.planning/research/v9-STATE-REPRESENTATION.md
+++ b/.planning/research/v9-STATE-REPRESENTATION.md
@@ -1,0 +1,419 @@
+# v9.0 Research: Structured Game State & LLM-Readable Representation
+
+**Milestone:** v9.0
+**Researched:** 2026-05-23
+**Focus:** Current state representation, serialisation patterns, gaps
+
+---
+
+## 1. Full Game State Inventory
+
+### 1.1 Battle Aggregate (`domain/battle.py`)
+
+The `Battle` class is the aggregate root. Its fields constitute the core mutable state:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `_board_dimensions` | `BoardDimensions` (frozen dataclass) | width, height |
+| `_player_models` | `list[WargameModel]` | All player units (mutable entity objects) |
+| `_opponent_models` | `list[WargameModel]` | All opponent units |
+| `_objectives` | `list[WargameObjective]` | Capture targets |
+| `_deployment_zone` | `DeploymentZone` (frozen dataclass) | x_min, y_min, x_max, y_max |
+| `_opponent_deployment_zone` | `DeploymentZone` | Same structure for opponent |
+| `_player_vp` | `int` | Cumulative player victory points |
+| `_opponent_vp` | `int` | Cumulative opponent victory points |
+| `_player_vp_delta` | `int` | VP scored this step (reset each step) |
+| `_opponent_vp_delta` | `int` | VP scored this step for opponent |
+
+### 1.2 GameClock State (`domain/game_clock.py`)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `_n_rounds` | `int` | Total battle rounds (typically 5) |
+| `_first_player` | `PlayerSide` | Who goes first |
+| `_game_phase` | `GamePhase` | setup / battle / complete |
+| `_setup_idx` | `int` | Index into SETUP_PHASE_ORDER |
+| `_round` | `int` | Current battle round (1-based) |
+| `_active_player` | `PlayerSide` | Whose turn it is |
+| `_phase_idx` | `int` | Index into BATTLE_PHASE_ORDER |
+| `_total_steps` | `int` | Clock-level step counter |
+
+The clock exposes a `GameState` snapshot (frozen dataclass):
+- `game_phase: GamePhase`
+- `setup_phase: SetupPhase | None`
+- `battle_round: int | None`
+- `active_player: PlayerSide | None`
+- `phase: BattlePhase | None`
+
+### 1.3 WargameModel Entity (`domain/entities.py`)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `location` | `np.ndarray (2,)` | Current grid position [x, y] |
+| `previous_location` | `np.ndarray \| None` | Position before last move |
+| `stats` | `dict[str, int]` | Keys: `max_wounds`, `current_wounds`, `toughness`, `save` |
+| `distances_to_objectives` | `np.ndarray (n_obj, 2)` | Delta vectors to each objective |
+| `group_id` | `int` | Group membership |
+| `previous_closest_objective_distance` | `float \| None` | For reward shaping |
+| `best_closest_objective_distance` | `float \| None` | Best seen this episode |
+| `model_rewards_history` | `list[ModelRewards]` | Reward breakdown per step |
+| `advanced_this_turn` | `bool` | Whether model moved this turn (affects shooting) |
+
+**Derived property:**
+- `is_alive` → `stats["current_wounds"] > 0`
+
+### 1.4 WargameObjective Entity (`domain/entities.py`)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `location` | `np.ndarray (2,)` | Grid position |
+| `radius_size` | `int` | Capture radius |
+
+### 1.5 Value Objects (`domain/value_objects.py`)
+
+- `BoardDimensions(width, height)` — frozen dataclass
+- `DeploymentZone(x_min, y_min, x_max, y_max)` — frozen dataclass, has `as_array()` → `np.ndarray`
+
+### 1.6 Combat RNG State (on `WargameEnv`)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `_combat_rng` | `np.random.Generator` | Re-seeded per episode |
+| `_last_player_shooting_results` | `list[ShootingResult]` | Per-step combat outcomes |
+| `_last_opponent_shooting_results` | `list[ShootingResult]` | Per-step combat outcomes |
+
+`ShootingResult` (frozen dataclass): `hits`, `wounds`, `unsaved`, `damage_dealt`
+
+### 1.7 Env-Level Ephemeral State
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `current_turn` | `int` | Step counter (0-based, incremented in step()) |
+| `last_reward` | `float \| None` | Most recent reward value |
+| `last_reward_breakdown` | `dict[str, float]` | Per-calculator reward breakdown |
+| `episode_reward_breakdown` | `dict[str, float]` | Cumulative episode reward breakdown |
+| `episode_reward_steps` | `int` | Steps counted this episode |
+| `last_step_context` | `StepContext \| None` | Last step's derived context |
+| `_player_side` | `PlayerSide` | Which side the RL agent controls |
+| `_skip_phases` | `frozenset[BattlePhase]` | Phases to auto-advance |
+| `phase_manager` | `RewardPhaseManager` | Current phase state |
+
+### 1.8 Configuration (`WargameEnvConfig` — Pydantic)
+
+Fully serialisable, includes:
+- Board dimensions, movement params (n_angles, n_speeds, max_speed)
+- Entity counts and per-entity configs (`ModelConfig`, `ObjectiveConfig`)
+- Deployment zones
+- Reward phases (curriculum), terminal bonuses
+- Skip phases, turn order, battle rounds
+- Mission config (type + params)
+- Opponent policy config
+- `blocking_mask` (terrain)
+- `max_turns_override`, `terminate_on_player_elimination`
+
+---
+
+## 2. Existing Serialisation
+
+### 2.1 `WargameEnvInfo.model_dump()` (returned as Gym info dict)
+
+The info dict exported from `step()` and `reset()` contains:
+
+```python
+{
+    "current_turn": int,
+    "wargame_models": [
+        {
+            "location": np.ndarray,        # (2,)
+            "distances_to_objectives": np.ndarray,  # (n_obj, 2)
+            "group_id": int,
+            "max_groups": int,
+            "alive": float,                # 1.0 or 0.0
+            "current_wounds": int,
+            "max_wounds": int,
+            "weapon_attacks": int,
+            "weapon_ballistic_skill": int,
+            "weapon_strength": int,
+            "weapon_ap": int,
+            "weapon_damage": int,
+            "toughness": int,
+            "save_stat": int,
+        },
+        ...
+    ],
+    "objectives": [{"location": np.ndarray}],
+    "opponent_models": [...],              # same schema as wargame_models
+    "deployment_zone": (int, int, int, int),
+    "opponent_deployment_zone": (int, int, int, int),
+    "player_vp": int,
+    "opponent_vp": int,
+    "player_vp_delta": int,
+    "opponent_vp_delta": int,
+}
+```
+
+**Note:** `model_dump()` on a Pydantic model with `arbitrary_types_allowed=True` preserves numpy arrays as-is — they are NOT converted to JSON-safe lists.
+
+### 2.2 Config Serialisation in `train.py`
+
+- `env_config.model_dump()` → nested dict logged to Wandb as config
+- `dqn_config.model_dump()` / `ppo_config.model_dump()` → same
+- `to_yaml_str(env_config)` via `pydantic-yaml` in `EnvConfigCallback` → YAML file alongside checkpoints
+
+### 2.3 Other Dict/JSON Exports
+
+- `test_reward_phases.py` uses `cfg.model_dump()` for round-trip validation
+- No explicit JSON export (no `model_dump_json()` usage found)
+- No `model_json_schema()` usage found anywhere in codebase
+
+---
+
+## 3. Gaps: What's Missing from Info Dict vs Full State
+
+### 3.1 Game Timing (Partially Missing)
+
+| Data | In Info? | In Observation? | Notes |
+|------|----------|-----------------|-------|
+| `battle_round` | NO | YES (obs) | Info dict lacks this |
+| `battle_phase` / index | NO | YES (obs) | Info dict lacks this |
+| `game_phase` (setup/battle/complete) | NO | NO | Never exposed |
+| `active_player` | NO | NO | Never exposed |
+| `n_rounds` | NO | YES (obs) | Info dict lacks this |
+| `max_turns` | NO | NO | Only on env |
+| `total_clock_steps` | NO | NO | Only on GameClock |
+
+### 3.2 Terrain
+
+| Data | In Info? | Notes |
+|------|----------|-------|
+| `blocking_mask` (LOS terrain) | NO | Only in config; not in per-step output |
+| LOS between specific cells | NO | Computed on demand via `has_line_of_sight_between_cells` |
+
+### 3.3 Actions Taken
+
+| Data | In Info? | Notes |
+|------|----------|-------|
+| Player action this step | NO | Not stored after application |
+| Opponent action this step | NO | Applied and discarded |
+| Action mask (valid actions) | NO (in obs) | In observation only |
+| Which models moved/shot | NO | `advanced_this_turn` on model but not serialised |
+
+### 3.4 Combat / Shooting Results
+
+| Data | In Info? | Notes |
+|------|----------|-------|
+| `_last_player_shooting_results` | NO | `ShootingResult` dataclasses on env |
+| `_last_opponent_shooting_results` | NO | Same |
+| Per-model hits/wounds/damage | NO | Lost after step |
+
+### 3.5 Reward Breakdown
+
+| Data | In Info? | Notes |
+|------|----------|-------|
+| `last_reward` | NO | On env only |
+| `last_reward_breakdown` | NO | Dict on env, not serialised |
+| `episode_reward_breakdown` | NO | Accumulated dict on env |
+| Current reward phase name | NO | On phase_manager |
+| Current reward phase index | NO | On phase_manager |
+
+### 3.6 Derived Spatial Data
+
+| Data | In Info? | Notes |
+|------|----------|-------|
+| `DistanceCache` | NO | Computed each step, discarded |
+| Objective ownership (per-objective) | NO | Computed by VP calc on demand |
+| Group cohesion distances | NO | Computed by reward calc on demand |
+| `previous_closest_objective_distance` | NO | On model entity, not in obs/info |
+| `best_closest_objective_distance` | NO | Same |
+
+### 3.7 Episode Context
+
+| Data | In Info? | Notes |
+|------|----------|-------|
+| Episode seed | NO | Only used to seed `_combat_rng` |
+| Turn order this episode | NO | `_player_side` on env |
+| Which side is the RL agent | NO | Implicit |
+| Is terminated (this step) | NO | Returned as separate Gym value |
+
+---
+
+## 4. Pydantic Model Assessment
+
+### 4.1 Current Pydantic Usage
+
+| Model | Layer | Usage |
+|-------|-------|-------|
+| `WargameEnvConfig` | types | Full config — YAML load/dump, Wandb logging, `model_dump()` |
+| `WargameEnvInfo` | types | Info dict returned from step/reset — `model_dump()` |
+| `ModelConfig` | types | Per-model YAML config |
+| `ObjectiveConfig` | types | Per-objective YAML config |
+| `WeaponProfile` | types | Weapon stats in config |
+| `OpponentPolicyConfig` | types | Opponent policy selection |
+| `MissionConfig` | types | VP calculator selection |
+| `RewardPhaseConfig` | reward | Phase curriculum config |
+| `RewardCalculatorConfig` | reward | Per-calculator config |
+| `SuccessCriteriaConfig` | reward | Success criteria config |
+| `ModelRewards` | reward/types | Per-model reward breakdown |
+
+### 4.2 Capabilities Available but Unused
+
+1. **`model_json_schema()`** — Not used anywhere. Could auto-generate JSON Schema for the state model, enabling LLM tool-use / function-calling integration.
+
+2. **`model_dump_json()`** — Not used. Would produce JSON strings directly (more efficient than `model_dump()` → `json.dumps()`).
+
+3. **`model_validate()`** / `model_validate_json()` — Only used implicitly via constructor. Could be used for state restoration/deserialization.
+
+4. **Computed fields (`@computed_field`)** — Not used. Could expose derived properties (like `is_alive`) in serialised output without storing them.
+
+5. **Custom serializers (`@field_serializer`)** — Not used. Would solve the numpy-to-list conversion problem for JSON-safe output.
+
+6. **Discriminated unions** — Not used. Could model polymorphic state cleanly (e.g., different phase states).
+
+### 4.3 Leverageability Assessment
+
+**YES, Pydantic is the right tool for the canonical state model.** Reasons:
+
+1. **Already the config standard** — Team is familiar, tooling (pydantic-yaml) already present
+2. **Schema generation** — `model_json_schema()` produces JSON Schema that LLMs can consume as tool descriptions
+3. **Validation at construction** — Ensures state integrity; catches bugs at serialisation boundaries
+4. **Serialisation modes** — `model_dump(mode="json")` converts numpy arrays to lists automatically; `model_dump_json()` for direct JSON string output
+5. **Nested models compose** — A `FullGameState` model can include `BoardState`, `ModelState[]`, `ClockState`, `CombatLog` etc.
+6. **Backward compat** — Can annotate optional fields to grow the schema without breaking consumers
+
+**Caveats:**
+- numpy arrays need `ConfigDict(arbitrary_types_allowed=True)` or custom validators to handle JSON serialisation cleanly
+- Large arrays (blocking_mask 50×50) should probably use a compact encoding rather than nested lists
+- The `WargameModel` entity class is NOT Pydantic (plain class with numpy) — a parallel Pydantic `ModelState` would be needed for serialisation
+
+---
+
+## 5. StepContext Analysis
+
+`StepContext` (dataclass with `slots=True`) is assembled in `WargameEnv.step()` with per-step derived data:
+
+| Field | Type | What It Represents |
+|-------|------|--------------------|
+| `distance_cache` | `DistanceCache` | All spatial relationships this step |
+| `current_turn` | `int` | Step number (env-level) |
+| `max_turns` | `int` | Episode step limit |
+| `board_width` | `int` | Board dimensions |
+| `board_height` | `int` | Board dimensions |
+| `is_terminated` | `bool` | Whether episode ended this step |
+| `current_round` | `int` | Battle round from clock |
+| `battle_phase` | `BattlePhase` | Current phase |
+| `player_damage_dealt` | `int` | Damage from player shooting this step |
+| `opponent_damage_dealt` | `int` | Damage from opponent shooting this step |
+| `player_models_killed` | `int` | Opponent models killed this step |
+| `opponent_models_killed` | `int` | Player models killed this step |
+
+**What should be part of state output:**
+- `current_round` and `battle_phase` → Game clock state (high priority)
+- `player_damage_dealt` / `opponent_damage_dealt` → Combat summary (high priority for LLM narration)
+- `player_models_killed` / `opponent_models_killed` → Casualty report (high priority)
+- `is_terminated` → Episode status (already returned by Gym API, but useful in state blob)
+- `distance_cache` → Spatial relationships (derived; maybe expose as "models at objectives" boolean array rather than raw cache)
+- `max_turns` → Context for time pressure (medium priority)
+
+---
+
+## 6. Recommendations for v9.0 Canonical State Model
+
+### 6.1 Proposed Structure
+
+```python
+class GameStateSnapshot(BaseModel):
+    """Complete, serialisable game state for one step."""
+
+    # -- Timing --
+    step: int
+    battle_round: int
+    battle_phase: BattlePhase
+    active_player: PlayerSide
+    game_phase: GamePhase
+
+    # -- Board --
+    board_width: int
+    board_height: int
+    terrain: TerrainState | None  # blocking mask if present
+
+    # -- Entities --
+    player_models: list[ModelSnapshot]
+    opponent_models: list[ModelSnapshot]
+    objectives: list[ObjectiveSnapshot]
+
+    # -- Zones --
+    deployment_zone: tuple[int, int, int, int]
+    opponent_deployment_zone: tuple[int, int, int, int]
+
+    # -- Scoring --
+    player_vp: int
+    opponent_vp: int
+    player_vp_delta: int
+    opponent_vp_delta: int
+    objective_control: list[str]  # "player" | "opponent" | "contested" | "none"
+
+    # -- Combat (this step) --
+    combat_results: CombatSummary | None
+
+    # -- Actions --
+    player_action: list[int] | None  # action indices taken
+    action_descriptions: list[str] | None  # human-readable
+
+    # -- Reward --
+    reward: float | None
+    reward_breakdown: dict[str, float]
+    reward_phase: str
+
+    # -- Status --
+    is_terminated: bool
+    termination_reason: str | None
+```
+
+### 6.2 Key Design Decisions
+
+1. **Pydantic BaseModel** — Get `model_dump()`, `model_dump_json()`, `model_json_schema()` for free
+2. **numpy → list conversion** — Use `mode="json"` or custom `@field_serializer` to produce JSON-safe output
+3. **Flat where possible** — Avoid deep nesting that confuses LLMs; prefer `player_vp` over `scoring.player.vp`
+4. **Optional combat/action fields** — Only populated when relevant (None during movement phase for combat results)
+5. **Human-readable derivations** — Include `action_descriptions` and `termination_reason` for LLM consumption
+6. **Schema export** — Use `GameStateSnapshot.model_json_schema()` to generate the tool parameter schema
+
+### 6.3 What Needs Building
+
+| Component | Current State | Work Needed |
+|-----------|--------------|-------------|
+| `GameStateSnapshot` Pydantic model | Does not exist | Create with all fields |
+| numpy serialisation | `arbitrary_types_allowed` workaround | Add `@field_serializer` for clean JSON |
+| Action logging | Actions applied and discarded | Store action in step before applying |
+| Combat result capture | `ShootingResult` not serialised | Include in state output |
+| Objective ownership | Computed on demand | Compute and include per-step |
+| Reward breakdown | Dict on env, not serialised | Include in state output |
+| Clock state exposure | Via `game_clock_state` property | Already accessible, just not serialised |
+| Terrain state | Only in config | Compact representation in state (or reference) |
+| Termination reason | `is_terminated` bool only | Add enum/string for reason |
+| Human-readable action | No decoder exposed | Map action int → "move NE speed 4" / "shoot target 2" |
+
+---
+
+## 7. Serialisation Format Comparison
+
+| Format | Pros | Cons | Recommendation |
+|--------|------|------|----------------|
+| JSON (via `model_dump_json()`) | Universal, LLM-native, schema support | Verbose for large arrays | **Primary format** |
+| YAML (via `pydantic-yaml`) | Human-readable, config already uses it | Slower, less LLM tooling support | Config only |
+| MessagePack | Compact, fast | Not human-readable, no LLM support | Not recommended |
+| Protobuf | Schema-driven, compact | Complex setup, poor LLM interop | Not recommended |
+
+**Verdict:** JSON with Pydantic schema generation. LLMs work natively with JSON. The `model_json_schema()` output can serve as the function parameter schema for tool-use APIs.
+
+---
+
+## 8. Confidence Assessment
+
+| Finding | Confidence | Rationale |
+|---------|------------|-----------|
+| Full state inventory | HIGH | Direct code inspection |
+| Gaps analysis | HIGH | Compared info dict to all state sources |
+| Pydantic leverageability | HIGH | Features verified in Pydantic v2 docs |
+| Recommended structure | MEDIUM | Design opinion; needs validation against actual LLM tool-use patterns |
+| numpy serialisation approach | HIGH | Pydantic v2 `mode="json"` handles this |

--- a/.planning/research/v9-SUMMARY.md
+++ b/.planning/research/v9-SUMMARY.md
@@ -1,0 +1,178 @@
+# Research Summary: v9.0 — Structured Game State & LLM-Readable Representation
+
+**Project:** Wargame RL
+**Milestone:** v9.0
+**Researched:** 2026-05-23
+**Confidence:** HIGH (all findings from direct codebase analysis)
+
+## Executive Summary
+
+The wargame_rl codebase already contains rich structured data at every step — entity positions and wounds, game clock state, combat results via `ShootingResult`, detailed reward breakdowns, and action indices that can be decoded to human-readable text. However, none of this data is surfaced outside the RL tensor pipeline. The Gymnasium info dict (`WargameEnvInfo`) captures roughly half the state, while critical data — game timing, combat results, actions taken, reward breakdowns, objective control — is either computed and discarded or stored in private env fields without serialisation. The gap is not missing data but missing *output plumbing*.
+
+The recommended approach is to build a Pydantic-based canonical state model (`GameStateSnapshot`) that collects all game state into a single serialisable object, then implement bidirectional I/O: *export* (env → snapshot → JSON) and *injection* (JSON → snapshot → env). Pydantic is the right tool — it's already the config standard, provides `model_dump_json()` and `model_json_schema()` for free, handles numpy serialisation via `mode="json"`, and composes nested models naturally. The new layer fits cleanly as a `BattleView` consumer alongside renderers and reward calculators, with zero impact on the RL pipeline.
+
+The main risk is scope creep. The user's priorities are **(1) bidirectional state I/O** and **(2) LLM-interpretable representation**. Event streaming, replay, delta encoding, and pluggable serialisation codecs are documented in the v9.0 requirements but are lower priority and should be deferred to later phases. The other key risk is the `GameClock` — it lacks a `set_state()` method and all its fields are private, making state injection impossible without a small domain change.
+
+## Key Findings
+
+### State Representation (v9-STATE-REPRESENTATION.md)
+
+The full game state spans five sources: `Battle` aggregate (models, objectives, VP, zones), `GameClock` (round, phase, active player), `WargameEnv` ephemeral fields (turn counter, reward, shooting results, combat RNG), `WargameModel` entities (location, wounds, distances, reward-shaping history), and `WargameEnvConfig` (immutable rules). A comprehensive gap analysis found **17 data categories** missing from the info dict that are present internally, including battle round/phase, terrain/LOS, actions taken, shooting results, reward breakdown, objective ownership, and episode context.
+
+**Key conclusion:** Pydantic v2 is highly leverageable. `model_dump(mode="json")` auto-converts numpy arrays to lists. `model_json_schema()` can generate JSON Schema for LLM tool-use integration. JSON is the recommended primary format — LLMs work natively with it, and schema generation is free.
+
+### LLM Representation (v9-LLM-REPRESENTATION.md)
+
+An LLM evaluator needs a structured per-step summary covering: state before action, decoded action descriptions, combat narrative with probabilities, reward breakdown with phase context, and state after. The codebase has the data but lacks text formatting.
+
+**What exists but isn't surfaced:**
+- `ActionHandler._decode_action()` returns (dx, dy) — needs a `describe_action()` wrapper for "Move NE at speed 4"
+- `ShootingResult` stores hits/wounds/unsaved/damage — but not attacker-target pairing
+- `last_reward_breakdown` dict with per-calculator values — never serialised
+- Opponent actions are applied and discarded — never recorded
+- Objective control is computed for rendering only — not in observations
+
+**What needs building:** `describe_action()` text formatter, attacker-target pairing in shooting results, opponent action recording, objective control in state output, `StepNarrator` class that produces LLM-readable text from `BattleView` + step context.
+
+### Bidirectional State I/O (v9-STATE-IO.md)
+
+**Export (state out) is straightforward.** All mutable state is readable via properties or public attributes. `GameClock.state` already returns a `GameState` snapshot. No private internals need exposure.
+
+**Injection (state in) is the hard part.** The env has no "set state" path. Three things block it:
+1. `GameClock` has no `set_state()` method — all fields are private with no setters
+2. No `Battle.apply_snapshot()` — entity state must be set via direct mutation (tests already do this)
+3. No `WargameEnv.load_state()` orchestrator — nothing coordinates clock + entities + VP + derived state recomputation
+
+Derived state (distances_to_objectives, action masks, distance cache) should be recomputed after injection, not injected. Reward-shaping history (`previous_closest_objective_distance`, `best_closest_objective_distance`) should be set to `None` — the safest sentinel for "first step after injection." Existing test patterns (post-reset mutation of locations and wounds) validate that direct entity mutation works.
+
+### Architecture (v9-ARCHITECTURE.md)
+
+The state layer fits cleanly into the DDD architecture as `envs/state/`, a peer of `envs/renders/` and `envs/reward/`. It depends on `BattleView` + `types/` only — same dependency direction as every other consumer. The registry pattern used by reward calculators, criteria, missions, and opponent policies can be reused for formatter registration. Hooks attach after `reset()` and `step()`, mirroring the renderer pattern.
+
+**Zero impact on RL pipeline.** `observation_to_tensor()`, Lightning modules, `train.py`, and checkpoints are untouched. State export is a parallel output path serving different consumers (LLMs, APIs, debugging) than the tensor pipeline (RL networks).
+
+**Zero impact on existing configs.** New `WargameEnvConfig` fields default to `None` or empty list, so existing YAML files keep working.
+
+## Implications for Roadmap
+
+Based on research, I recommend **four phases** with the first two being the user's stated priorities and the latter two being deferrable.
+
+### Phase 1: Canonical State Model & Export
+
+**Rationale:** Everything depends on the canonical state schema. Export (state → JSON) is the simpler direction and immediately enables programmatic state inspection, LLM consumption via JSON, and debugging. This is the foundation for both user priorities.
+
+**Delivers:**
+- `GameStateSnapshot` Pydantic model with all fields from the state inventory
+- `ModelSnapshot`, `ObjectiveSnapshot`, `ClockSnapshot` sub-models
+- numpy → JSON serialisation via `@field_serializer` or `mode="json"`
+- `WargameEnv.to_snapshot() → GameStateSnapshot` method
+- `GameStateSnapshot.model_dump_json()` for JSON output
+- `GameStateSnapshot.model_json_schema()` for schema export
+- Combat result capture with attacker-target pairing (modify `_resolve_shooting_action`)
+- Opponent action recording (store before applying)
+- Objective control computation included in snapshot
+- Reward breakdown and phase name in snapshot
+- `schema_version` field from day one
+
+**From research:** STATE-REPRESENTATION §6 (proposed structure), ARCHITECTURE §3 (lives in `envs/state/`), ARCHITECTURE §6 (parallel path to RL pipeline)
+
+**Avoids:** Performance overhead — export is optional, disabled by default during training. Only active during simulation/evaluation/API serving.
+
+### Phase 2: State Injection & Bidirectional I/O
+
+**Rationale:** Depends on Phase 1's schema. This is the "input" side of bidirectional I/O — the ability to construct an env at an arbitrary game state from a snapshot. Required for scenario testing, LLM-driven evaluation, and programmatic game setup.
+
+**Delivers:**
+- `GameClock.set_state()` method (small domain change, 5-10 lines)
+- `validate_snapshot(snapshot, config)` function enforcing hard constraints
+- `WargameEnv.load_state(snapshot)` orchestrator that sets clock, entities, VP, recomputes derived state
+- Round-trip test: `env.to_snapshot()` → `env.load_state(snapshot)` → `env.to_snapshot()` produces identical output
+- Documented invariants (locations in bounds, wounds in range, clock consistency, entity count match)
+
+**From research:** STATE-IO §3–4 (injection requirements, clock gaps), STATE-IO §6 (validation constraints), STATE-IO §7 (test patterns)
+
+**Avoids:** Reward-shaping state discontinuity — sets shaping fields to `None` (first-step sentinel), which is the safest behaviour.
+
+### Phase 3: LLM-Readable Text Representation
+
+**Rationale:** Depends on Phase 1's snapshot model and action/combat data capture. Builds the human/LLM-readable text layer on top of the canonical state. This is the "LLM-interpretable" priority — an LLM can read structured text and judge whether the RL agent's actions are good or bad.
+
+**Delivers:**
+- `describe_action(action_int, model_idx, phase) → str` method on `ActionHandler`
+- Compass direction mapping (16-angle → direction name)
+- `CombatNarrative` structured type with probabilities (hit chance, wound threshold, modified save)
+- `StepNarrator` class producing per-step text summaries from `BattleView` + step context
+- Reward breakdown text with phase context (essential — without phase name, reward values are uninterpretable)
+- `text` formatter registered in formatter registry
+
+**From research:** LLM-REPRESENTATION §1 (action decoding), §3 (step summary requirements), §6 (combat narrative data), §8 (implementation priorities)
+
+### Phase 4: Event Streaming, Replay & Advanced Serialisation (Deferred)
+
+**Rationale:** Lower priority per user's stated preferences. Depends on stable snapshot model from Phase 1. Can be built incrementally after the core I/O and LLM features are proven.
+
+**Delivers (when needed):**
+- `StateExporter` protocol with `on_reset()` / `on_step()` hooks
+- Append-only event log (ordered events recording match history)
+- Delta encoding (efficient state updates vs full snapshots)
+- Deterministic replay from event log
+- Pluggable formatter registry (JSON is default; extension points for binary/compact formats)
+- `EventLog` accumulator as an exporter implementation
+
+**From research:** ARCHITECTURE §4 (registry pattern), §7 (hook attachment points), §8 (BattleView data availability)
+
+### Phase Ordering Rationale
+
+- **Phase 1 before Phase 2:** Export is simpler than injection (read vs write), and the schema must exist before injection can target it. Export also provides immediate value for debugging and LLM experiments.
+- **Phase 2 before Phase 3:** Bidirectional I/O is the user's top priority. LLM text is built on top of the same data but adds a formatting layer that's less architecturally critical.
+- **Phase 3 after Phase 2:** The `describe_action()` and `CombatNarrative` types from Phase 3 enhance the snapshot from Phase 1, but the snapshot is useful in JSON form without text narration. Phase 3 can proceed independently once Phase 1 is complete.
+- **Phase 4 is deferred:** Event streaming and replay require a stable snapshot schema. Building them too early risks rework when the schema evolves during Phases 1–3.
+
+### Research Flags
+
+Phases likely needing deeper research during planning:
+- **Phase 2:** State injection is genuinely new capability — no existing tests construct mid-episode state. The `GameClock.set_state()` design needs careful validation against clock invariants (round boundaries, phase ordering, active player transitions).
+- **Phase 3:** LLM text format needs validation against actual LLM tool-use patterns. The proposed text format (structured plaintext vs JSON) should be tested with a real LLM to confirm interpretability.
+
+Phases with standard patterns (skip research-phase):
+- **Phase 1:** Well-documented Pydantic patterns, clear data sources, straightforward read-only serialisation. The research already provides the full field inventory and proposed model shape.
+- **Phase 4:** Registry pattern is established (4 existing registries), hook pattern mirrors renderer. Standard implementation.
+
+## Confidence Assessment
+
+| Area | Confidence | Notes |
+|------|------------|-------|
+| State representation | HIGH | Complete field inventory from code inspection; every field traced to source |
+| LLM representation | HIGH for data availability, MEDIUM for text format | Data exists; optimal LLM consumption format needs validation with actual LLM usage |
+| State I/O (export) | HIGH | All state readable via properties; `GameClock.state` already returns snapshot |
+| State I/O (injection) | HIGH for feasibility, MEDIUM for edge cases | Tests show direct mutation works; clock injection needs new method; reward-shaping discontinuity is documented |
+| Architecture | HIGH | DDD layers, BattleView protocol, registry pattern all well-established; new layer fits naturally |
+
+**Overall confidence:** HIGH
+
+### Gaps to Address
+
+- **LLM text format validation:** The proposed structured text format should be tested with an actual LLM before committing to it as the canonical format. JSON may be sufficient for LLM tool-use, making a custom text format a nice-to-have rather than essential.
+- **Coordinate system in narration:** The grid uses screen coordinates (+y = south) but angles start at east going counter-clockwise. The narration layer must document this and map correctly to compass directions. Bugs here would produce misleading LLM evaluations.
+- **numpy serialisation strategy:** `mode="json"` auto-converts numpy arrays to lists, but large arrays (e.g., 50×50 blocking mask) may need compact encoding. Need to decide: always convert to lists, or use a compact representation for terrain.
+- **Schema versioning strategy:** `schema_version` should be included from day one (Phase 1). The versioning policy (breaking vs non-breaking changes, deprecation) should be documented but doesn't need to be fully designed upfront.
+- **Performance budget:** State export during training should be opt-in and benchmarked. The exporter should add negligible overhead when disabled. During evaluation/simulation, JSON serialisation of a typical state (4 models, 4 opponents, 3 objectives) should be sub-millisecond.
+
+## Sources
+
+### Primary (HIGH confidence)
+- Direct codebase analysis — all findings verified against source code
+- `domain/battle.py`, `domain/entities.py`, `domain/game_clock.py`, `domain/value_objects.py` — state inventory
+- `envs/wargame.py` — env lifecycle, reset flow, step flow, BattleView implementation
+- `envs/types/` — config, observation, info, action types
+- `envs/env_components/` — action handler, observation builder, placement
+- `envs/reward/` — phase manager, calculators, criteria
+- `docs/ddd-envs.md` — architecture guide and extension patterns
+
+### Secondary (MEDIUM confidence)
+- Pydantic v2 documentation — `model_dump_json()`, `model_json_schema()`, `@field_serializer` capabilities
+- LLM tool-use patterns — JSON Schema as function parameter schema (well-established pattern, not project-specific)
+
+---
+*Research completed: 2026-05-23*
+*Ready for roadmap: yes*

--- a/tests/test_shooting_resolution.py
+++ b/tests/test_shooting_resolution.py
@@ -428,7 +428,9 @@ class TestShootingIntegration:
         shoot_action = WargameEnvAction(actions=[shooting_slice.start])
         env.step(shoot_action)
         assert env._last_player_shooting_results, "Expected at least one result"
-        total_dmg = sum(r.damage_dealt for r in env._last_player_shooting_results)
+        total_dmg = sum(
+            r.result.damage_dealt for r in env._last_player_shooting_results
+        )
         if total_dmg > 0:
             assert env.opponent_models[0].stats["current_wounds"] < initial_wounds
 
@@ -443,7 +445,12 @@ class TestShootingIntegration:
             env.step(WargameEnvAction(actions=[ss.start]))
             results.append(
                 [
-                    (r.hits, r.wounds, r.unsaved, r.damage_dealt)
+                    (
+                        r.result.hits,
+                        r.result.wounds,
+                        r.result.unsaved,
+                        r.result.damage_dealt,
+                    )
                     for r in env._last_player_shooting_results
                 ]
             )
@@ -470,9 +477,8 @@ class TestShootingIntegration:
         ss = env._action_handler.shooting_slice
         assert ss is not None
         env.step(WargameEnvAction(actions=[ss.start, ss.start + 1]))
-        # At least one side should have resolved
-        p_dmg = sum(r.damage_dealt for r in env._last_player_shooting_results)
-        o_dmg = sum(r.damage_dealt for r in env._last_opponent_shooting_results)
+        p_dmg = sum(r.result.damage_dealt for r in env._last_player_shooting_results)
+        o_dmg = sum(r.result.damage_dealt for r in env._last_opponent_shooting_results)
         assert p_dmg >= 0
         assert o_dmg >= 0
 
@@ -624,7 +630,12 @@ class TestCombatRNG:
             env.step(WargameEnvAction(actions=[ss.start]))
             results_by_run.append(
                 [
-                    (r.hits, r.wounds, r.unsaved, r.damage_dealt)
+                    (
+                        r.result.hits,
+                        r.result.wounds,
+                        r.result.unsaved,
+                        r.result.damage_dealt,
+                    )
                     for r in env._last_player_shooting_results
                 ]
             )
@@ -641,7 +652,12 @@ class TestCombatRNG:
             env.step(WargameEnvAction(actions=[ss.start]))
             results_by_seed.append(
                 [
-                    (r.hits, r.wounds, r.unsaved, r.damage_dealt)
+                    (
+                        r.result.hits,
+                        r.result.wounds,
+                        r.result.unsaved,
+                        r.result.damage_dealt,
+                    )
                     for r in env._last_player_shooting_results
                 ]
             )

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -8,7 +8,7 @@ import pytest
 
 from wargame_rl.wargame.envs.env_components.actions import STAY_ACTION
 from wargame_rl.wargame.envs.state.snapshot import GameStateSnapshot, JsonEncoder
-from wargame_rl.wargame.envs.types import WargameEnvAction, WargameEnvConfig
+from wargame_rl.wargame.envs.types import TurnOrder, WargameEnvAction, WargameEnvConfig
 from wargame_rl.wargame.envs.types.config import (
     ModelConfig,
     OpponentPolicyConfig,
@@ -74,7 +74,7 @@ def shooting_env() -> WargameEnv:
             ),
         ],
         opponent_policy=OpponentPolicyConfig(type="random"),
-        turn_order="player",
+        turn_order=TurnOrder.player,
         skip_phases=[BattlePhase.command, BattlePhase.charge, BattlePhase.fight],
         n_movement_angles=8,
         n_speed_bins=3,

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,0 +1,200 @@
+"""Integration tests for the canonical GameStateSnapshot."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from wargame_rl.wargame.envs.env_components.actions import STAY_ACTION
+from wargame_rl.wargame.envs.state.snapshot import GameStateSnapshot, JsonEncoder
+from wargame_rl.wargame.envs.types import WargameEnvAction, WargameEnvConfig
+from wargame_rl.wargame.envs.types.config import (
+    ModelConfig,
+    OpponentPolicyConfig,
+    WeaponProfile,
+)
+from wargame_rl.wargame.envs.types.game_timing import BattlePhase
+from wargame_rl.wargame.envs.wargame import WargameEnv
+
+
+@pytest.fixture
+def shooting_env() -> WargameEnv:
+    """Env with opponents, weapons, and only movement+shooting phases."""
+    cfg = WargameEnvConfig(
+        board_width=30,
+        board_height=30,
+        number_of_wargame_models=2,
+        number_of_objectives=1,
+        number_of_opponent_models=2,
+        models=[
+            ModelConfig(
+                x=5,
+                y=5,
+                max_wounds=3,
+                weapons=[
+                    WeaponProfile(
+                        range=50,
+                        attacks=4,
+                        ballistic_skill=2,
+                        strength=8,
+                        ap=2,
+                        damage=2,
+                    )
+                ],
+            ),
+            ModelConfig(
+                x=6,
+                y=5,
+                max_wounds=3,
+                weapons=[
+                    WeaponProfile(
+                        range=50,
+                        attacks=4,
+                        ballistic_skill=2,
+                        strength=8,
+                        ap=2,
+                        damage=2,
+                    )
+                ],
+            ),
+        ],
+        opponent_models=[
+            ModelConfig(
+                x=20,
+                y=5,
+                max_wounds=3,
+                weapons=[WeaponProfile(range=50)],
+            ),
+            ModelConfig(
+                x=21,
+                y=5,
+                max_wounds=3,
+                weapons=[WeaponProfile(range=50)],
+            ),
+        ],
+        opponent_policy=OpponentPolicyConfig(type="random"),
+        turn_order="player",
+        skip_phases=[BattlePhase.command, BattlePhase.charge, BattlePhase.fight],
+        n_movement_angles=8,
+        n_speed_bins=3,
+    )
+    env = WargameEnv(config=cfg)
+    return env
+
+
+def _step_to_shooting(env: WargameEnv) -> None:
+    """Step with STAY until we reach shooting phase."""
+    n = len(env.wargame_models)
+    env.step(WargameEnvAction(actions=[STAY_ACTION] * n))
+
+
+class TestSnapshotAfterReset:
+    def test_to_snapshot_after_reset(self, shooting_env: WargameEnv) -> None:
+        shooting_env.reset(seed=42)
+        snap = shooting_env.to_snapshot()
+
+        assert snap.board_width == 30
+        assert snap.board_height == 30
+        assert len(snap.player_models) == 2
+        assert len(snap.opponent_models) == 2
+        assert len(snap.objectives) == 1
+        assert snap.step == 0
+        assert snap.player_actions is None
+        assert snap.is_terminated is False
+
+
+class TestSnapshotAfterStep:
+    def test_to_snapshot_after_step(self, shooting_env: WargameEnv) -> None:
+        shooting_env.reset(seed=42)
+        n = len(shooting_env.wargame_models)
+        shooting_env.step(WargameEnvAction(actions=[STAY_ACTION] * n))
+        snap = shooting_env.to_snapshot()
+
+        assert snap.step >= 1
+        assert snap.player_actions is not None
+
+    def test_opponent_actions_recorded(self, shooting_env: WargameEnv) -> None:
+        """Opponent acts after player finishes all phases in a round."""
+        shooting_env.reset(seed=42)
+        n = len(shooting_env.wargame_models)
+        # Step through movement then shooting to complete player's turn
+        shooting_env.step(WargameEnvAction(actions=[STAY_ACTION] * n))
+        shooting_env.step(WargameEnvAction(actions=[STAY_ACTION] * n))
+        snap = shooting_env.to_snapshot()
+
+        assert snap.opponent_actions is not None
+
+
+class TestJsonSerialisation:
+    def test_json_serialisation(self, shooting_env: WargameEnv) -> None:
+        shooting_env.reset(seed=42)
+        snap = shooting_env.to_snapshot()
+        raw = snap.model_dump_json()
+        parsed = json.loads(raw)
+        assert isinstance(parsed, dict)
+        assert "player_models" in parsed
+
+    def test_json_schema(self) -> None:
+        schema = GameStateSnapshot.model_json_schema()
+        assert "properties" in schema
+
+
+class TestCombatResults:
+    def test_combat_results_have_pairing(self, shooting_env: WargameEnv) -> None:
+        """After a shooting step, combat results carry attacker/target indices and analytical fields."""
+        shooting_env.reset(seed=42)
+        _step_to_shooting(shooting_env)
+
+        ss = shooting_env._action_handler.shooting_slice
+        assert ss is not None
+        shooting_env.step(WargameEnvAction(actions=[ss.start, ss.start + 1]))
+
+        snap = shooting_env.to_snapshot()
+        if snap.player_combat_results:
+            cr = snap.player_combat_results[0]
+            assert cr.attacker_idx >= 0
+            assert cr.target_idx >= 0
+            assert cr.expected_damage >= 0.0
+            assert 0.0 <= cr.hit_probability <= 1.0
+            assert 0.0 <= cr.wound_probability <= 1.0
+
+
+class TestRewardBreakdown:
+    def test_reward_breakdown_in_snapshot(self, shooting_env: WargameEnv) -> None:
+        shooting_env.reset(seed=42)
+        n = len(shooting_env.wargame_models)
+        shooting_env.step(WargameEnvAction(actions=[STAY_ACTION] * n))
+        snap = shooting_env.to_snapshot()
+
+        assert snap.reward.phase_name != ""
+        assert snap.reward.phase_index >= 0
+
+
+class TestObjectiveControl:
+    def test_objective_control(self, shooting_env: WargameEnv) -> None:
+        shooting_env.reset(seed=42)
+        snap = shooting_env.to_snapshot()
+
+        assert isinstance(snap.objective_control, list)
+        assert len(snap.objective_control) == len(snap.objectives)
+        for ctrl in snap.objective_control:
+            assert ctrl in ("player", "opponent", "none")
+
+
+class TestSchemaVersion:
+    def test_schema_version(self, shooting_env: WargameEnv) -> None:
+        shooting_env.reset(seed=42)
+        snap = shooting_env.to_snapshot()
+        assert snap.schema_version == "1.0"
+
+
+class TestEncoder:
+    def test_encoder(self, shooting_env: WargameEnv) -> None:
+        shooting_env.reset(seed=42)
+        snap = shooting_env.to_snapshot()
+        encoder = JsonEncoder()
+        raw = encoder.encode(snap)
+        parsed = json.loads(raw)
+        assert isinstance(parsed, dict)
+        assert encoder.content_type() == "application/json"

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -101,6 +101,7 @@ class TestSnapshotAfterReset:
         assert len(snap.objectives) == 1
         assert snap.step == 0
         assert snap.player_actions is None
+        assert snap.player_action_descriptions is None
         assert snap.is_terminated is False
 
 
@@ -186,7 +187,7 @@ class TestSchemaVersion:
     def test_schema_version(self, shooting_env: WargameEnv) -> None:
         shooting_env.reset(seed=42)
         snap = shooting_env.to_snapshot()
-        assert snap.schema_version == "1.0"
+        assert snap.schema_version == "1.1"
 
 
 class TestEncoder:
@@ -198,3 +199,104 @@ class TestEncoder:
         parsed = json.loads(raw)
         assert isinstance(parsed, dict)
         assert encoder.content_type() == "application/json"
+
+
+class TestSpatialFields:
+    def test_model_distances_to_objectives(self, shooting_env: WargameEnv) -> None:
+        shooting_env.reset(seed=42)
+        snap = shooting_env.to_snapshot()
+
+        for pm in snap.player_models:
+            assert len(pm.distances_to_objectives) == len(snap.objectives)
+            assert all(d >= 0.0 for d in pm.distances_to_objectives)
+
+        for om in snap.opponent_models:
+            assert len(om.distances_to_objectives) == len(snap.objectives)
+
+    def test_at_objective_flags(self, shooting_env: WargameEnv) -> None:
+        shooting_env.reset(seed=42)
+        snap = shooting_env.to_snapshot()
+
+        for pm in snap.player_models:
+            assert len(pm.at_objective) == len(snap.objectives)
+            assert all(isinstance(v, bool) for v in pm.at_objective)
+
+    def test_closest_objective(self, shooting_env: WargameEnv) -> None:
+        shooting_env.reset(seed=42)
+        snap = shooting_env.to_snapshot()
+
+        for pm in snap.player_models:
+            if pm.alive:
+                assert pm.closest_objective_idx is not None
+                assert pm.closest_objective_distance is not None
+                assert 0 <= pm.closest_objective_idx < len(snap.objectives)
+            else:
+                assert pm.closest_objective_idx is None
+
+    def test_objective_models_in_range(self, shooting_env: WargameEnv) -> None:
+        shooting_env.reset(seed=42)
+        snap = shooting_env.to_snapshot()
+
+        for obj in snap.objectives:
+            assert isinstance(obj.player_models_in_range, list)
+            assert isinstance(obj.opponent_models_in_range, list)
+            for idx in obj.player_models_in_range:
+                assert 0 <= idx < len(snap.player_models)
+            for idx in obj.opponent_models_in_range:
+                assert 0 <= idx < len(snap.opponent_models)
+
+
+class TestForceBalance:
+    def test_alive_counts(self, shooting_env: WargameEnv) -> None:
+        shooting_env.reset(seed=42)
+        snap = shooting_env.to_snapshot()
+
+        assert snap.player_alive_count == sum(1 for m in snap.player_models if m.alive)
+        assert snap.opponent_alive_count == sum(
+            1 for m in snap.opponent_models if m.alive
+        )
+
+    def test_total_wounds(self, shooting_env: WargameEnv) -> None:
+        shooting_env.reset(seed=42)
+        snap = shooting_env.to_snapshot()
+
+        assert snap.player_total_wounds == sum(
+            m.current_wounds for m in snap.player_models if m.alive
+        )
+        assert snap.opponent_total_wounds == sum(
+            m.current_wounds for m in snap.opponent_models if m.alive
+        )
+
+
+class TestActionDescriptions:
+    def test_action_descriptions_after_step(self, shooting_env: WargameEnv) -> None:
+        shooting_env.reset(seed=42)
+        n = len(shooting_env.wargame_models)
+        shooting_env.step(WargameEnvAction(actions=[STAY_ACTION] * n))
+        snap = shooting_env.to_snapshot()
+
+        assert snap.player_action_descriptions is not None
+        assert len(snap.player_action_descriptions) == n
+        assert all(d == "Stay" for d in snap.player_action_descriptions)
+
+    def test_shooting_action_description(self, shooting_env: WargameEnv) -> None:
+        shooting_env.reset(seed=42)
+        _step_to_shooting(shooting_env)
+
+        ss = shooting_env._action_handler.shooting_slice
+        assert ss is not None
+        shooting_env.step(WargameEnvAction(actions=[ss.start, ss.start + 1]))
+        snap = shooting_env.to_snapshot()
+
+        assert snap.player_action_descriptions is not None
+        assert snap.player_action_descriptions[0] == "Shoot at opponent 0"
+        assert snap.player_action_descriptions[1] == "Shoot at opponent 1"
+
+
+class TestMissionContext:
+    def test_mission_fields(self, shooting_env: WargameEnv) -> None:
+        shooting_env.reset(seed=42)
+        snap = shooting_env.to_snapshot()
+
+        assert isinstance(snap.mission_type, str)
+        assert isinstance(snap.mission_params, dict)

--- a/wargame_rl/wargame/envs/domain/shooting.py
+++ b/wargame_rl/wargame/envs/domain/shooting.py
@@ -48,6 +48,15 @@ class ShootingResult:
     damage_dealt: int
 
 
+@dataclass(frozen=True, slots=True)
+class PairedShootingResult:
+    """A shooting result paired with attacker and target indices."""
+
+    attacker_idx: int
+    target_idx: int
+    result: ShootingResult
+
+
 def wound_roll_threshold(strength: int, toughness: int) -> int:
     """Return the minimum D6 roll needed to wound (2-6).
 

--- a/wargame_rl/wargame/envs/state/__init__.py
+++ b/wargame_rl/wargame/envs/state/__init__.py
@@ -1,0 +1,17 @@
+"""Canonical game-state snapshot: serialisable representation of env state."""
+
+from __future__ import annotations
+
+from wargame_rl.wargame.envs.state.snapshot import (
+    GameStateSnapshot,
+    JsonEncoder,
+    SnapshotEncoder,
+    build_snapshot,
+)
+
+__all__ = [
+    "GameStateSnapshot",
+    "JsonEncoder",
+    "SnapshotEncoder",
+    "build_snapshot",
+]

--- a/wargame_rl/wargame/envs/state/snapshot.py
+++ b/wargame_rl/wargame/envs/state/snapshot.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 class WeaponSnapshot(BaseModel):
     """Weapon stat block (mirrors WeaponProfile with native types)."""
 
-    weapon_range: int = Field(alias="range")
+    weapon_range: int = Field(validation_alias="range")
     attacks: int
     ballistic_skill: int
     strength: int

--- a/wargame_rl/wargame/envs/state/snapshot.py
+++ b/wargame_rl/wargame/envs/state/snapshot.py
@@ -6,7 +6,8 @@ serialisable to JSON, MessagePack, or any other format.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import numpy as np
 from pydantic import BaseModel, Field
@@ -59,6 +60,10 @@ class ModelSnapshot(BaseModel):
     save: int
     advanced_this_turn: bool
     weapons: list[WeaponSnapshot]
+    distances_to_objectives: list[float]
+    at_objective: list[bool]
+    closest_objective_idx: int | None
+    closest_objective_distance: float | None
 
 
 class ObjectiveSnapshot(BaseModel):
@@ -66,6 +71,8 @@ class ObjectiveSnapshot(BaseModel):
 
     location: list[int]
     radius_size: int
+    player_models_in_range: list[int]
+    opponent_models_in_range: list[int]
 
 
 class ClockSnapshot(BaseModel):
@@ -103,7 +110,7 @@ class RewardSnapshot(BaseModel):
 class GameStateSnapshot(BaseModel):
     """Complete, serialisable snapshot of game state at one point in time."""
 
-    schema_version: str = "1.0"
+    schema_version: str = "1.1"
     step: int
     max_steps: int
     clock: ClockSnapshot
@@ -122,11 +129,18 @@ class GameStateSnapshot(BaseModel):
     objective_control: list[str]
     player_actions: list[int] | None
     opponent_actions: list[int] | None
+    player_action_descriptions: list[str] | None
     player_combat_results: list[CombatResultSnapshot]
     opponent_combat_results: list[CombatResultSnapshot]
     reward: RewardSnapshot
     is_terminated: bool
     is_truncated: bool
+    player_alive_count: int
+    opponent_alive_count: int
+    player_total_wounds: int
+    opponent_total_wounds: int
+    mission_type: str
+    mission_params: dict[str, int | float | str]
 
 
 # ---------------------------------------------------------------------------
@@ -137,6 +151,8 @@ class GameStateSnapshot(BaseModel):
 def _model_to_snapshot(
     model: WargameModel,
     config: ModelConfig | None,
+    obj_distances: list[float] | None = None,
+    obj_in_range: list[bool] | None = None,
 ) -> ModelSnapshot:
     """Convert a domain WargameModel to a snapshot."""
     weapons: list[WeaponSnapshot] = []
@@ -152,6 +168,16 @@ def _model_to_snapshot(
                     damage=w.damage,
                 )
             )
+
+    dists = obj_distances or []
+    at_obj = obj_in_range or []
+    if dists and model.is_alive:
+        closest_idx = int(np.argmin(dists))
+        closest_dist = float(dists[closest_idx])
+    else:
+        closest_idx = None
+        closest_dist = None
+
     return ModelSnapshot(
         location=model.location.tolist(),
         previous_location=(
@@ -167,13 +193,23 @@ def _model_to_snapshot(
         save=model.stats["save"],
         advanced_this_turn=model.advanced_this_turn,
         weapons=weapons,
+        distances_to_objectives=dists,
+        at_objective=at_obj,
+        closest_objective_idx=closest_idx,
+        closest_objective_distance=closest_dist,
     )
 
 
-def _objective_to_snapshot(obj: WargameObjective) -> ObjectiveSnapshot:
+def _objective_to_snapshot(
+    obj: WargameObjective,
+    player_in_range: list[int],
+    opponent_in_range: list[int],
+) -> ObjectiveSnapshot:
     return ObjectiveSnapshot(
         location=obj.location.tolist(),
         radius_size=obj.radius_size,
+        player_models_in_range=player_in_range,
+        opponent_models_in_range=opponent_in_range,
     )
 
 
@@ -229,39 +265,140 @@ def _combat_result_to_snapshot(
     )
 
 
-def _compute_objective_control(
+@dataclass
+class _SpatialData:
+    """Intermediate spatial analysis used to populate multiple snapshot fields."""
+
+    objective_control: list[str]
+    player_obj_dists: list[list[float]]
+    player_at_obj: list[list[bool]]
+    opponent_obj_dists: list[list[float]]
+    opponent_at_obj: list[list[bool]]
+    player_in_range_per_obj: list[list[int]]
+    opponent_in_range_per_obj: list[list[int]]
+
+
+def _compute_spatial_data(
     player_models: list[WargameModel],
     opponent_models: list[WargameModel],
     objectives: list[WargameObjective],
-) -> list[str]:
-    """Compute per-objective ownership strings: 'player', 'opponent', or 'none'."""
+) -> _SpatialData:
+    """Compute all spatial relationships between models and objectives."""
+    n_obj = len(objectives)
+    n_player = len(player_models)
+    n_opp = len(opponent_models)
+
+    empty = _SpatialData(
+        objective_control=[],
+        player_obj_dists=[[] for _ in range(n_player)],
+        player_at_obj=[[] for _ in range(n_player)],
+        opponent_obj_dists=[[] for _ in range(n_opp)],
+        opponent_at_obj=[[] for _ in range(n_opp)],
+        player_in_range_per_obj=[],
+        opponent_in_range_per_obj=[],
+    )
     if not objectives:
-        return []
+        return empty
 
     p_cache = compute_distances(player_models, objectives)
     o_cache = (
         compute_distances(opponent_models, objectives) if opponent_models else None
     )
 
+    p_norms = p_cache.model_obj_norms_offset
+    radii = p_cache.obj_radii
+    p_in_range = p_norms <= radii
+
     if o_cache is not None:
-        p_ctrl, o_ctrl = objective_ownership_from_norms_offset(
-            p_cache.model_obj_norms_offset,
-            o_cache.model_obj_norms_offset,
-            p_cache.obj_radii,
-        )
+        o_norms = o_cache.model_obj_norms_offset
+        o_in_range = o_norms <= radii
+        p_ctrl, o_ctrl = objective_ownership_from_norms_offset(p_norms, o_norms, radii)
     else:
-        p_ctrl = np.any(p_cache.model_obj_norms_offset <= p_cache.obj_radii, axis=0)
+        o_norms = np.zeros((0, n_obj), dtype=np.float64)
+        o_in_range = np.zeros((0, n_obj), dtype=bool)
+        p_ctrl = np.any(p_in_range, axis=0)
         o_ctrl = np.zeros_like(p_ctrl, dtype=bool)
 
-    result: list[str] = []
+    control: list[str] = []
     for pi, oi in zip(p_ctrl, o_ctrl):
         if pi:
-            result.append("player")
+            control.append("player")
         elif oi:
-            result.append("opponent")
+            control.append("opponent")
         else:
-            result.append("none")
-    return result
+            control.append("none")
+
+    p_dists = [p_norms[i].tolist() for i in range(n_player)]
+    p_at = [p_in_range[i].tolist() for i in range(n_player)]
+    o_dists = [o_norms[i].tolist() for i in range(n_opp)]
+    o_at = [o_in_range[i].tolist() for i in range(n_opp)]
+
+    p_in_range_per_obj: list[list[int]] = []
+    o_in_range_per_obj: list[list[int]] = []
+    for j in range(n_obj):
+        p_in_range_per_obj.append([i for i in range(n_player) if p_in_range[i, j]])
+        o_in_range_per_obj.append(
+            [i for i in range(n_opp) if o_in_range[i, j]] if n_opp > 0 else []
+        )
+
+    return _SpatialData(
+        objective_control=control,
+        player_obj_dists=p_dists,
+        player_at_obj=p_at,
+        opponent_obj_dists=o_dists,
+        opponent_at_obj=o_at,
+        player_in_range_per_obj=p_in_range_per_obj,
+        opponent_in_range_per_obj=o_in_range_per_obj,
+    )
+
+
+COMPASS_LABELS_16 = [
+    "E",
+    "ENE",
+    "NE",
+    "NNE",
+    "N",
+    "NNW",
+    "NW",
+    "WNW",
+    "W",
+    "WSW",
+    "SW",
+    "SSW",
+    "S",
+    "SSE",
+    "SE",
+    "ESE",
+]
+
+
+def _describe_action(
+    action: int,
+    n_angles: int,
+    n_speed_bins: int,
+    shooting_slice_start: int | None,
+    shooting_slice_end: int | None,
+) -> str:
+    """Decode a raw action integer into a human-readable description."""
+    if action == 0:
+        return "Stay"
+    if (
+        shooting_slice_start is not None
+        and shooting_slice_end is not None
+        and shooting_slice_start <= action < shooting_slice_end
+    ):
+        target_idx = action - shooting_slice_start
+        return f"Shoot at opponent {target_idx}"
+    move_idx = action - 1
+    angle_idx = move_idx // n_speed_bins
+    speed_idx = move_idx % n_speed_bins
+    speed_label = speed_idx + 1
+    if n_angles <= 16:
+        step = 16 // n_angles
+        direction = COMPASS_LABELS_16[angle_idx * step]
+    else:
+        direction = f"angle {angle_idx}"
+    return f"Move {direction} at speed {speed_label}"
 
 
 # ---------------------------------------------------------------------------
@@ -295,15 +432,23 @@ def build_snapshot(
     phase_index: int,
     is_terminated: bool,
     is_truncated: bool,
+    n_angles: int = 16,
+    n_speed_bins: int = 6,
+    shooting_slice_start: int | None = None,
+    shooting_slice_end: int | None = None,
 ) -> GameStateSnapshot:
     """Build a complete game-state snapshot from env internals."""
     player_configs = config.models
     opponent_configs = config.opponent_models
 
+    spatial = _compute_spatial_data(player_models, opponent_models, objectives)
+
     p_snaps = [
         _model_to_snapshot(
             m,
             player_configs[i] if player_configs and i < len(player_configs) else None,
+            obj_distances=spatial.player_obj_dists[i],
+            obj_in_range=spatial.player_at_obj[i],
         )
         for i, m in enumerate(player_models)
     ]
@@ -315,11 +460,24 @@ def build_snapshot(
                 if opponent_configs and i < len(opponent_configs)
                 else None
             ),
+            obj_distances=spatial.opponent_obj_dists[i]
+            if i < len(spatial.opponent_obj_dists)
+            else [],
+            obj_in_range=spatial.opponent_at_obj[i]
+            if i < len(spatial.opponent_at_obj)
+            else [],
         )
         for i, m in enumerate(opponent_models)
     ]
 
-    obj_snaps = [_objective_to_snapshot(o) for o in objectives]
+    obj_snaps = [
+        _objective_to_snapshot(
+            o,
+            player_in_range=spatial.player_in_range_per_obj[j],
+            opponent_in_range=spatial.opponent_in_range_per_obj[j],
+        )
+        for j, o in enumerate(objectives)
+    ]
     clock = _clock_to_snapshot(clock_state)
 
     p_combat = [
@@ -331,11 +489,20 @@ def build_snapshot(
         for r in opponent_shooting_results
     ]
 
-    obj_control = _compute_objective_control(player_models, opponent_models, objectives)
-
     p_actions: list[int] | None = None
+    p_action_descs: list[str] | None = None
     if player_action is not None and hasattr(player_action, "actions"):
         p_actions = list(player_action.actions)
+        p_action_descs = [
+            _describe_action(
+                a,
+                n_angles,
+                n_speed_bins,
+                shooting_slice_start,
+                shooting_slice_end,
+            )
+            for a in p_actions
+        ]
 
     o_actions: list[int] | None = None
     if opponent_action is not None and hasattr(opponent_action, "actions"):
@@ -343,6 +510,13 @@ def build_snapshot(
 
     dz: list[int] = deployment_zone.tolist()
     odz: list[int] = opponent_deployment_zone.tolist()
+
+    p_alive = sum(1 for m in player_models if m.is_alive)
+    o_alive = sum(1 for m in opponent_models if m.is_alive)
+    p_wounds = sum(m.stats["current_wounds"] for m in player_models if m.is_alive)
+    o_wounds = sum(m.stats["current_wounds"] for m in opponent_models if m.is_alive)
+
+    mission_params: dict[str, Any] = dict(config.mission.params)
 
     return GameStateSnapshot(
         step=step,
@@ -360,9 +534,10 @@ def build_snapshot(
         opponent_vp=opponent_vp,
         player_vp_delta=player_vp_delta,
         opponent_vp_delta=opponent_vp_delta,
-        objective_control=obj_control,
+        objective_control=spatial.objective_control,
         player_actions=p_actions,
         opponent_actions=o_actions,
+        player_action_descriptions=p_action_descs,
         player_combat_results=p_combat,
         opponent_combat_results=o_combat,
         reward=RewardSnapshot(
@@ -373,6 +548,12 @@ def build_snapshot(
         ),
         is_terminated=is_terminated,
         is_truncated=is_truncated,
+        player_alive_count=p_alive,
+        opponent_alive_count=o_alive,
+        player_total_wounds=p_wounds,
+        opponent_total_wounds=o_wounds,
+        mission_type=config.mission.type,
+        mission_params=mission_params,
     )
 
 

--- a/wargame_rl/wargame/envs/state/snapshot.py
+++ b/wargame_rl/wargame/envs/state/snapshot.py
@@ -1,0 +1,401 @@
+"""Canonical game-state snapshot: pure-Python Pydantic models with JSON export.
+
+All fields use native Python types (no numpy) so the snapshot is trivially
+serialisable to JSON, MessagePack, or any other format.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+from wargame_rl.wargame.envs.domain.shooting import (
+    DefenderStats,
+    PairedShootingResult,
+    expected_damage,
+    wound_roll_threshold,
+)
+from wargame_rl.wargame.envs.env_components.distance_cache import (
+    compute_distances,
+    objective_ownership_from_norms_offset,
+)
+
+if TYPE_CHECKING:
+    from wargame_rl.wargame.envs.domain.entities import WargameModel, WargameObjective
+    from wargame_rl.wargame.envs.types.config import ModelConfig, WargameEnvConfig
+    from wargame_rl.wargame.envs.types.game_timing import GameState
+
+
+# ---------------------------------------------------------------------------
+# Sub-models
+# ---------------------------------------------------------------------------
+
+
+class WeaponSnapshot(BaseModel):
+    """Weapon stat block (mirrors WeaponProfile with native types)."""
+
+    weapon_range: int = Field(alias="range")
+    attacks: int
+    ballistic_skill: int
+    strength: int
+    ap: int
+    damage: int
+
+    model_config = {"populate_by_name": True}
+
+
+class ModelSnapshot(BaseModel):
+    """State of a single model (unit) on the board."""
+
+    location: list[int]
+    previous_location: list[int] | None
+    group_id: int
+    alive: bool
+    current_wounds: int
+    max_wounds: int
+    toughness: int
+    save: int
+    advanced_this_turn: bool
+    weapons: list[WeaponSnapshot]
+
+
+class ObjectiveSnapshot(BaseModel):
+    """State of an objective marker."""
+
+    location: list[int]
+    radius_size: int
+
+
+class ClockSnapshot(BaseModel):
+    """Game timing position."""
+
+    game_phase: str
+    battle_round: int | None
+    active_player: str | None
+    battle_phase: str | None
+
+
+class CombatResultSnapshot(BaseModel):
+    """One model-vs-model shooting resolution with analytical fields."""
+
+    attacker_idx: int
+    target_idx: int
+    hits: int
+    wounds: int
+    unsaved: int
+    damage_dealt: int
+    expected_damage: float
+    hit_probability: float
+    wound_probability: float
+
+
+class RewardSnapshot(BaseModel):
+    """Reward breakdown for the last step."""
+
+    total: float | None
+    breakdown: dict[str, float]
+    phase_name: str
+    phase_index: int
+
+
+class GameStateSnapshot(BaseModel):
+    """Complete, serialisable snapshot of game state at one point in time."""
+
+    schema_version: str = "1.0"
+    step: int
+    max_steps: int
+    clock: ClockSnapshot
+    n_rounds: int
+    board_width: int
+    board_height: int
+    player_models: list[ModelSnapshot]
+    opponent_models: list[ModelSnapshot]
+    objectives: list[ObjectiveSnapshot]
+    deployment_zone: list[int]
+    opponent_deployment_zone: list[int]
+    player_vp: int
+    opponent_vp: int
+    player_vp_delta: int
+    opponent_vp_delta: int
+    objective_control: list[str]
+    player_actions: list[int] | None
+    opponent_actions: list[int] | None
+    player_combat_results: list[CombatResultSnapshot]
+    opponent_combat_results: list[CombatResultSnapshot]
+    reward: RewardSnapshot
+    is_terminated: bool
+    is_truncated: bool
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _model_to_snapshot(
+    model: WargameModel,
+    config: ModelConfig | None,
+) -> ModelSnapshot:
+    """Convert a domain WargameModel to a snapshot."""
+    weapons: list[WeaponSnapshot] = []
+    if config is not None:
+        for w in config.weapons:
+            weapons.append(
+                WeaponSnapshot(
+                    weapon_range=w.range,
+                    attacks=w.attacks,
+                    ballistic_skill=w.ballistic_skill,
+                    strength=w.strength,
+                    ap=w.ap,
+                    damage=w.damage,
+                )
+            )
+    return ModelSnapshot(
+        location=model.location.tolist(),
+        previous_location=(
+            model.previous_location.tolist()
+            if model.previous_location is not None
+            else None
+        ),
+        group_id=model.group_id,
+        alive=model.is_alive,
+        current_wounds=model.stats["current_wounds"],
+        max_wounds=model.stats["max_wounds"],
+        toughness=model.stats["toughness"],
+        save=model.stats["save"],
+        advanced_this_turn=model.advanced_this_turn,
+        weapons=weapons,
+    )
+
+
+def _objective_to_snapshot(obj: WargameObjective) -> ObjectiveSnapshot:
+    return ObjectiveSnapshot(
+        location=obj.location.tolist(),
+        radius_size=obj.radius_size,
+    )
+
+
+def _clock_to_snapshot(state: GameState) -> ClockSnapshot:
+    return ClockSnapshot(
+        game_phase=state.game_phase.value,
+        battle_round=state.battle_round,
+        active_player=state.active_player.value if state.active_player else None,
+        battle_phase=state.phase.value if state.phase else None,
+    )
+
+
+def _combat_result_to_snapshot(
+    paired: PairedShootingResult,
+    attacker_configs: list[ModelConfig] | None,
+    targets: list[WargameModel],
+) -> CombatResultSnapshot:
+    """Convert a PairedShootingResult to a snapshot with analytical fields."""
+    r = paired.result
+    exp_dmg = 0.0
+    p_hit = 0.0
+    p_wound = 0.0
+
+    has_weapon = (
+        attacker_configs is not None
+        and paired.attacker_idx < len(attacker_configs)
+        and attacker_configs[paired.attacker_idx].weapons
+    )
+    has_target = paired.target_idx < len(targets)
+
+    if has_weapon and has_target:
+        weapon = attacker_configs[paired.attacker_idx].weapons[0]  # type: ignore[index]
+        target = targets[paired.target_idx]
+        defender = DefenderStats(
+            toughness=target.stats["toughness"],
+            save=target.stats["save"],
+        )
+        exp_dmg = expected_damage(weapon, defender)
+        p_hit = (7 - weapon.ballistic_skill) / 6.0
+        threshold = wound_roll_threshold(weapon.strength, defender.toughness)
+        p_wound = (7 - threshold) / 6.0
+
+    return CombatResultSnapshot(
+        attacker_idx=paired.attacker_idx,
+        target_idx=paired.target_idx,
+        hits=r.hits,
+        wounds=r.wounds,
+        unsaved=r.unsaved,
+        damage_dealt=r.damage_dealt,
+        expected_damage=exp_dmg,
+        hit_probability=p_hit,
+        wound_probability=p_wound,
+    )
+
+
+def _compute_objective_control(
+    player_models: list[WargameModel],
+    opponent_models: list[WargameModel],
+    objectives: list[WargameObjective],
+) -> list[str]:
+    """Compute per-objective ownership strings: 'player', 'opponent', or 'none'."""
+    if not objectives:
+        return []
+
+    p_cache = compute_distances(player_models, objectives)
+    o_cache = (
+        compute_distances(opponent_models, objectives) if opponent_models else None
+    )
+
+    if o_cache is not None:
+        p_ctrl, o_ctrl = objective_ownership_from_norms_offset(
+            p_cache.model_obj_norms_offset,
+            o_cache.model_obj_norms_offset,
+            p_cache.obj_radii,
+        )
+    else:
+        p_ctrl = np.any(p_cache.model_obj_norms_offset <= p_cache.obj_radii, axis=0)
+        o_ctrl = np.zeros_like(p_ctrl, dtype=bool)
+
+    result: list[str] = []
+    for pi, oi in zip(p_ctrl, o_ctrl):
+        if pi:
+            result.append("player")
+        elif oi:
+            result.append("opponent")
+        else:
+            result.append("none")
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Public factory
+# ---------------------------------------------------------------------------
+
+
+def build_snapshot(
+    *,
+    config: WargameEnvConfig,
+    step: int,
+    max_steps: int,
+    clock_state: GameState,
+    n_rounds: int,
+    player_models: list[WargameModel],
+    opponent_models: list[WargameModel],
+    objectives: list[WargameObjective],
+    deployment_zone: np.ndarray,
+    opponent_deployment_zone: np.ndarray,
+    player_vp: int,
+    opponent_vp: int,
+    player_vp_delta: int,
+    opponent_vp_delta: int,
+    player_shooting_results: list[PairedShootingResult],
+    opponent_shooting_results: list[PairedShootingResult],
+    player_action: object | None,
+    opponent_action: object | None,
+    last_reward: float | None,
+    reward_breakdown: dict[str, float],
+    phase_name: str,
+    phase_index: int,
+    is_terminated: bool,
+    is_truncated: bool,
+) -> GameStateSnapshot:
+    """Build a complete game-state snapshot from env internals."""
+    player_configs = config.models
+    opponent_configs = config.opponent_models
+
+    p_snaps = [
+        _model_to_snapshot(
+            m,
+            player_configs[i] if player_configs and i < len(player_configs) else None,
+        )
+        for i, m in enumerate(player_models)
+    ]
+    o_snaps = [
+        _model_to_snapshot(
+            m,
+            (
+                opponent_configs[i]
+                if opponent_configs and i < len(opponent_configs)
+                else None
+            ),
+        )
+        for i, m in enumerate(opponent_models)
+    ]
+
+    obj_snaps = [_objective_to_snapshot(o) for o in objectives]
+    clock = _clock_to_snapshot(clock_state)
+
+    p_combat = [
+        _combat_result_to_snapshot(r, player_configs, opponent_models)
+        for r in player_shooting_results
+    ]
+    o_combat = [
+        _combat_result_to_snapshot(r, opponent_configs, player_models)
+        for r in opponent_shooting_results
+    ]
+
+    obj_control = _compute_objective_control(player_models, opponent_models, objectives)
+
+    p_actions: list[int] | None = None
+    if player_action is not None and hasattr(player_action, "actions"):
+        p_actions = list(player_action.actions)
+
+    o_actions: list[int] | None = None
+    if opponent_action is not None and hasattr(opponent_action, "actions"):
+        o_actions = list(opponent_action.actions)
+
+    dz: list[int] = deployment_zone.tolist()
+    odz: list[int] = opponent_deployment_zone.tolist()
+
+    return GameStateSnapshot(
+        step=step,
+        max_steps=max_steps,
+        clock=clock,
+        n_rounds=n_rounds,
+        board_width=config.board_width,
+        board_height=config.board_height,
+        player_models=p_snaps,
+        opponent_models=o_snaps,
+        objectives=obj_snaps,
+        deployment_zone=dz,
+        opponent_deployment_zone=odz,
+        player_vp=player_vp,
+        opponent_vp=opponent_vp,
+        player_vp_delta=player_vp_delta,
+        opponent_vp_delta=opponent_vp_delta,
+        objective_control=obj_control,
+        player_actions=p_actions,
+        opponent_actions=o_actions,
+        player_combat_results=p_combat,
+        opponent_combat_results=o_combat,
+        reward=RewardSnapshot(
+            total=last_reward,
+            breakdown=dict(reward_breakdown),
+            phase_name=phase_name,
+            phase_index=phase_index,
+        ),
+        is_terminated=is_terminated,
+        is_truncated=is_truncated,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Encoder protocol + JSON implementation
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class SnapshotEncoder(Protocol):
+    """Protocol for snapshot serialisation."""
+
+    def encode(self, snapshot: GameStateSnapshot) -> str: ...
+
+    def content_type(self) -> str: ...
+
+
+class JsonEncoder:
+    """JSON encoder for GameStateSnapshot."""
+
+    def encode(self, snapshot: GameStateSnapshot) -> str:
+        """Serialise a snapshot to a JSON string."""
+        return str(snapshot.model_dump_json())
+
+    def content_type(self) -> str:
+        return "application/json"

--- a/wargame_rl/wargame/envs/wargame.py
+++ b/wargame_rl/wargame/envs/wargame.py
@@ -555,6 +555,7 @@ class WargameEnv(gym.Env):
 
     def to_snapshot(self) -> GameStateSnapshot:
         """Build a serialisable snapshot of the current game state."""
+        ss = self._action_handler.shooting_slice
         return build_snapshot(
             config=self.config,
             step=self.current_turn,
@@ -580,6 +581,10 @@ class WargameEnv(gym.Env):
             phase_index=self.phase_manager.current_phase_index,
             is_terminated=self._last_terminated,
             is_truncated=False,
+            n_angles=self.config.n_movement_angles,
+            n_speed_bins=self.config.n_speed_bins,
+            shooting_slice_start=ss.start if ss else None,
+            shooting_slice_end=ss.end if ss else None,
         )
 
     def render(self) -> None:

--- a/wargame_rl/wargame/envs/wargame.py
+++ b/wargame_rl/wargame/envs/wargame.py
@@ -22,7 +22,7 @@ from wargame_rl.wargame.envs.domain.los import has_line_of_sight, iter_los_cells
 from wargame_rl.wargame.envs.domain.placement import place_for_episode
 from wargame_rl.wargame.envs.domain.shooting import (
     DefenderStats,
-    ShootingResult,
+    PairedShootingResult,
     resolve_shooting,
 )
 from wargame_rl.wargame.envs.domain.termination import is_battle_over
@@ -47,6 +47,7 @@ from wargame_rl.wargame.envs.opponent.registry import (
 from wargame_rl.wargame.envs.renders import renderer
 from wargame_rl.wargame.envs.reward.phase_manager import RewardPhaseManager
 from wargame_rl.wargame.envs.reward.step_context import StepContext
+from wargame_rl.wargame.envs.state.snapshot import GameStateSnapshot, build_snapshot
 from wargame_rl.wargame.envs.types import (
     BattlePhase,
     PlayerSide,
@@ -122,8 +123,13 @@ class WargameEnv(gym.Env):
 
         # Combat RNG (re-seeded per episode in reset)
         self._combat_rng: np.random.Generator = np.random.default_rng()
-        self._last_player_shooting_results: list[ShootingResult] = []
-        self._last_opponent_shooting_results: list[ShootingResult] = []
+        self._last_player_shooting_results: list[PairedShootingResult] = []
+        self._last_opponent_shooting_results: list[PairedShootingResult] = []
+
+        # Last actions and termination flag (for snapshot / replay)
+        self._last_player_action: WargameEnvAction | None = None
+        self._last_opponent_action: WargameEnvAction | None = None
+        self._last_terminated: bool = False
 
         # Last reward from step(); None until first step after reset
         self.last_reward: float | None = None
@@ -288,6 +294,9 @@ class WargameEnv(gym.Env):
         self._combat_rng = np.random.default_rng(int(combat_seed))
         self._last_player_shooting_results = []
         self._last_opponent_shooting_results = []
+        self._last_player_action = None
+        self._last_opponent_action = None
+        self._last_terminated = False
 
         self.current_turn = 0
         self.last_reward = None
@@ -330,12 +339,12 @@ class WargameEnv(gym.Env):
         targets: list[WargameModel],
         shooting_slice: ActionSlice | None,
         attacker_configs: list[ModelConfig] | None,
-    ) -> list[ShootingResult]:
+    ) -> list[PairedShootingResult]:
         """Resolve shooting for each model in the action against targets.
 
-        Returns one ShootingResult per model that actually fired.
+        Returns one PairedShootingResult per model that actually fired.
         """
-        results: list[ShootingResult] = []
+        results: list[PairedShootingResult] = []
         if shooting_slice is None:
             return results
         for i, act in enumerate(action.actions):
@@ -365,7 +374,11 @@ class WargameEnv(gym.Env):
             result = resolve_shooting(w, defender, self._combat_rng)
             if result.damage_dealt > 0:
                 targets[target_idx].take_damage(result.damage_dealt)
-            results.append(result)
+            results.append(
+                PairedShootingResult(
+                    attacker_idx=i, target_idx=target_idx, result=result
+                )
+            )
         return results
 
     def _apply_player_action(self, action: WargameEnvAction) -> None:
@@ -399,6 +412,7 @@ class WargameEnv(gym.Env):
         opp_action = self._opponent_policy.select_action(
             self.opponent_models, self, action_mask=opp_mask
         )
+        self._last_opponent_action = opp_action
         if phase == BattlePhase.shooting:
             self._last_opponent_shooting_results = self._resolve_shooting_action(
                 opp_action,
@@ -445,6 +459,7 @@ class WargameEnv(gym.Env):
         opp_alive_before = [m.is_alive for m in self.opponent_models]
         player_alive_before = [m.is_alive for m in self.wargame_models]
 
+        self._last_player_action = action
         self._apply_player_action(action)
 
         self.current_turn += 1
@@ -489,12 +504,13 @@ class WargameEnv(gym.Env):
             all_at_objective,
             all_eliminated=all_eliminated,
         )
+        self._last_terminated = is_terminated
 
         clock_state = self._game_clock.state
         phase = clock_state.phase or BattlePhase.command
 
-        p_dmg = sum(r.damage_dealt for r in self._last_player_shooting_results)
-        o_dmg = sum(r.damage_dealt for r in self._last_opponent_shooting_results)
+        p_dmg = sum(r.result.damage_dealt for r in self._last_player_shooting_results)
+        o_dmg = sum(r.result.damage_dealt for r in self._last_opponent_shooting_results)
         p_kills = sum(
             1
             for i, m in enumerate(self.opponent_models)
@@ -536,6 +552,35 @@ class WargameEnv(gym.Env):
             )
         self.episode_reward_steps += 1
         return observation, reward, is_terminated, False, info.model_dump()
+
+    def to_snapshot(self) -> GameStateSnapshot:
+        """Build a serialisable snapshot of the current game state."""
+        return build_snapshot(
+            config=self.config,
+            step=self.current_turn,
+            max_steps=self.max_turns,
+            clock_state=self._game_clock.state,
+            n_rounds=self._game_clock.n_rounds,
+            player_models=self.wargame_models,
+            opponent_models=self.opponent_models,
+            objectives=self.objectives,
+            deployment_zone=self.deployment_zone,
+            opponent_deployment_zone=self.opponent_deployment_zone,
+            player_vp=self.player_vp,
+            opponent_vp=self.opponent_vp,
+            player_vp_delta=self.player_vp_delta,
+            opponent_vp_delta=self.opponent_vp_delta,
+            player_shooting_results=self._last_player_shooting_results,
+            opponent_shooting_results=self._last_opponent_shooting_results,
+            player_action=self._last_player_action,
+            opponent_action=self._last_opponent_action,
+            last_reward=self.last_reward,
+            reward_breakdown=self.last_reward_breakdown,
+            phase_name=self.phase_manager.current_phase_name,
+            phase_index=self.phase_manager.current_phase_index,
+            is_terminated=self._last_terminated,
+            is_truncated=False,
+        )
 
     def render(self) -> None:
         if self.renderer is not None:


### PR DESCRIPTION
## Summary

- Implements v9-01 (Canonical State Model & Export) — a Pydantic-based `GameStateSnapshot` that captures the full game state as JSON-serialisable native Python types
- Adds `PairedShootingResult` to the domain layer for combat traceability (attacker/target indices)
- Enriches the snapshot with derived spatial, force, action, and mission fields (schema v1.1) so consumers can answer "who's winning?" without recomputing anything

### Key additions
- **Spatial awareness**: per-model `distances_to_objectives`, `at_objective`, `closest_objective_idx/distance`; per-objective `player/opponent_models_in_range`
- **Force balance**: `player/opponent_alive_count`, `player/opponent_total_wounds`
- **Action descriptions**: human-readable decoded actions (e.g. "Move NE at speed 2", "Shoot at opponent 0")
- **Mission context**: `mission_type` and `mission_params`
- **Combat analytics**: `expected_damage`, `hit_probability`, `wound_probability` per combat result
- **Encoder protocol**: `SnapshotEncoder` with `JsonEncoder` implementation

## Test plan

- [x] 19 integration tests in `test_snapshot.py` covering: reset/step snapshots, JSON serialisation, schema generation, combat result pairing, opponent action recording, reward breakdown, objective control, spatial fields, force balance, action descriptions (stay + shooting), mission context, encoder
- [x] Updated `test_shooting_resolution.py` for `PairedShootingResult` wrapper
- [x] All pre-commit hooks pass (ruff, mypy, isort, autoflake)
- [x] Full test suite passes (only pre-existing CUDA compat failure on `test_agent[mlp]`)


Made with [Cursor](https://cursor.com)