### PR TITLE
docs: sync roadmap and state with merged v9 work, defer v1 phase 6

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -17,7 +17,7 @@ Decimal phases appear between their surrounding integers in numeric order.
 - [x] **Phase 3: Line of Sight Service** - Single domain service for Bresenham LOS reused by rules, masks, and rendering (completed 2026-04-04)
 - [x] **Phase 4: Shooting Action Space** - Extend ActionRegistry with shooting targets, phase-gated masks combining LOS/range/alive (completed 2026-04-05)
 - [x] **Phase 5: Shooting Resolution** - Tabletop attack sequence (hit→wound→save→damage) with configurable weapon profiles (completed 2026-04-06)
-- [ ] **Phase 6: Combat Reward & Curriculum** - Reward calculators for damage/losses and curriculum phases for learning to shoot
+- [ ] ~~**Phase 6: Combat Reward & Curriculum**~~ - Deferred: Reward calculators for damage/losses and curriculum phases for learning to shoot
 
 ## Phase Details
 
@@ -86,7 +86,7 @@ Plans:
 - [x] 05-01-PLAN.md — Config + domain shooting resolution + entity extensions + unit tests
 - [x] 05-02-PLAN.md — Env wiring + mask extensions + observation pipeline + integration tests
 
-### Phase 6: Combat Reward & Curriculum
+### Phase 6: Combat Reward & Curriculum (Deferred)
 **Goal**: The agent learns to use shooting effectively through reward shaping and curriculum progression
 **Depends on**: Phase 5
 **Requirements**: CRWD-01, CRWD-02, CRWD-03, CRWD-04
@@ -95,6 +95,7 @@ Plans:
   2. A `models_lost` penalty calculator is registered and configurable in YAML reward phases
   3. A curriculum phase exists where the agent learns to shoot before combining shooting with movement and objectives
   4. An agent trained with combat reward phases demonstrates shooting at valid targets during simulation
+**Note**: Deferred — shooting mechanics (Phases 1–5) are complete; reward shaping for combat will be revisited when needed.
 **Plans**: TBD
 
 ## Progress
@@ -110,4 +111,4 @@ Phases execute in numeric order: 1 → 2 → 3 → 4 → 5 → 6
 | 3. Line of Sight Service | 1/1 | Complete | 2026-04-04 |
 | 4. Shooting Action Space | 2/2 | Complete | 2026-04-05 |
 | 5. Shooting Resolution | 2/2 | Complete | 2026-04-06 |
-| 6. Combat Reward & Curriculum | 0/0 | Not started | - |
+| 6. Combat Reward & Curriculum | - | Deferred | - |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,10 +2,10 @@
 gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
-status: verifying
-stopped_at: Completed 05-02-PLAN.md
-last_updated: "2026-04-06T14:56:09.666Z"
-last_activity: 2026-04-06
+status: active
+stopped_at: v9 roadmap updated; v1.0 Phase 6 next
+last_updated: "2026-06-07T09:21:00.000Z"
+last_activity: 2026-06-07
 progress:
   total_phases: 6
   completed_phases: 5
@@ -20,18 +20,17 @@ progress:
 See: .planning/PROJECT.md (updated 2026-04-04)
 
 **Core value:** Agents learn recognisable tactical behaviour through reward shaping and environment design
-**Current focus:** Phase 05 — shooting-resolution
+**Current focus:** v1.0 Phases 1–5 complete, Phase 6 deferred; v9 Phases 1–3 complete, Phase 4 deferred
 
 ## Current Position
 
-Phase: 6
-Plan: Not started
-Status: Phase complete — ready for verification
-Last activity: 2026-04-06
+**v1.0 (Shooting & Model Destruction):**
+Phases 1–5 complete (8/8 plans executed)
+Phase 6 deferred
 
-Progress: Phases **1–3** complete (4/4 plans executed in tracked milestone plans); **Phase 4** next
-
-**Plans bar:** `[████████████████████] 4/4 plans (100%)` *(milestone plan queue to date)*
+**v9 (Structured Game State & LLM-Readable Representation):**
+Phases 1–3 complete (merged 2026-05-23 via PRs #110, #111)
+Phase 4 deferred
 
 ## Performance Metrics
 
@@ -101,6 +100,6 @@ None yet.
 
 ## Session Continuity
 
-Last session: 2026-04-06T14:48:47.649Z
-Stopped at: Completed 05-02-PLAN.md
+Last session: 2026-06-07T09:21:00.000Z
+Stopped at: Updated v9 roadmap to reflect merged work
 Resume file: None

--- a/.planning/v9-ROADMAP.md
+++ b/.planning/v9-ROADMAP.md
@@ -8,9 +8,9 @@ The build order follows dependency: the canonical schema first (everything depen
 
 ## Phases
 
-- [ ] **Phase 1: Canonical State Model & Export** — Pydantic `GameStateSnapshot` projected from `BattleView`, JSON serialisation, `WargameEnv.to_snapshot()`, combat/action metadata capture
-- [ ] **Phase 2: State Injection & Bidirectional I/O** — `GameClock.set_state()`, `WargameEnv.load_state(snapshot)`, validation, derive computed fields from injected state
-- [ ] **Phase 3: LLM-Readable Text Representation** — Action descriptions, combat narrative, step narrator, reward breakdown text for LLM evaluation
+- [x] **Phase 1: Canonical State Model & Export** — Pydantic `GameStateSnapshot` projected from `BattleView`, JSON serialisation, `WargameEnv.to_snapshot()`, combat/action metadata capture (completed 2026-05-23)
+- [x] **Phase 2: State Injection & Bidirectional I/O** — `GameClock.set_state()`, `WargameEnv.load_state(snapshot)`, validation, derive computed fields from injected state (completed 2026-05-23)
+- [x] **Phase 3: LLM-Readable Text Representation** — Action descriptions, combat narrative, step narrator, reward breakdown text for LLM evaluation (completed 2026-05-23)
 - [ ] ~~**Phase 4: Event Streaming & Replay**~~ — Deferred: append-only event log, delta encoding, deterministic replay, pluggable codec interface
 
 ## Phase Details
@@ -27,7 +27,7 @@ The build order follows dependency: the canonical schema first (everything depen
   5. Opponent actions are recorded before application and available in the snapshot
 **Plans:** 1 plan
 Plans:
-- [ ] v9-01-01-PLAN.md — Snapshot Pydantic models, PairedShootingResult, build_snapshot factory, to_snapshot(), encoder protocol, tests
+- [x] v9-01-01-PLAN.md — Snapshot Pydantic models, PairedShootingResult, build_snapshot factory, to_snapshot(), encoder protocol, tests
 
 ### Phase 2: State Injection & Bidirectional I/O
 **Goal**: An arbitrary game state can be constructed from a snapshot, enabling scenario testing, LLM-driven evaluation, and programmatic game setup
@@ -38,7 +38,8 @@ Plans:
   2. `GameClock.set_state()` can position the clock at any valid round/phase/player combination
   3. Round-trip fidelity: `env.to_snapshot()` → `env.load_state(snapshot)` → `env.to_snapshot()` produces identical output (excluding derived-only fields)
   4. `validate_snapshot(snapshot, config)` rejects snapshots that violate hard constraints (locations out of bounds, wounds out of range, entity count mismatch, invalid clock state)
-**Plans**: TBD
+**Plans**: Implemented directly (no formal plan — code landed in v9-01 branch)
+**Key commits**: `42fad10` — `GameClock.set_state()`, `validate_snapshot()`, `WargameEnv.load_state()`, 23 tests
 
 ### Phase 3: LLM-Readable Text Representation
 **Goal**: An LLM can read a structured text summary of any game step and judge whether the RL agent's actions are tactically sound
@@ -49,7 +50,8 @@ Plans:
   2. `StepNarrator` produces per-step text summaries covering: state before action, decoded actions, combat narrative with hit/wound/save probabilities, reward breakdown with phase context, and state after
   3. Combat narrative includes analytical context: expected damage per target, wound threshold, modified save — enough for an LLM to evaluate whether the agent chose the optimal target
   4. Reward breakdown text includes the active reward phase name — without this, reward values are uninterpretable to an LLM
-**Plans**: TBD
+**Plans**: Implemented directly (no formal plan — code landed in v9-01 branch)
+**Key commits**: `ee30c1b` — `StepNarrator`, public `describe_action` API, 8 tests
 
 ### Phase 4: Event Streaming & Replay (Deferred)
 **Goal**: A complete match history can be recorded as an ordered event stream and replayed deterministically
@@ -72,7 +74,7 @@ Phase 4 is deferred.
 
 | Phase | Plans Complete | Status | Completed |
 |-------|----------------|--------|-----------|
-| 1. Canonical State Model & Export | 0/1 | Planned | - |
-| 2. State Injection & Bidirectional I/O | 0/0 | Not started | - |
-| 3. LLM-Readable Text Representation | 0/0 | Not started | - |
+| 1. Canonical State Model & Export | 1/1 | Complete | 2026-05-23 |
+| 2. State Injection & Bidirectional I/O | 1/1 | Complete | 2026-05-23 |
+| 3. LLM-Readable Text Representation | 1/1 | Complete | 2026-05-23 |
 | 4. Event Streaming & Replay | - | Deferred | - |


### PR DESCRIPTION
- Mark v9 phases 1–3 complete (merged 2026-05-23)
- Defer v1.0 phase 6 (Combat Reward & Curriculum)
- Update STATE.md to reflect current project position