### PR TITLE
feat: canonical game state model with snapshot, injection, and LLM narrator (v9-01 → v9-03)

### DIFF
--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -90,14 +90,33 @@ Deferred to future milestones. Tracked but not in current roadmap.
 
 ### Structured state & events (v9.0)
 
-Deferred to v9.0. Roadmap phases TBD when the milestone is activated.
+Roadmap: `.planning/v9-ROADMAP.md`
 
-- **SGS-01**: A canonical programmatic game-state model exists (board, entities, phase, scoring, etc.), sourced from domain / read-only views, not tied to RL observation tensors
-- **SGS-02**: Serialised state is suitable for external APIs and for LLM-facing validation (stable identifiers, documented semantics, explicit schema version)
-- **SGS-03**: A layered change protocol expresses updates as full snapshots and/or granular deltas at defined abstraction levels to minimise redundancy
-- **SGS-04**: Default encoding is JSON; a codec or encoder interface allows additional formats without changing the canonical model
-- **SGS-05**: An append-only, ordered event stream can represent a complete match history for storage or streaming
-- **SGS-06**: Replay is deterministic: events (optionally with periodic snapshots) applied from a known initial configuration reconstruct any requested historical state (fast-forward / seek)
+#### Canonical State & Export
+
+- [ ] **SGS-01**: A canonical programmatic game-state model exists (board, entities, phase, scoring, etc.), sourced from domain / read-only views, not tied to RL observation tensors
+- [ ] **SGS-02**: Serialised state is suitable for external APIs and for LLM-facing validation (stable identifiers, documented semantics, explicit schema version)
+- [ ] **SGS-04**: Default encoding is JSON; a codec or encoder interface allows additional formats without changing the canonical model
+
+#### State Injection (new — discovered during v9.0 research)
+
+- [ ] **SGS-07**: `GameClock.set_state()` can position the clock at any valid round/phase/player combination for state injection
+- [ ] **SGS-08**: `WargameEnv.load_state(snapshot)` constructs a mid-episode environment from a `GameStateSnapshot`, recomputing derived state
+- [ ] **SGS-09**: Round-trip state fidelity: `to_snapshot()` → `load_state()` → `to_snapshot()` produces identical output
+
+#### LLM Text Representation (new — discovered during v9.0 research)
+
+- [ ] **SGS-10**: `describe_action()` method produces human/LLM-readable text for any action integer (e.g. "Move NE at speed 4", "Shoot at opponent 1")
+- [ ] **SGS-11**: Combat results include attacker-target pairing and analytical context (probabilities, expected damage) for LLM evaluation
+- [ ] **SGS-12**: Opponent actions are recorded before application and available in state output
+- [ ] **SGS-13**: `StepNarrator` produces per-step text summaries covering state, decoded actions, combat narrative, and reward breakdown with phase context
+- [ ] **SGS-14**: Reward breakdown and active reward phase name are included in state output
+
+#### Event Streaming & Replay (deferred)
+
+- [ ] **SGS-03**: A layered change protocol expresses updates as full snapshots and/or granular deltas at defined abstraction levels to minimise redundancy
+- [ ] **SGS-05**: An append-only, ordered event stream can represent a complete match history for storage or streaming
+- [ ] **SGS-06**: Replay is deterministic: events (optionally with periodic snapshots) applied from a known initial configuration reconstruct any requested historical state (fast-forward / seek)
 
 ## Out of Scope
 
@@ -142,12 +161,36 @@ Deferred to v9.0. Roadmap phases TBD when the milestone is activated.
 | OBS-02 | Phase 5 | Complete |
 | OBS-03 | Phase 2 | Pending |
 
-**Coverage:**
+**v1.0 Coverage:**
 - v1 requirements: 26 total
 - Mapped to phases: 26 ✓
 - Unmapped: 0
-- v9.0 (structured state & events): 6 requirements (**SGS-01**–**SGS-06**); phases not yet defined
+
+**v9.0 Coverage (structured state & events):**
+
+| Requirement | Phase | Status |
+|-------------|-------|--------|
+| SGS-01 | Phase 1 | Pending |
+| SGS-02 | Phase 3 | Pending |
+| SGS-03 | Phase 4 | Deferred |
+| SGS-04 | Phase 1 | Pending |
+| SGS-05 | Phase 4 | Deferred |
+| SGS-06 | Phase 4 | Deferred |
+| SGS-07 | Phase 2 | Pending |
+| SGS-08 | Phase 2 | Pending |
+| SGS-09 | Phase 2 | Pending |
+| SGS-10 | Phase 3 | Pending |
+| SGS-11 | Phase 1 | Pending |
+| SGS-12 | Phase 1 | Pending |
+| SGS-13 | Phase 3 | Pending |
+| SGS-14 | Phase 1 | Pending |
+
+- v9.0 requirements: 14 total (6 original + 8 discovered during research)
+- Mapped to phases: 14 ✓
+- Active (Phases 1–3): 11
+- Deferred (Phase 4): 3
+- Unmapped: 0
 
 ---
 *Requirements defined: 2026-04-02*
-*Last updated: 2026-04-05 — added v9.0 SGS-* requirements (roadmap TBD)*
+*Last updated: 2026-05-23 — v9.0 requirements expanded (SGS-07–SGS-14 from research), phases mapped to v9-ROADMAP.md*

--- a/.planning/phases/v9-01-canonical-state-model/v9-01-01-PLAN.md
+++ b/.planning/phases/v9-01-canonical-state-model/v9-01-01-PLAN.md
@@ -1,0 +1,423 @@
+---
+phase: v9-01-canonical-state-model
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - wargame_rl/wargame/envs/domain/shooting.py
+  - wargame_rl/wargame/envs/wargame.py
+  - wargame_rl/wargame/envs/state/__init__.py
+  - wargame_rl/wargame/envs/state/snapshot.py
+  - tests/test_shooting_resolution.py
+  - tests/test_snapshot.py
+autonomous: true
+requirements: [SGS-01, SGS-04, SGS-11, SGS-12, SGS-14]
+
+must_haves:
+  truths:
+    - "WargameEnv.to_snapshot() returns a GameStateSnapshot Pydantic model after reset and after step"
+    - "snapshot.model_dump_json() produces valid JSON with zero numpy types"
+    - "GameStateSnapshot.model_json_schema() produces a valid JSON Schema document"
+    - "Combat results include attacker_idx, target_idx, and analytical context (expected_damage, hit_probability, wound_probability)"
+    - "Opponent actions are recorded before application and available in the snapshot"
+    - "Reward breakdown (per-calculator totals) and active phase name appear in the snapshot"
+    - "SnapshotEncoder protocol exists with a JsonEncoder implementation"
+  artifacts:
+    - path: "wargame_rl/wargame/envs/state/__init__.py"
+      provides: "Package init re-exporting GameStateSnapshot, build_snapshot, SnapshotEncoder, JsonEncoder"
+      contains: "GameStateSnapshot"
+    - path: "wargame_rl/wargame/envs/state/snapshot.py"
+      provides: "All Pydantic snapshot models, build_snapshot factory, encoder protocol"
+      contains: "class GameStateSnapshot"
+    - path: "wargame_rl/wargame/envs/domain/shooting.py"
+      provides: "PairedShootingResult dataclass wrapping ShootingResult with attacker/target indices"
+      contains: "class PairedShootingResult"
+    - path: "wargame_rl/wargame/envs/wargame.py"
+      provides: "to_snapshot() method, _last_player_action, _last_opponent_action, _last_terminated"
+      contains: "def to_snapshot"
+    - path: "tests/test_snapshot.py"
+      provides: "Tests covering SGS-01, SGS-04, SGS-11, SGS-12, SGS-14"
+      contains: "test_to_snapshot"
+  key_links:
+    - from: "wargame_rl/wargame/envs/wargame.py"
+      to: "wargame_rl/wargame/envs/state/snapshot.py"
+      via: "to_snapshot() calls build_snapshot() with env state"
+      pattern: "build_snapshot"
+    - from: "wargame_rl/wargame/envs/state/snapshot.py"
+      to: "wargame_rl/wargame/envs/domain/battle_view.py"
+      via: "build_snapshot reads BattleView properties for board, entities, clock, VP"
+      pattern: "BattleView"
+    - from: "wargame_rl/wargame/envs/wargame.py"
+      to: "wargame_rl/wargame/envs/domain/shooting.py"
+      via: "_resolve_shooting_action returns list[PairedShootingResult]"
+      pattern: "PairedShootingResult"
+---
+
+<objective>
+Build the canonical game state model: a `GameStateSnapshot` Pydantic model projected from `BattleView` and env-level ephemeral state, exported to JSON via `WargameEnv.to_snapshot()`. Capture attacker-target pairing in combat results, record opponent actions before application, and include reward breakdown with phase context.
+
+Purpose: Foundation for all v9.0 work — state injection (Phase 2) and LLM text representation (Phase 3) both depend on this snapshot model existing.
+Output: `envs/state/` package with Pydantic models, `PairedShootingResult` in domain, `to_snapshot()` on WargameEnv, `SnapshotEncoder` protocol, comprehensive tests.
+</objective>
+
+<execution_context>
+@$HOME/.cursor/get-shit-done/workflows/execute-plan.md
+@$HOME/.cursor/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/v9-ROADMAP.md
+@.planning/phases/v9-01-canonical-state-model/v9-01-RESEARCH.md
+@docs/ddd-envs.md
+
+<interfaces>
+<!-- Key types and contracts the executor needs. Extracted from codebase. -->
+
+From wargame_rl/wargame/envs/domain/shooting.py:
+```python
+@dataclass(frozen=True, slots=True)
+class ShootingResult:
+    hits: int
+    wounds: int
+    unsaved: int
+    damage_dealt: int
+
+def wound_roll_threshold(strength: int, toughness: int) -> int: ...
+def expected_damage(weapon: WeaponStats, defender: DefenderStats) -> float: ...
+```
+
+From wargame_rl/wargame/envs/wargame.py (current _resolve_shooting_action):
+```python
+def _resolve_shooting_action(
+    self,
+    action: WargameEnvAction,
+    attackers: list[WargameModel],
+    targets: list[WargameModel],
+    shooting_slice: ActionSlice | None,
+    attacker_configs: list[ModelConfig] | None,
+) -> list[ShootingResult]:
+    # Loop has `i` (attacker index) and `target_idx` available
+    # but wraps into plain ShootingResult losing pairing info
+```
+
+From wargame_rl/wargame/envs/wargame.py (current _apply_opponent_action):
+```python
+def _apply_opponent_action(self) -> None:
+    # opp_action = self._opponent_policy.select_action(...)
+    # action is immediately applied; not stored
+```
+
+From wargame_rl/wargame/envs/domain/battle_view.py:
+```python
+class BattleView(Protocol):
+    board_width: int
+    board_height: int
+    config: WargameEnvConfig
+    player_models: list[WargameModel]
+    opponent_models: list[WargameModel]
+    objectives: list[WargameObjective]
+    deployment_zone: np.ndarray
+    opponent_deployment_zone: np.ndarray
+    current_turn: int
+    last_reward: float | None
+    game_clock_state: GameState
+    n_rounds: int
+    player_vp: int
+    opponent_vp: int
+    player_vp_delta: int
+    opponent_vp_delta: int
+```
+
+From wargame_rl/wargame/envs/reward/phase_manager.py:
+```python
+class RewardPhaseManager:
+    last_reward_breakdown: dict[str, float]
+    @property
+    def current_phase_name(self) -> str: ...
+    @property
+    def current_phase_index(self) -> int: ...
+```
+
+From wargame_rl/wargame/envs/domain/entities.py:
+```python
+class WargameModel:
+    location: np.ndarray          # shape (2,), int32
+    previous_location: np.ndarray | None
+    stats: dict[str, int]         # keys: max_wounds, current_wounds, toughness, save
+    group_id: int
+    advanced_this_turn: bool
+    @property
+    def is_alive(self) -> bool: ...
+
+class WargameObjective:
+    location: np.ndarray          # shape (2,), int32
+    radius_size: int
+```
+
+From wargame_rl/wargame/envs/types/game_timing.py:
+```python
+@dataclass(frozen=True, slots=True)
+class GameState:
+    game_phase: GamePhase       # "setup" | "battle" | "complete"
+    setup_phase: SetupPhase | None
+    battle_round: int | None
+    active_player: PlayerSide | None
+    phase: BattlePhase | None   # "command" | "movement" | "shooting" | ...
+```
+
+From wargame_rl/wargame/envs/types/config.py:
+```python
+class WeaponProfile(BaseModel):
+    range: int
+    attacks: int      # default 2
+    ballistic_skill: int  # default 3
+    strength: int     # default 4
+    ap: int           # default 1
+    damage: int       # default 1
+
+class ModelConfig(BaseModel):
+    max_wounds: int   # default 1
+    toughness: int    # default 3
+    save: int         # default 4
+    weapons: list[WeaponProfile]
+```
+
+From wargame_rl/wargame/envs/env_components/distance_cache.py:
+```python
+def compute_distances(
+    wargame_models: list[WargameModel],
+    objectives: list[WargameObjective],
+    compute_model_model: bool = False,
+    alive_mask: np.ndarray | None = None,
+) -> DistanceCache: ...
+
+def objective_ownership_from_norms_offset(
+    player_norms_offset: np.ndarray,
+    opponent_norms_offset: np.ndarray,
+    obj_radii: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]: ...
+```
+
+From wargame_rl/wargame/envs/types/__init__.py:
+```python
+class WargameEnvAction:
+    actions: tuple[int, ...]
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add PairedShootingResult and record actions/termination in env</name>
+  <files>
+    wargame_rl/wargame/envs/domain/shooting.py,
+    wargame_rl/wargame/envs/wargame.py,
+    tests/test_shooting_resolution.py
+  </files>
+  <read_first>
+    wargame_rl/wargame/envs/domain/shooting.py,
+    wargame_rl/wargame/envs/wargame.py,
+    tests/test_shooting_resolution.py
+  </read_first>
+  <action>
+  **shooting.py** — Add `PairedShootingResult` dataclass after `ShootingResult`:
+
+  Frozen dataclass with slots, three fields: `attacker_idx: int`, `target_idx: int`, `result: ShootingResult`. Place it in `domain/shooting.py` as a peer of `ShootingResult` — it is a shooting-resolution value object with context, keeping the domain layer self-contained.
+
+  **wargame.py** — Five changes:
+
+  1. **Import** `PairedShootingResult` alongside `ShootingResult` from `domain.shooting`.
+
+  2. **New fields in `__init__`** — Add after existing `_last_*_shooting_results` declarations:
+     - `self._last_player_action: WargameEnvAction | None = None`
+     - `self._last_opponent_action: WargameEnvAction | None = None`
+     - `self._last_terminated: bool = False`
+
+     Change the type of existing shooting result fields from `list[ShootingResult]` to `list[PairedShootingResult]`.
+
+  3. **`reset()`** — Add resets for the new fields alongside the existing shooting result resets:
+     - `self._last_player_action = None`
+     - `self._last_opponent_action = None`
+     - `self._last_terminated = False`
+
+  4. **`_resolve_shooting_action`** — Change return type to `list[PairedShootingResult]`. Change the internal `results` list type. In the loop, after `resolve_shooting()` returns and damage is applied, wrap the result: `results.append(PairedShootingResult(attacker_idx=i, target_idx=target_idx, result=result))`.
+
+  5. **`_apply_opponent_action`** — Store the action before applying: add `self._last_opponent_action = opp_action` immediately after `opp_action = self._opponent_policy.select_action(...)`, before the phase check.
+
+  6. **`step()`** — Three additions:
+     - Store player action at the top: `self._last_player_action = action` (before `_apply_player_action`).
+     - Update damage aggregation to access the wrapped result: `r.result.damage_dealt` instead of `r.damage_dealt` (two lines: `p_dmg` and `o_dmg`).
+     - Store termination state: `self._last_terminated = is_terminated` (after `is_terminated` is computed, before the return).
+
+  **tests/test_shooting_resolution.py** — Update all accesses to `_last_player_shooting_results` and `_last_opponent_shooting_results` entries. Every `r.damage_dealt` becomes `r.result.damage_dealt`, every `r.hits` becomes `r.result.hits`, every `r.wounds` becomes `r.result.wounds`, etc. The list itself is still accessed the same way; only field access on individual results changes because `PairedShootingResult` wraps `ShootingResult` in its `.result` field. Verify the tests that iterate over results and check `.attacker_idx` / `.target_idx` are now available (no need to add new tests — just confirm nothing breaks).
+  </action>
+  <verify>
+    <automated>uv run pytest tests/test_shooting_resolution.py -x -q</automated>
+  </verify>
+  <done>PairedShootingResult exists in domain/shooting.py; _resolve_shooting_action returns paired results; opponent and player actions are stored; is_terminated is stored; existing shooting tests pass with updated field access</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Snapshot Pydantic models, factory, encoder, and to_snapshot()</name>
+  <files>
+    wargame_rl/wargame/envs/state/__init__.py,
+    wargame_rl/wargame/envs/state/snapshot.py,
+    wargame_rl/wargame/envs/wargame.py
+  </files>
+  <read_first>
+    wargame_rl/wargame/envs/domain/battle_view.py,
+    wargame_rl/wargame/envs/domain/entities.py,
+    wargame_rl/wargame/envs/types/config.py,
+    wargame_rl/wargame/envs/types/game_timing.py,
+    wargame_rl/wargame/envs/env_components/distance_cache.py,
+    wargame_rl/wargame/envs/reward/phase_manager.py,
+    wargame_rl/wargame/envs/domain/shooting.py
+  </read_first>
+  <action>
+  **Create `wargame_rl/wargame/envs/state/__init__.py`** — Re-export the public API:
+  `GameStateSnapshot`, `build_snapshot`, `SnapshotEncoder`, `JsonEncoder`.
+
+  **Create `wargame_rl/wargame/envs/state/snapshot.py`** — All models use native Python types only (no numpy). `from __future__ import annotations` at the top.
+
+  Sub-models:
+
+  - `WeaponSnapshot(BaseModel)`: `range_: int` (use `alias="range"` or field name `weapon_range`... actually use `range` as the field name since Pydantic allows it even though it shadows the builtin — or use `Field(alias="range")` with `model_config = ConfigDict(populate_by_name=True)`. Simplest: just name the field `range` — Pydantic v2 allows it), `attacks: int`, `ballistic_skill: int`, `strength: int`, `ap: int`, `damage: int`.
+
+  - `ModelSnapshot(BaseModel)`: `location: list[int]` (2-element), `previous_location: list[int] | None`, `group_id: int`, `alive: bool`, `current_wounds: int`, `max_wounds: int`, `toughness: int`, `save: int`, `advanced_this_turn: bool`, `weapons: list[WeaponSnapshot]`.
+
+  - `ObjectiveSnapshot(BaseModel)`: `location: list[int]`, `radius_size: int`.
+
+  - `ClockSnapshot(BaseModel)`: `game_phase: str`, `battle_round: int | None`, `active_player: str | None`, `battle_phase: str | None`.
+
+  - `CombatResultSnapshot(BaseModel)`: `attacker_idx: int`, `target_idx: int`, `hits: int`, `wounds: int`, `unsaved: int`, `damage_dealt: int`, `expected_damage: float`, `hit_probability: float`, `wound_probability: float`. The analytical fields satisfy SGS-11's "analytical context (probabilities, expected damage) for LLM evaluation".
+
+  - `RewardSnapshot(BaseModel)`: `total: float | None`, `breakdown: dict[str, float]`, `phase_name: str`, `phase_index: int`.
+
+  - `GameStateSnapshot(BaseModel)`: `schema_version: str` (default `"1.0"`), `step: int`, `max_steps: int`, `clock: ClockSnapshot`, `n_rounds: int`, `board_width: int`, `board_height: int`, `player_models: list[ModelSnapshot]`, `opponent_models: list[ModelSnapshot]`, `objectives: list[ObjectiveSnapshot]`, `deployment_zone: list[int]`, `opponent_deployment_zone: list[int]`, `player_vp: int`, `opponent_vp: int`, `player_vp_delta: int`, `opponent_vp_delta: int`, `objective_control: list[str]`, `player_actions: list[int] | None`, `opponent_actions: list[int] | None`, `player_combat_results: list[CombatResultSnapshot]`, `opponent_combat_results: list[CombatResultSnapshot]`, `reward: RewardSnapshot`, `is_terminated: bool`, `is_truncated: bool`.
+
+  **Encoder protocol** (SGS-04) — Define at the bottom of `snapshot.py`:
+
+  - `SnapshotEncoder(Protocol)` with `def encode(self, snapshot: GameStateSnapshot) -> str | bytes` and `def content_type(self) -> str`.
+  - `JsonEncoder` implementing it: `encode` returns `snapshot.model_dump_json(indent=2)`, `content_type` returns `"application/json"`.
+
+  **Private helpers in `snapshot.py`:**
+
+  - `_model_to_snapshot(model: WargameModel, config: ModelConfig | None) -> ModelSnapshot`: Convert entity + config to snapshot. Call `model.location.tolist()` for location (numpy→list), `model.previous_location.tolist()` if not None, read stats dict for wounds/toughness/save, build `WeaponSnapshot` list from config's weapons if config is provided.
+
+  - `_objective_to_snapshot(obj: WargameObjective) -> ObjectiveSnapshot`: `obj.location.tolist()`, `obj.radius_size`.
+
+  - `_clock_to_snapshot(state: GameState) -> ClockSnapshot`: Use `.value` on enums for string fields. Handle None fields.
+
+  - `_combat_result_to_snapshot(paired: PairedShootingResult, attacker_configs: list[ModelConfig] | None, targets: list[WargameModel]) -> CombatResultSnapshot`: Extract hits/wounds/unsaved/damage_dealt from `paired.result`. Compute analytical context: look up weapon from `attacker_configs[paired.attacker_idx].weapons[0]` (if available), build `DefenderStats` from `targets[paired.target_idx]`, call `expected_damage()` for the expected_damage field, compute `hit_probability = (7 - weapon.ballistic_skill) / 6.0`, compute `wound_probability = (7 - wound_roll_threshold(weapon.strength, defender_toughness)) / 6.0`. If weapon/config unavailable, set analytical fields to 0.0.
+
+  - `_compute_objective_control(view: BattleView) -> list[str]`: Compute per-objective ownership using `compute_distances` and `objective_ownership_from_norms_offset` from `env_components.distance_cache`. Import `alive_mask_for` from `domain.entities`. For each objective, determine label: "player", "opponent", "contested", or "none" based on whether either/both/neither side has a model within the objective radius. Follow the pattern from the research code example (check `p_any` and `o_any` for each objective). Handle the case where there are no opponent models (empty opponent_models → no opponent control).
+
+  **`build_snapshot()` factory function** — Public function that assembles a `GameStateSnapshot` from env state. Parameters: `view: BattleView`, `clock_state: GameState`, `step: int`, `max_steps: int`, `player_action: WargameEnvAction | None`, `opponent_action: WargameEnvAction | None`, `player_combat_results: list[PairedShootingResult]`, `opponent_combat_results: list[PairedShootingResult]`, `reward_total: float | None`, `reward_breakdown: dict[str, float]`, `reward_phase_name: str`, `reward_phase_index: int`, `is_terminated: bool`, `is_truncated: bool`, `attacker_configs: list[ModelConfig] | None` (player weapon configs for analytical context), `target_configs: list[ModelConfig] | None` (opponent weapon configs for their analytical context). Calls the private helpers to build each sub-model. Uses `int(x)` for any numpy scalar that might leak through. Converts deployment zones via `.tolist()`.
+
+  **wargame.py** — Add `to_snapshot()` method to `WargameEnv`:
+
+  Import `build_snapshot` and `GameStateSnapshot` from `wargame_rl.wargame.envs.state`. Add a public method `to_snapshot(self) -> GameStateSnapshot` that calls `build_snapshot()` passing all necessary state from the env: `view=self` (WargameEnv implements BattleView), `clock_state=self._game_clock.state`, `step=self.current_turn`, `max_steps=self.max_turns`, `player_action=self._last_player_action`, `opponent_action=self._last_opponent_action`, `player_combat_results=self._last_player_shooting_results`, `opponent_combat_results=self._last_opponent_shooting_results`, `reward_total=self.last_reward`, `reward_breakdown=self.last_reward_breakdown`, `reward_phase_name=self.phase_manager.current_phase_name`, `reward_phase_index=self.phase_manager.current_phase_index`, `is_terminated=self._last_terminated`, `is_truncated=False`, `attacker_configs=self.config.models`, `target_configs=self.config.opponent_models`. Docstring: "Return a serialisable snapshot of the current game state."
+  </action>
+  <verify>
+    <automated>uv run pytest tests/ -x -q</automated>
+  </verify>
+  <done>envs/state/ package exists with all Pydantic models; build_snapshot converts all numpy to native Python; WargameEnv.to_snapshot() returns a GameStateSnapshot; SnapshotEncoder protocol and JsonEncoder exist; all existing tests still pass</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 3: Snapshot integration tests</name>
+  <files>tests/test_snapshot.py</files>
+  <read_first>
+    wargame_rl/wargame/envs/state/snapshot.py,
+    wargame_rl/wargame/envs/wargame.py,
+    tests/conftest.py,
+    tests/test_shooting_resolution.py
+  </read_first>
+  <behavior>
+    - test_to_snapshot_after_reset: env.reset(); snapshot = env.to_snapshot(); snapshot is GameStateSnapshot with correct board dimensions, entity counts, clock in battle phase
+    - test_to_snapshot_after_step: env.step(action); snapshot has step >= 1, player_actions is not None
+    - test_json_serialisation: snapshot.model_dump_json() produces valid JSON parseable by json.loads; no numpy types in the output
+    - test_json_schema: GameStateSnapshot.model_json_schema() returns a dict with "properties" key
+    - test_combat_results_have_pairing: env with opponents in shooting phase; snapshot.player_combat_results entries have attacker_idx, target_idx, and analytical fields (expected_damage, hit_probability, wound_probability)
+    - test_opponent_actions_recorded: env with opponents; after step, snapshot.opponent_actions is not None (list of ints)
+    - test_reward_breakdown_in_snapshot: snapshot.reward.breakdown is a dict; snapshot.reward.phase_name is a non-empty string; snapshot.reward.phase_index >= 0
+    - test_objective_control: snapshot.objective_control is a list of strings, each in {"player", "opponent", "contested", "none"}
+    - test_schema_version: snapshot.schema_version == "1.0"
+    - test_encoder_protocol: JsonEncoder().encode(snapshot) produces valid JSON string; JsonEncoder().content_type() == "application/json"
+  </behavior>
+  <action>
+  Create `tests/test_snapshot.py` with a test fixture and integration tests.
+
+  **Fixture: `shooting_env`** — An env configured with opponents and weapons so shooting can occur. Use `WargameEnvConfig` with: `number_of_wargame_models=2`, `number_of_opponent_models=2`, `number_of_objectives=1`, `number_of_battle_rounds=5`, `render_mode=None`, `skip_phases=[]` (enable all phases so shooting phase is reached), fixed positions for models and opponents (use `models` and `opponent_models` with explicit x/y so they are in weapon range), weapon profiles on both sides (e.g. `WeaponProfile(range=20, attacks=2, ballistic_skill=3, strength=4, ap=1, damage=1)`). Use `turn_order="player"` so player acts first.
+
+  **Tests:**
+
+  1. `test_to_snapshot_after_reset` — Reset env, call `to_snapshot()`. Assert: returns `GameStateSnapshot`, `board_width`/`board_height` match config, `len(player_models)` and `len(opponent_models)` match config, `step == 0`, `is_terminated is False`, `player_actions is None`.
+
+  2. `test_to_snapshot_after_step` — Reset, step with a sampled action. Assert: `step >= 1`, `player_actions is not None`, `len(player_actions)` matches model count.
+
+  3. `test_json_serialisation` — Call `to_snapshot()`, then `model_dump_json()`. Parse with `json.loads()`. Assert no exception, result is a dict. Also verify no numpy types by checking `isinstance` of nested values (spot-check location fields are plain lists of int).
+
+  4. `test_json_schema` — Call `GameStateSnapshot.model_json_schema()`. Assert result is a dict with `"properties"` and `"title"` keys.
+
+  5. `test_combat_results_have_pairing` — Use the `shooting_env` fixture. Step through phases until the shooting phase is reached (check `env._game_clock.state.phase == BattlePhase.shooting`), then step with shooting actions targeting opponents. Call `to_snapshot()`. If `player_combat_results` is non-empty, assert each entry has `attacker_idx >= 0`, `target_idx >= 0`, `expected_damage >= 0.0`, and `0 <= hit_probability <= 1.0`.
+
+  6. `test_opponent_actions_recorded` — Use the `shooting_env` fixture. Reset and step to trigger opponent action. Assert `snapshot.opponent_actions is not None` and is a list of ints.
+
+  7. `test_reward_breakdown_in_snapshot` — Reset, step. Assert `snapshot.reward.phase_name` is a non-empty string, `snapshot.reward.phase_index >= 0`, `isinstance(snapshot.reward.breakdown, dict)`.
+
+  8. `test_objective_control` — Reset, snapshot. Assert `snapshot.objective_control` is a list, length matches objective count, each element is one of `"player"`, `"opponent"`, `"contested"`, `"none"`.
+
+  9. `test_schema_version` — `snapshot.schema_version == "1.0"`.
+
+  10. `test_encoder` — `JsonEncoder().encode(snapshot)` returns a string parseable by `json.loads`; `JsonEncoder().content_type() == "application/json"`.
+
+  Use `@pytest.fixture` for env setup. Use `seed=42` in `reset()` for determinism. For the shooting test, if combat doesn't trigger due to RNG, assert the structure is correct (empty list is valid — the structural test on a result only runs if results are non-empty).
+  </action>
+  <verify>
+    <automated>uv run pytest tests/test_snapshot.py -v</automated>
+  </verify>
+  <done>All snapshot tests pass; SGS-01 (canonical model), SGS-04 (JSON + encoder), SGS-11 (combat pairing + analytical context), SGS-12 (opponent actions recorded), SGS-14 (reward breakdown + phase name) are verified</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+No new trust boundaries introduced. The snapshot model is an internal read-only projection of existing env state. No external input, no network, no user-supplied data enters through the snapshot path.
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-v9-01-01 | Information Disclosure | `model_dump_json()` output | accept | Snapshot is designed for full-state export; no secrets or PII exist in game state |
+| T-v9-01-02 | Tampering | numpy scalar types in JSON | mitigate | Convert all numpy types to native Python at construction time in `build_snapshot`; test verifies `json.loads()` round-trips cleanly |
+</threat_model>
+
+<verification>
+- `uv run pytest tests/test_snapshot.py -v` — all snapshot tests pass
+- `uv run pytest tests/test_shooting_resolution.py -x -q` — existing shooting tests pass with PairedShootingResult
+- `uv run pytest tests/ -x -q` — full test suite passes (no regressions)
+- `uv run ruff check wargame_rl/wargame/envs/state/ wargame_rl/wargame/envs/domain/shooting.py wargame_rl/wargame/envs/wargame.py` — no lint errors
+- `uv run ruff format --check wargame_rl/wargame/envs/state/ wargame_rl/wargame/envs/domain/shooting.py wargame_rl/wargame/envs/wargame.py` — already formatted
+</verification>
+
+<success_criteria>
+- `WargameEnv.to_snapshot()` returns a `GameStateSnapshot` after both `reset()` and `step()`
+- `snapshot.model_dump_json()` produces valid JSON with no numpy types (parseable by `json.loads`)
+- `GameStateSnapshot.model_json_schema()` produces a JSON Schema with all field definitions
+- Combat results contain `attacker_idx`, `target_idx`, `expected_damage`, `hit_probability`, `wound_probability`
+- Opponent actions are stored before application and appear as `list[int]` in the snapshot
+- Reward snapshot includes `breakdown` dict, `phase_name` string, and `phase_index` int
+- `SnapshotEncoder` protocol exists; `JsonEncoder` produces valid JSON
+- `schema_version == "1.0"` on every snapshot
+- All existing tests pass without modification (except `test_shooting_resolution.py` updated for `PairedShootingResult`)
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/v9-01-canonical-state-model/v9-01-01-SUMMARY.md`
+</output>

--- a/.planning/v9-ROADMAP.md
+++ b/.planning/v9-ROADMAP.md
@@ -1,0 +1,78 @@
+# Roadmap: Structured Game State & LLM-Readable Representation
+
+## Overview
+
+This milestone adds programmatic state I/O and LLM-interpretable representation to the wargame environment. The codebase already contains rich structured data at every step — entity positions and wounds, game clock state, combat results, detailed reward breakdowns, and decodable action indices — but none of it is surfaced outside the RL tensor pipeline. This milestone builds a Pydantic-based canonical state model (`GameStateSnapshot`), bidirectional I/O (export and injection), and a text narration layer for LLM evaluation.
+
+The build order follows dependency: the canonical schema first (everything depends on it), then state injection (the "input" side of bidirectional I/O), then LLM text (builds on the data captured in the snapshot). Event streaming and replay are deferred — they require a stable schema and are lower priority than the user's core goals of bidirectional state I/O and LLM-interpretable representation.
+
+## Phases
+
+- [ ] **Phase 1: Canonical State Model & Export** — Pydantic `GameStateSnapshot` projected from `BattleView`, JSON serialisation, `WargameEnv.to_snapshot()`, combat/action metadata capture
+- [ ] **Phase 2: State Injection & Bidirectional I/O** — `GameClock.set_state()`, `WargameEnv.load_state(snapshot)`, validation, derive computed fields from injected state
+- [ ] **Phase 3: LLM-Readable Text Representation** — Action descriptions, combat narrative, step narrator, reward breakdown text for LLM evaluation
+- [ ] ~~**Phase 4: Event Streaming & Replay**~~ — Deferred: append-only event log, delta encoding, deterministic replay, pluggable codec interface
+
+## Phase Details
+
+### Phase 1: Canonical State Model & Export
+**Goal**: The full game state is available as a structured, serialisable Pydantic model that can be exported to JSON at any point during an episode
+**Depends on**: Nothing (first phase)
+**Requirements**: SGS-01, SGS-04, SGS-11, SGS-12, SGS-14
+**Success Criteria** (what must be TRUE):
+  1. `WargameEnv.to_snapshot()` returns a `GameStateSnapshot` Pydantic model containing board, entities, clock, VP, combat results, actions taken, and reward breakdown
+  2. `snapshot.model_dump_json()` produces valid JSON with all numpy arrays converted to native Python types — parseable by any JSON consumer
+  3. `GameStateSnapshot.model_json_schema()` produces a JSON Schema document describing the state structure (usable as LLM tool parameter schema)
+  4. Combat results include attacker-target pairing (which model shot which target) — not just flat `ShootingResult` lists
+  5. Opponent actions are recorded before application and available in the snapshot
+**Plans:** 1 plan
+Plans:
+- [ ] v9-01-01-PLAN.md — Snapshot Pydantic models, PairedShootingResult, build_snapshot factory, to_snapshot(), encoder protocol, tests
+
+### Phase 2: State Injection & Bidirectional I/O
+**Goal**: An arbitrary game state can be constructed from a snapshot, enabling scenario testing, LLM-driven evaluation, and programmatic game setup
+**Depends on**: Phase 1
+**Requirements**: SGS-07, SGS-08, SGS-09
+**Success Criteria** (what must be TRUE):
+  1. `WargameEnv.load_state(snapshot)` sets clock, entity positions/wounds, VP, and recomputes derived state (distances, action masks) — the env is ready for `step()` immediately after
+  2. `GameClock.set_state()` can position the clock at any valid round/phase/player combination
+  3. Round-trip fidelity: `env.to_snapshot()` → `env.load_state(snapshot)` → `env.to_snapshot()` produces identical output (excluding derived-only fields)
+  4. `validate_snapshot(snapshot, config)` rejects snapshots that violate hard constraints (locations out of bounds, wounds out of range, entity count mismatch, invalid clock state)
+**Plans**: TBD
+
+### Phase 3: LLM-Readable Text Representation
+**Goal**: An LLM can read a structured text summary of any game step and judge whether the RL agent's actions are tactically sound
+**Depends on**: Phase 1
+**Requirements**: SGS-02, SGS-10, SGS-13
+**Success Criteria** (what must be TRUE):
+  1. `describe_action(action_int, model_idx, phase)` returns human-readable text (e.g. "Move NE at speed 4" or "Shoot at opponent 1") with correct compass direction mapping for all 16 angles
+  2. `StepNarrator` produces per-step text summaries covering: state before action, decoded actions, combat narrative with hit/wound/save probabilities, reward breakdown with phase context, and state after
+  3. Combat narrative includes analytical context: expected damage per target, wound threshold, modified save — enough for an LLM to evaluate whether the agent chose the optimal target
+  4. Reward breakdown text includes the active reward phase name — without this, reward values are uninterpretable to an LLM
+**Plans**: TBD
+
+### Phase 4: Event Streaming & Replay (Deferred)
+**Goal**: A complete match history can be recorded as an ordered event stream and replayed deterministically
+**Depends on**: Phase 1 (stable schema)
+**Requirements**: SGS-03, SGS-05, SGS-06
+**Success Criteria** (what must be TRUE):
+  1. A `StateExporter` protocol with `on_reset()` / `on_step()` hooks produces an append-only event log recording the full match
+  2. Delta encoding represents state updates efficiently (full snapshots at anchors, granular deltas between them)
+  3. Deterministic replay: applying the event log from a known initial configuration reconstructs any requested historical state
+  4. A pluggable formatter registry (extending SGS-04) allows alternative encodings behind a shared codec interface
+**Note**: This phase is deferred — not planned for immediate execution. SGS-03, SGS-05, SGS-06 are lower priority per user direction. The schema must stabilise through Phases 1–3 before building streaming and replay on top of it.
+**Plans**: TBD
+
+## Progress
+
+**Execution Order:**
+Phases execute in numeric order: 1 → 2 → 3
+(Phases 2 and 3 are independent after Phase 1 and can execute in parallel)
+Phase 4 is deferred.
+
+| Phase | Plans Complete | Status | Completed |
+|-------|----------------|--------|-----------|
+| 1. Canonical State Model & Export | 0/1 | Planned | - |
+| 2. State Injection & Bidirectional I/O | 0/0 | Not started | - |
+| 3. LLM-Readable Text Representation | 0/0 | Not started | - |
+| 4. Event Streaming & Replay | - | Deferred | - |

--- a/tests/test_narrator.py
+++ b/tests/test_narrator.py
@@ -1,0 +1,161 @@
+"""Tests for StepNarrator and public describe_action API."""
+
+from __future__ import annotations
+
+import pytest
+
+from wargame_rl.wargame.envs.env_components.actions import STAY_ACTION
+from wargame_rl.wargame.envs.state.narrator import StepNarrator
+from wargame_rl.wargame.envs.state.snapshot import describe_action
+from wargame_rl.wargame.envs.types import TurnOrder, WargameEnvAction, WargameEnvConfig
+from wargame_rl.wargame.envs.types.config import (
+    ModelConfig,
+    OpponentPolicyConfig,
+    WeaponProfile,
+)
+from wargame_rl.wargame.envs.types.game_timing import BattlePhase
+from wargame_rl.wargame.envs.wargame import WargameEnv
+
+
+@pytest.fixture
+def shooting_env() -> WargameEnv:
+    cfg = WargameEnvConfig(
+        board_width=30,
+        board_height=30,
+        number_of_wargame_models=2,
+        number_of_objectives=1,
+        number_of_opponent_models=2,
+        models=[
+            ModelConfig(
+                x=5,
+                y=5,
+                max_wounds=3,
+                weapons=[
+                    WeaponProfile(
+                        range=50,
+                        attacks=4,
+                        ballistic_skill=2,
+                        strength=8,
+                        ap=2,
+                        damage=2,
+                    )
+                ],
+            ),
+            ModelConfig(
+                x=6,
+                y=5,
+                max_wounds=3,
+                weapons=[
+                    WeaponProfile(
+                        range=50,
+                        attacks=4,
+                        ballistic_skill=2,
+                        strength=8,
+                        ap=2,
+                        damage=2,
+                    )
+                ],
+            ),
+        ],
+        opponent_models=[
+            ModelConfig(x=20, y=5, max_wounds=3, weapons=[WeaponProfile(range=50)]),
+            ModelConfig(x=21, y=5, max_wounds=3, weapons=[WeaponProfile(range=50)]),
+        ],
+        opponent_policy=OpponentPolicyConfig(type="random"),
+        turn_order=TurnOrder.player,
+        skip_phases=[BattlePhase.command, BattlePhase.charge, BattlePhase.fight],
+        n_movement_angles=8,
+        n_speed_bins=3,
+    )
+    return WargameEnv(config=cfg)
+
+
+class TestNarrateAfterReset:
+    def test_narrate_produces_sections(self, shooting_env: WargameEnv) -> None:
+        shooting_env.reset(seed=42)
+        snap = shooting_env.to_snapshot()
+        narrator = StepNarrator()
+        text = narrator.narrate(snap)
+
+        assert "===" in text
+        assert "BOARD:" in text
+        assert "FORCE STATUS:" in text
+        assert "PLAYER MODELS:" in text
+        assert "OBJECTIVES:" in text
+        assert "REWARD" in text
+        assert "STATUS:" in text
+
+
+class TestNarrateAfterShooting:
+    def test_combat_section_present(self, shooting_env: WargameEnv) -> None:
+        shooting_env.reset(seed=42)
+        n = len(shooting_env.wargame_models)
+        shooting_env.step(WargameEnvAction(actions=[STAY_ACTION] * n))
+
+        ss = shooting_env._action_handler.shooting_slice
+        assert ss is not None
+        shooting_env.step(WargameEnvAction(actions=[ss.start, ss.start + 1]))
+
+        snap = shooting_env.to_snapshot()
+        narrator = StepNarrator()
+        text = narrator.narrate(snap)
+
+        assert "COMBAT:" in text
+        assert "expected" in text
+        assert "% hit" in text
+        assert "% wound" in text
+
+
+class TestNarrateRewardPhase:
+    def test_includes_reward_phase_name(self, shooting_env: WargameEnv) -> None:
+        shooting_env.reset(seed=42)
+        n = len(shooting_env.wargame_models)
+        shooting_env.step(WargameEnvAction(actions=[STAY_ACTION] * n))
+
+        snap = shooting_env.to_snapshot()
+        narrator = StepNarrator()
+        text = narrator.narrate(snap)
+
+        assert snap.reward.phase_name in text
+
+
+class TestNarrateForceBalance:
+    def test_includes_alive_counts(self, shooting_env: WargameEnv) -> None:
+        shooting_env.reset(seed=42)
+        snap = shooting_env.to_snapshot()
+        narrator = StepNarrator()
+        text = narrator.narrate(snap)
+
+        assert f"{snap.player_alive_count} alive" in text
+        assert f"{snap.opponent_alive_count} alive" in text
+        assert f"{snap.player_total_wounds} wounds" in text
+
+
+class TestDescribeActionPublic:
+    @pytest.mark.parametrize(
+        "action,expected",
+        [
+            (0, "Stay"),
+        ],
+    )
+    def test_stay(self, action: int, expected: str) -> None:
+        result = describe_action(action, 8, 3, None, None)
+        assert result == expected
+
+    def test_move(self) -> None:
+        result = describe_action(1, 8, 3, None, None)
+        assert "Move" in result
+        assert "speed" in result
+
+    def test_shoot(self) -> None:
+        result = describe_action(25, 8, 3, 25, 27)
+        assert result == "Shoot at opponent 0"
+
+    def test_compass_directions_8_angles(self) -> None:
+        directions = []
+        for angle_idx in range(8):
+            action = 1 + angle_idx * 3
+            desc = describe_action(action, 8, 3, None, None)
+            direction = desc.split("Move ")[1].split(" at")[0]
+            directions.append(direction)
+        assert directions == ["E", "NE", "N", "NW", "W", "SW", "S", "SE"]

--- a/tests/test_state_injection.py
+++ b/tests/test_state_injection.py
@@ -1,0 +1,343 @@
+"""Tests for state injection: GameClock.set_state, validate_snapshot, load_state, round-trip."""
+
+from __future__ import annotations
+
+import pytest
+
+from wargame_rl.wargame.envs.domain.game_clock import GameClock, GameClockError
+from wargame_rl.wargame.envs.env_components.actions import STAY_ACTION
+from wargame_rl.wargame.envs.state.snapshot import validate_snapshot
+from wargame_rl.wargame.envs.types import TurnOrder, WargameEnvAction, WargameEnvConfig
+from wargame_rl.wargame.envs.types.config import (
+    ModelConfig,
+    OpponentPolicyConfig,
+    WeaponProfile,
+)
+from wargame_rl.wargame.envs.types.game_timing import (
+    BattlePhase,
+    GamePhase,
+    PlayerSide,
+    SetupPhase,
+)
+from wargame_rl.wargame.envs.wargame import WargameEnv
+
+
+@pytest.fixture
+def env() -> WargameEnv:
+    """Env with opponents, weapons, and movement+shooting phases."""
+    cfg = WargameEnvConfig(
+        board_width=30,
+        board_height=30,
+        number_of_wargame_models=2,
+        number_of_objectives=1,
+        number_of_opponent_models=2,
+        models=[
+            ModelConfig(
+                x=5,
+                y=5,
+                max_wounds=3,
+                weapons=[
+                    WeaponProfile(
+                        range=50,
+                        attacks=4,
+                        ballistic_skill=2,
+                        strength=8,
+                        ap=2,
+                        damage=2,
+                    )
+                ],
+            ),
+            ModelConfig(
+                x=6,
+                y=5,
+                max_wounds=3,
+                weapons=[
+                    WeaponProfile(
+                        range=50,
+                        attacks=4,
+                        ballistic_skill=2,
+                        strength=8,
+                        ap=2,
+                        damage=2,
+                    )
+                ],
+            ),
+        ],
+        opponent_models=[
+            ModelConfig(
+                x=20,
+                y=5,
+                max_wounds=3,
+                weapons=[WeaponProfile(range=50)],
+            ),
+            ModelConfig(
+                x=21,
+                y=5,
+                max_wounds=3,
+                weapons=[WeaponProfile(range=50)],
+            ),
+        ],
+        opponent_policy=OpponentPolicyConfig(type="random"),
+        turn_order=TurnOrder.player,
+        skip_phases=[BattlePhase.command, BattlePhase.charge, BattlePhase.fight],
+        n_movement_angles=8,
+        n_speed_bins=3,
+    )
+    return WargameEnv(config=cfg)
+
+
+# ---------------------------------------------------------------------------
+# GameClock.set_state
+# ---------------------------------------------------------------------------
+
+
+class TestClockSetState:
+    def test_set_to_battle_round_2_shooting(self) -> None:
+        clock = GameClock(n_rounds=5)
+        state = clock.set_state(
+            GamePhase.battle,
+            battle_round=2,
+            active_player=PlayerSide.player_1,
+            phase=BattlePhase.shooting,
+            total_steps=10,
+        )
+        assert state.game_phase is GamePhase.battle
+        assert state.battle_round == 2
+        assert state.active_player is PlayerSide.player_1
+        assert state.phase is BattlePhase.shooting
+        assert clock.total_steps == 10
+
+    def test_set_to_setup(self) -> None:
+        clock = GameClock(n_rounds=5)
+        clock.skip_setup()
+        state = clock.set_state(
+            GamePhase.setup,
+            setup_phase=SetupPhase.deploy_armies,
+        )
+        assert state.game_phase is GamePhase.setup
+        assert state.setup_phase is SetupPhase.deploy_armies
+
+    def test_set_to_complete(self) -> None:
+        clock = GameClock(n_rounds=5)
+        state = clock.set_state(GamePhase.complete)
+        assert state.game_phase is GamePhase.complete
+        assert clock.is_game_over
+
+    def test_battle_missing_round_raises(self) -> None:
+        clock = GameClock(n_rounds=5)
+        with pytest.raises(GameClockError, match="battle_round.*required"):
+            clock.set_state(
+                GamePhase.battle,
+                active_player=PlayerSide.player_1,
+                phase=BattlePhase.movement,
+            )
+
+    def test_battle_round_out_of_range_raises(self) -> None:
+        clock = GameClock(n_rounds=5)
+        with pytest.raises(GameClockError, match="battle_round must be in"):
+            clock.set_state(
+                GamePhase.battle,
+                battle_round=6,
+                active_player=PlayerSide.player_1,
+                phase=BattlePhase.movement,
+            )
+
+    def test_setup_missing_phase_raises(self) -> None:
+        clock = GameClock(n_rounds=5)
+        with pytest.raises(GameClockError, match="setup_phase is required"):
+            clock.set_state(GamePhase.setup)
+
+    def test_advance_works_after_set_state(self) -> None:
+        clock = GameClock(n_rounds=5)
+        clock.set_state(
+            GamePhase.battle,
+            battle_round=3,
+            active_player=PlayerSide.player_1,
+            phase=BattlePhase.command,
+            total_steps=20,
+        )
+        state = clock.advance_phase()
+        assert state.phase is BattlePhase.movement
+        assert clock.total_steps == 21
+
+
+# ---------------------------------------------------------------------------
+# validate_snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestValidateSnapshot:
+    def test_valid_snapshot_passes(self, env: WargameEnv) -> None:
+        env.reset(seed=42)
+        snap = env.to_snapshot()
+        errors = validate_snapshot(snap, env.config)
+        assert errors == []
+
+    def test_wrong_player_model_count(self, env: WargameEnv) -> None:
+        env.reset(seed=42)
+        snap = env.to_snapshot()
+        bad = snap.model_copy(update={"player_models": snap.player_models[:1]})
+        errors = validate_snapshot(bad, env.config)
+        assert any("player models" in e for e in errors)
+
+    def test_wrong_opponent_model_count(self, env: WargameEnv) -> None:
+        env.reset(seed=42)
+        snap = env.to_snapshot()
+        bad = snap.model_copy(update={"opponent_models": []})
+        errors = validate_snapshot(bad, env.config)
+        assert any("opponent models" in e for e in errors)
+
+    def test_out_of_bounds_location(self, env: WargameEnv) -> None:
+        env.reset(seed=42)
+        snap = env.to_snapshot()
+        bad_models = [m.model_copy() for m in snap.player_models]
+        bad_models[0] = bad_models[0].model_copy(update={"location": [99, 99]})
+        bad = snap.model_copy(update={"player_models": bad_models})
+        errors = validate_snapshot(bad, env.config)
+        assert any("out of bounds" in e for e in errors)
+
+    def test_wounds_out_of_range(self, env: WargameEnv) -> None:
+        env.reset(seed=42)
+        snap = env.to_snapshot()
+        bad_models = [m.model_copy() for m in snap.player_models]
+        bad_models[0] = bad_models[0].model_copy(update={"current_wounds": 999})
+        bad = snap.model_copy(update={"player_models": bad_models})
+        errors = validate_snapshot(bad, env.config)
+        assert any("current_wounds" in e for e in errors)
+
+    def test_invalid_step(self, env: WargameEnv) -> None:
+        env.reset(seed=42)
+        snap = env.to_snapshot()
+        bad = snap.model_copy(update={"step": -1})
+        errors = validate_snapshot(bad, env.config)
+        assert any("step=" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# WargameEnv.load_state
+# ---------------------------------------------------------------------------
+
+
+class TestLoadState:
+    def test_load_after_reset(self, env: WargameEnv) -> None:
+        env.reset(seed=42)
+        snap = env.to_snapshot()
+        obs, info = env.load_state(snap)
+        assert obs is not None
+        assert isinstance(info, dict)
+
+    def test_models_at_expected_positions(self, env: WargameEnv) -> None:
+        env.reset(seed=42)
+        snap = env.to_snapshot()
+        env.reset(seed=99)
+        env.load_state(snap)
+
+        for i, ms in enumerate(snap.player_models):
+            assert list(env.wargame_models[i].location) == ms.location
+        for i, ms in enumerate(snap.opponent_models):
+            assert list(env.opponent_models[i].location) == ms.location
+
+    def test_wounds_restored(self, env: WargameEnv) -> None:
+        env.reset(seed=42)
+        snap = env.to_snapshot()
+        bad_models = [m.model_copy() for m in snap.player_models]
+        bad_models[0] = bad_models[0].model_copy(update={"current_wounds": 1})
+        modified_snap = snap.model_copy(update={"player_models": bad_models})
+        env.load_state(modified_snap)
+        assert env.wargame_models[0].stats["current_wounds"] == 1
+
+    def test_vp_restored(self, env: WargameEnv) -> None:
+        env.reset(seed=42)
+        snap = env.to_snapshot()
+        modified_snap = snap.model_copy(update={"player_vp": 10, "opponent_vp": 5})
+        env.load_state(modified_snap)
+        assert env.player_vp == 10
+        assert env.opponent_vp == 5
+
+    def test_invalid_snapshot_raises(self, env: WargameEnv) -> None:
+        env.reset(seed=42)
+        snap = env.to_snapshot()
+        bad = snap.model_copy(update={"player_models": []})
+        with pytest.raises(ValueError, match="Invalid snapshot"):
+            env.load_state(bad)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip fidelity
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    def test_round_trip_after_reset(self, env: WargameEnv) -> None:
+        env.reset(seed=42)
+        snap1 = env.to_snapshot()
+        env.load_state(snap1)
+        snap2 = env.to_snapshot()
+
+        assert snap1.model_dump() == snap2.model_dump()
+
+    def test_round_trip_after_step(self, env: WargameEnv) -> None:
+        env.reset(seed=42)
+        n = len(env.wargame_models)
+        env.step(WargameEnvAction(actions=[STAY_ACTION] * n))
+        snap1 = env.to_snapshot()
+
+        env.reset(seed=99)
+        env.load_state(snap1)
+        snap2 = env.to_snapshot()
+
+        assert snap1.model_dump() == snap2.model_dump()
+
+    def test_round_trip_with_shooting(self, env: WargameEnv) -> None:
+        env.reset(seed=42)
+        n = len(env.wargame_models)
+        env.step(WargameEnvAction(actions=[STAY_ACTION] * n))
+
+        ss = env._action_handler.shooting_slice
+        assert ss is not None
+        env.step(WargameEnvAction(actions=[ss.start, ss.start + 1]))
+        snap1 = env.to_snapshot()
+
+        env.reset(seed=99)
+        env.load_state(snap1)
+        snap2 = env.to_snapshot()
+
+        assert snap1.model_dump() == snap2.model_dump()
+
+
+# ---------------------------------------------------------------------------
+# Load state then step
+# ---------------------------------------------------------------------------
+
+
+class TestLoadStateThenStep:
+    def test_step_after_load(self, env: WargameEnv) -> None:
+        """Env is steppable immediately after load_state."""
+        env.reset(seed=42)
+        snap = env.to_snapshot()
+
+        env.reset(seed=99)
+        env.load_state(snap)
+
+        n = len(env.wargame_models)
+        obs, reward, terminated, truncated, info = env.step(
+            WargameEnvAction(actions=[STAY_ACTION] * n)
+        )
+        assert obs is not None
+        assert isinstance(reward, float)
+
+    def test_step_produces_valid_snapshot(self, env: WargameEnv) -> None:
+        """A snapshot taken after load+step is also valid."""
+        env.reset(seed=42)
+        snap = env.to_snapshot()
+
+        env.reset(seed=99)
+        env.load_state(snap)
+
+        n = len(env.wargame_models)
+        env.step(WargameEnvAction(actions=[STAY_ACTION] * n))
+        snap2 = env.to_snapshot()
+
+        errors = validate_snapshot(snap2, env.config)
+        assert errors == []
+        assert snap2.step == snap.step + 1

--- a/wargame_rl/wargame/envs/domain/game_clock.py
+++ b/wargame_rl/wargame/envs/domain/game_clock.py
@@ -12,6 +12,7 @@ from wargame_rl.wargame.envs.types.game_timing import (
     GamePhase,
     GameState,
     PlayerSide,
+    SetupPhase,
 )
 
 
@@ -100,6 +101,50 @@ class GameClock:
         self._active_player = self._first_player
         self._phase_idx = 0
         self._total_steps = 0
+        return self.state
+
+    # -- State injection -------------------------------------------------------
+
+    def set_state(
+        self,
+        game_phase: GamePhase,
+        *,
+        battle_round: int | None = None,
+        active_player: PlayerSide | None = None,
+        phase: BattlePhase | None = None,
+        setup_phase: SetupPhase | None = None,
+        total_steps: int = 0,
+    ) -> GameState:
+        """Position the clock at an arbitrary valid state.
+
+        Used by ``WargameEnv.load_state()`` to restore a mid-episode clock
+        position from a snapshot.
+        """
+        if game_phase is GamePhase.battle:
+            if battle_round is None or active_player is None or phase is None:
+                raise GameClockError(
+                    "battle_round, active_player, and phase are required "
+                    "when game_phase is battle"
+                )
+            if battle_round < 1 or battle_round > self._n_rounds:
+                raise GameClockError(
+                    f"battle_round must be in [1, {self._n_rounds}], got {battle_round}"
+                )
+            self._game_phase = GamePhase.battle
+            self._round = battle_round
+            self._active_player = active_player
+            self._phase_idx = BATTLE_PHASE_ORDER.index(phase)
+        elif game_phase is GamePhase.setup:
+            if setup_phase is None:
+                raise GameClockError("setup_phase is required when game_phase is setup")
+            self._game_phase = GamePhase.setup
+            self._setup_idx = SETUP_PHASE_ORDER.index(setup_phase)
+        elif game_phase is GamePhase.complete:
+            self._game_phase = GamePhase.complete
+        else:
+            raise GameClockError(f"Unknown game_phase: {game_phase}")
+
+        self._total_steps = total_steps
         return self.state
 
     # -- Setup navigation -----------------------------------------------------

--- a/wargame_rl/wargame/envs/state/__init__.py
+++ b/wargame_rl/wargame/envs/state/__init__.py
@@ -7,6 +7,7 @@ from wargame_rl.wargame.envs.state.snapshot import (
     JsonEncoder,
     SnapshotEncoder,
     build_snapshot,
+    validate_snapshot,
 )
 
 __all__ = [
@@ -14,4 +15,5 @@ __all__ = [
     "JsonEncoder",
     "SnapshotEncoder",
     "build_snapshot",
+    "validate_snapshot",
 ]

--- a/wargame_rl/wargame/envs/state/__init__.py
+++ b/wargame_rl/wargame/envs/state/__init__.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from wargame_rl.wargame.envs.state.narrator import StepNarrator
 from wargame_rl.wargame.envs.state.snapshot import (
     GameStateSnapshot,
     JsonEncoder,
     SnapshotEncoder,
     build_snapshot,
+    describe_action,
     validate_snapshot,
 )
 
@@ -14,6 +16,8 @@ __all__ = [
     "GameStateSnapshot",
     "JsonEncoder",
     "SnapshotEncoder",
+    "StepNarrator",
     "build_snapshot",
+    "describe_action",
     "validate_snapshot",
 ]

--- a/wargame_rl/wargame/envs/state/narrator.py
+++ b/wargame_rl/wargame/envs/state/narrator.py
@@ -1,0 +1,160 @@
+"""StepNarrator: produce LLM-readable text summaries from a GameStateSnapshot.
+
+Operates purely on snapshot data — no env or config dependency.
+"""
+
+from __future__ import annotations
+
+from wargame_rl.wargame.envs.state.snapshot import (
+    CombatResultSnapshot,
+    GameStateSnapshot,
+    ModelSnapshot,
+    ObjectiveSnapshot,
+)
+
+
+class StepNarrator:
+    """Produces structured text summaries of game steps for LLM consumption."""
+
+    def narrate(self, snapshot: GameStateSnapshot) -> str:
+        """Produce a full text summary of the game state at this step."""
+        sections = [
+            self._header(snapshot),
+            self._board(snapshot),
+            self._force_status(snapshot),
+            self._models(snapshot),
+            self._objectives(snapshot),
+            self._actions(snapshot),
+            self._combat(snapshot),
+            self._reward(snapshot),
+            self._status(snapshot),
+        ]
+        return "\n\n".join(s for s in sections if s)
+
+    def _header(self, s: GameStateSnapshot) -> str:
+        clock = s.clock
+        parts = [f"Step {s.step} / {s.max_steps}"]
+        if clock.battle_round is not None:
+            parts.append(f"Round {clock.battle_round}")
+        if clock.battle_phase is not None:
+            parts.append(clock.battle_phase.replace("_", " ").title())
+        if clock.active_player is not None:
+            parts.append(clock.active_player.replace("_", " ").title())
+        return f"=== {' | '.join(parts)} ==="
+
+    def _board(self, s: GameStateSnapshot) -> str:
+        return f"BOARD: {s.board_width}x{s.board_height} | Mission: {s.mission_type}"
+
+    def _force_status(self, s: GameStateSnapshot) -> str:
+        lines = ["FORCE STATUS:"]
+        lines.append(
+            f"  Player: {s.player_alive_count} alive "
+            f"({s.player_total_wounds} wounds) | "
+            f"Opponent: {s.opponent_alive_count} alive "
+            f"({s.opponent_total_wounds} wounds)"
+        )
+        lines.append(f"  Player VP: {s.player_vp} | Opponent VP: {s.opponent_vp}")
+        return "\n".join(lines)
+
+    def _model_line(self, idx: int, m: ModelSnapshot) -> str:
+        status = "Alive" if m.alive else "Dead"
+        wound_str = f"{m.current_wounds}/{m.max_wounds} wounds"
+        pos = f"({m.location[0]}, {m.location[1]})"
+        parts = [f"  Model {idx} [{status} {wound_str}] at {pos}"]
+        if m.alive and m.closest_objective_idx is not None:
+            dist = (
+                f"{m.closest_objective_distance:.1f}"
+                if m.closest_objective_distance is not None
+                else "?"
+            )
+            parts.append(
+                f"nearest objective: Obj {m.closest_objective_idx} ({dist} away)"
+            )
+        return " — ".join(parts)
+
+    def _models(self, s: GameStateSnapshot) -> str:
+        lines = ["PLAYER MODELS:"]
+        for i, m in enumerate(s.player_models):
+            lines.append(self._model_line(i, m))
+        if s.opponent_models:
+            lines.append("")
+            lines.append("OPPONENT MODELS:")
+            for i, m in enumerate(s.opponent_models):
+                lines.append(self._model_line(i, m))
+        return "\n".join(lines)
+
+    def _objectives(self, s: GameStateSnapshot) -> str:
+        lines = ["OBJECTIVES:"]
+        for i, o in enumerate(s.objectives):
+            ctrl = s.objective_control[i] if i < len(s.objective_control) else "?"
+            pos = f"({o.location[0]}, {o.location[1]})"
+            in_range = self._models_in_range_str(o)
+            lines.append(f"  Obj {i} at {pos} — {ctrl} | {in_range}")
+        return "\n".join(lines)
+
+    def _models_in_range_str(self, o: ObjectiveSnapshot) -> str:
+        parts: list[str] = []
+        if o.player_models_in_range:
+            ids = ", ".join(str(i) for i in o.player_models_in_range)
+            parts.append(f"player models {ids}")
+        if o.opponent_models_in_range:
+            ids = ", ".join(str(i) for i in o.opponent_models_in_range)
+            parts.append(f"opponent models {ids}")
+        return ", ".join(parts) if parts else "no models in range"
+
+    def _actions(self, s: GameStateSnapshot) -> str:
+        if not s.player_action_descriptions:
+            return ""
+        lines = ["ACTIONS TAKEN:"]
+        for i, desc in enumerate(s.player_action_descriptions):
+            lines.append(f"  Model {i}: {desc}")
+        return "\n".join(lines)
+
+    def _combat_line(self, cr: CombatResultSnapshot, side: str) -> list[str]:
+        target_side = "Opponent" if side == "Player" else "Player"
+        main = (
+            f"  {side} {cr.attacker_idx} -> {target_side} {cr.target_idx}: "
+            f"{cr.hits} hits, {cr.wounds} wounds, "
+            f"{cr.unsaved} unsaved, {cr.damage_dealt} damage dealt"
+        )
+        analytics = (
+            f"    (expected {cr.expected_damage:.2f} dmg, "
+            f"{cr.hit_probability * 100:.0f}% hit, "
+            f"{cr.wound_probability * 100:.0f}% wound)"
+        )
+        return [main, analytics]
+
+    def _combat(self, s: GameStateSnapshot) -> str:
+        if not s.player_combat_results and not s.opponent_combat_results:
+            return ""
+        lines = ["COMBAT:"]
+        for cr in s.player_combat_results:
+            lines.extend(self._combat_line(cr, "Player"))
+        for cr in s.opponent_combat_results:
+            lines.extend(self._combat_line(cr, "Opponent"))
+        return "\n".join(lines)
+
+    def _reward(self, s: GameStateSnapshot) -> str:
+        r = s.reward
+        total_str = f"{r.total:.3f}" if r.total is not None else "None"
+        lines = [f"REWARD [{r.phase_name}, phase {r.phase_index}]: {total_str}"]
+
+        top_level = {k: v for k, v in r.breakdown.items() if "/" not in k}
+        sub_level = {k: v for k, v in r.breakdown.items() if "/" in k}
+
+        for key, val in top_level.items():
+            lines.append(f"  {key}: {val:.3f}")
+            prefix = f"{key}/"
+            for sub_key, sub_val in sub_level.items():
+                if sub_key.startswith(prefix):
+                    label = sub_key[len(prefix) :]
+                    lines.append(f"    {label}: {sub_val:.3f}")
+
+        return "\n".join(lines)
+
+    def _status(self, s: GameStateSnapshot) -> str:
+        if s.is_terminated:
+            return "STATUS: Terminated"
+        if s.is_truncated:
+            return "STATUS: Truncated"
+        return "STATUS: In progress"

--- a/wargame_rl/wargame/envs/state/snapshot.py
+++ b/wargame_rl/wargame/envs/state/snapshot.py
@@ -22,11 +22,12 @@ from wargame_rl.wargame.envs.env_components.distance_cache import (
     compute_distances,
     objective_ownership_from_norms_offset,
 )
+from wargame_rl.wargame.envs.types.config import WargameEnvConfig
+from wargame_rl.wargame.envs.types.game_timing import BattlePhase, GameState
 
 if TYPE_CHECKING:
     from wargame_rl.wargame.envs.domain.entities import WargameModel, WargameObjective
-    from wargame_rl.wargame.envs.types.config import ModelConfig, WargameEnvConfig
-    from wargame_rl.wargame.envs.types.game_timing import GameState
+    from wargame_rl.wargame.envs.types.config import ModelConfig
 
 
 # ---------------------------------------------------------------------------
@@ -555,6 +556,78 @@ def build_snapshot(
         mission_type=config.mission.type,
         mission_params=mission_params,
     )
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def validate_snapshot(
+    snapshot: GameStateSnapshot,
+    config: WargameEnvConfig,
+) -> list[str]:
+    """Return a list of validation errors. Empty list means the snapshot is valid."""
+    errors: list[str] = []
+
+    if len(snapshot.player_models) != config.number_of_wargame_models:
+        errors.append(
+            f"Expected {config.number_of_wargame_models} player models, "
+            f"got {len(snapshot.player_models)}"
+        )
+    if len(snapshot.opponent_models) != config.number_of_opponent_models:
+        errors.append(
+            f"Expected {config.number_of_opponent_models} opponent models, "
+            f"got {len(snapshot.opponent_models)}"
+        )
+    if len(snapshot.objectives) != config.number_of_objectives:
+        errors.append(
+            f"Expected {config.number_of_objectives} objectives, "
+            f"got {len(snapshot.objectives)}"
+        )
+
+    bw, bh = config.board_width, config.board_height
+    for side, models in [
+        ("player", snapshot.player_models),
+        ("opponent", snapshot.opponent_models),
+    ]:
+        for i, m in enumerate(models):
+            x, y = m.location
+            if x < 0 or x >= bw or y < 0 or y >= bh:
+                errors.append(
+                    f"{side} model {i} location ({x}, {y}) out of bounds "
+                    f"[0, {bw}) x [0, {bh})"
+                )
+            if m.current_wounds < 0 or m.current_wounds > m.max_wounds:
+                errors.append(
+                    f"{side} model {i} current_wounds={m.current_wounds} "
+                    f"not in [0, {m.max_wounds}]"
+                )
+
+    for i, o in enumerate(snapshot.objectives):
+        x, y = o.location
+        if x < 0 or x >= bw or y < 0 or y >= bh:
+            errors.append(
+                f"objective {i} location ({x}, {y}) out of bounds [0, {bw}) x [0, {bh})"
+            )
+
+    clock = snapshot.clock
+    if clock.game_phase == "battle":
+        if clock.battle_round is not None:
+            n_rounds = config.number_of_battle_rounds
+            if clock.battle_round < 1 or clock.battle_round > n_rounds:
+                errors.append(
+                    f"battle_round={clock.battle_round} not in [1, {n_rounds}]"
+                )
+        if clock.battle_phase is not None:
+            valid_phases = {p.value for p in BattlePhase}
+            if clock.battle_phase not in valid_phases:
+                errors.append(f"invalid battle_phase '{clock.battle_phase}'")
+
+    if snapshot.step < 0 or snapshot.step > snapshot.max_steps:
+        errors.append(f"step={snapshot.step} not in [0, {snapshot.max_steps}]")
+
+    return errors
 
 
 # ---------------------------------------------------------------------------

--- a/wargame_rl/wargame/envs/state/snapshot.py
+++ b/wargame_rl/wargame/envs/state/snapshot.py
@@ -373,7 +373,7 @@ COMPASS_LABELS_16 = [
 ]
 
 
-def _describe_action(
+def describe_action(
     action: int,
     n_angles: int,
     n_speed_bins: int,
@@ -495,7 +495,7 @@ def build_snapshot(
     if player_action is not None and hasattr(player_action, "actions"):
         p_actions = list(player_action.actions)
         p_action_descs = [
-            _describe_action(
+            describe_action(
                 a,
                 n_angles,
                 n_speed_bins,

--- a/wargame_rl/wargame/envs/wargame.py
+++ b/wargame_rl/wargame/envs/wargame.py
@@ -23,6 +23,7 @@ from wargame_rl.wargame.envs.domain.placement import place_for_episode
 from wargame_rl.wargame.envs.domain.shooting import (
     DefenderStats,
     PairedShootingResult,
+    ShootingResult,
     resolve_shooting,
 )
 from wargame_rl.wargame.envs.domain.termination import is_battle_over
@@ -47,7 +48,11 @@ from wargame_rl.wargame.envs.opponent.registry import (
 from wargame_rl.wargame.envs.renders import renderer
 from wargame_rl.wargame.envs.reward.phase_manager import RewardPhaseManager
 from wargame_rl.wargame.envs.reward.step_context import StepContext
-from wargame_rl.wargame.envs.state.snapshot import GameStateSnapshot, build_snapshot
+from wargame_rl.wargame.envs.state.snapshot import (
+    GameStateSnapshot,
+    build_snapshot,
+    validate_snapshot,
+)
 from wargame_rl.wargame.envs.types import (
     BattlePhase,
     PlayerSide,
@@ -58,7 +63,11 @@ from wargame_rl.wargame.envs.types import (
     WargameEnvObservation,
 )
 from wargame_rl.wargame.envs.types.config import ModelConfig
-from wargame_rl.wargame.envs.types.game_timing import BATTLE_PHASE_ORDER, GameState
+from wargame_rl.wargame.envs.types.game_timing import (
+    BATTLE_PHASE_ORDER,
+    GamePhase,
+    GameState,
+)
 from wargame_rl.wargame.envs.wargame_model import WargameModel
 from wargame_rl.wargame.envs.wargame_objective import WargameObjective
 
@@ -586,6 +595,132 @@ class WargameEnv(gym.Env):
             shooting_slice_start=ss.start if ss else None,
             shooting_slice_end=ss.end if ss else None,
         )
+
+    def load_state(
+        self, snapshot: GameStateSnapshot
+    ) -> tuple[WargameEnvObservation, dict[str, Any]]:
+        """Restore env from a snapshot. Returns (observation, info) like reset().
+
+        The env is ready for ``step()`` immediately after this call.
+        """
+        errors = validate_snapshot(snapshot, self.config)
+        if errors:
+            raise ValueError(
+                "Invalid snapshot:\n" + "\n".join(f"  - {e}" for e in errors)
+            )
+
+        # Clock
+        clock = snapshot.clock
+        self._game_clock.set_state(
+            GamePhase(clock.game_phase),
+            battle_round=clock.battle_round,
+            active_player=(
+                PlayerSide(clock.active_player) if clock.active_player else None
+            ),
+            phase=BattlePhase(clock.battle_phase) if clock.battle_phase else None,
+            total_steps=snapshot.step,
+        )
+
+        # Player models
+        for i, ms in enumerate(snapshot.player_models):
+            m = self.wargame_models[i]
+            m.location = np.array(ms.location, dtype=np.int32)
+            m.previous_location = (
+                np.array(ms.previous_location, dtype=np.int32)
+                if ms.previous_location is not None
+                else None
+            )
+            m.stats["current_wounds"] = ms.current_wounds
+            m.advanced_this_turn = ms.advanced_this_turn
+            m.previous_closest_objective_distance = None
+            m.best_closest_objective_distance = None
+            m.model_rewards_history.clear()
+
+        # Opponent models
+        for i, ms in enumerate(snapshot.opponent_models):
+            m = self.opponent_models[i]
+            m.location = np.array(ms.location, dtype=np.int32)
+            m.previous_location = (
+                np.array(ms.previous_location, dtype=np.int32)
+                if ms.previous_location is not None
+                else None
+            )
+            m.stats["current_wounds"] = ms.current_wounds
+            m.advanced_this_turn = ms.advanced_this_turn
+            m.previous_closest_objective_distance = None
+            m.best_closest_objective_distance = None
+            m.model_rewards_history.clear()
+
+        # Objectives
+        for i, os_ in enumerate(snapshot.objectives):
+            self.objectives[i].location = np.array(os_.location, dtype=np.int32)
+
+        # VP
+        self._battle._player_vp = snapshot.player_vp
+        self._battle._opponent_vp = snapshot.opponent_vp
+        self._battle._player_vp_delta = 0
+        self._battle._opponent_vp_delta = 0
+
+        # Env counters
+        self.current_turn = snapshot.step
+        self._last_terminated = snapshot.is_terminated
+
+        # Reconstruct last actions
+        if snapshot.player_actions is not None:
+            self._last_player_action = WargameEnvAction(
+                actions=list(snapshot.player_actions)
+            )
+        else:
+            self._last_player_action = None
+
+        if snapshot.opponent_actions is not None:
+            self._last_opponent_action = WargameEnvAction(
+                actions=list(snapshot.opponent_actions)
+            )
+        else:
+            self._last_opponent_action = None
+
+        # Reconstruct combat results as PairedShootingResult stubs
+        self._last_player_shooting_results = [
+            PairedShootingResult(
+                attacker_idx=cr.attacker_idx,
+                target_idx=cr.target_idx,
+                result=ShootingResult(
+                    hits=cr.hits,
+                    wounds=cr.wounds,
+                    unsaved=cr.unsaved,
+                    damage_dealt=cr.damage_dealt,
+                ),
+            )
+            for cr in snapshot.player_combat_results
+        ]
+        self._last_opponent_shooting_results = [
+            PairedShootingResult(
+                attacker_idx=cr.attacker_idx,
+                target_idx=cr.target_idx,
+                result=ShootingResult(
+                    hits=cr.hits,
+                    wounds=cr.wounds,
+                    unsaved=cr.unsaved,
+                    damage_dealt=cr.damage_dealt,
+                ),
+            )
+            for cr in snapshot.opponent_combat_results
+        ]
+
+        # Reward
+        self.last_reward = snapshot.reward.total
+        self.last_reward_breakdown = dict(snapshot.reward.breakdown)
+        self.episode_reward_breakdown = {}
+        self.episode_reward_steps = 0
+        self.last_step_context = None
+
+        # Recompute distances and build observation
+        cache = compute_distances(self.wargame_models, self.objectives)
+        observation = self._get_obs(cache)
+        info = self._get_info()
+
+        return observation, info.model_dump()
 
     def render(self) -> None:
         if self.renderer is not None:


### PR DESCRIPTION
## Summary

Implements the first three phases of milestone v9 — Canonical State Model & Export:

- **v9-01**: `GameStateSnapshot` Pydantic model with `to_snapshot()` on `WargameEnv`, JSON serialisation, schema generation, and `SnapshotEncoder` protocol. Enriched with spatial, force balance, action description, and mission fields.
- **v9-02**: Bidirectional state I/O — `validate_snapshot()` and `WargameEnv.load_state()` for restoring env from a snapshot, plus `GameClock.set_state()`. Full round-trip fidelity verified.
- **v9-03**: `StepNarrator` producing structured LLM-readable text summaries from snapshots, and public `describe_action()` API.

## Changes

- `wargame_rl/wargame/envs/state/` — new package: `snapshot.py` (models, builder, encoder, validation), `narrator.py` (StepNarrator), `__init__.py` (re-exports)
- `wargame_rl/wargame/envs/wargame.py` — `to_snapshot()`, `load_state()`, action/combat tracking
- `wargame_rl/wargame/envs/domain/game_clock.py` — `set_state()` for arbitrary clock positioning
- `wargame_rl/wargame/envs/domain/shooting.py` — `PairedShootingResult` dataclass
- `tests/test_snapshot.py` — 15 tests for snapshot creation, serialisation, enrichment
- `tests/test_state_injection.py` — 19 tests for clock, validation, load_state, round-trip
- `tests/test_narrator.py` — 8 tests for narrator sections and describe_action API
- `.planning/` — v9 roadmap, requirements, v9-01 plan


Made with [Cursor](https://cursor.com)