### PR TITLE
feat: add event streaming, replay, and match analysis (v9 phase 4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -306,5 +306,8 @@ profile.html
 # Video recordings
 *.mp4
 
+# Event log recordings
+recordings/
+
 # VSCode
 .vscode/

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -20,7 +20,7 @@ progress:
 See: .planning/PROJECT.md (updated 2026-04-04)
 
 **Core value:** Agents learn recognisable tactical behaviour through reward shaping and environment design
-**Current focus:** v1.0 Phases 1–5 complete, Phase 6 deferred; v9 Phases 1–3 complete, Phase 4 deferred
+**Current focus:** v9 Phase 4 (Event Streaming & Replay) next; v1.0 complete (Phase 6 deferred)
 
 ## Current Position
 
@@ -30,7 +30,8 @@ Phase 6 deferred
 
 **v9 (Structured Game State & LLM-Readable Representation):**
 Phases 1–3 complete (merged 2026-05-23 via PRs #110, #111)
-Phase 4 deferred
+Phase 4 (Event Streaming & Replay) — not started
+Phase 5 (Milestone Validation) — not started
 
 ## Performance Metrics
 

--- a/.planning/v9-ROADMAP.md
+++ b/.planning/v9-ROADMAP.md
@@ -4,14 +4,15 @@
 
 This milestone adds programmatic state I/O and LLM-interpretable representation to the wargame environment. The codebase already contains rich structured data at every step — entity positions and wounds, game clock state, combat results, detailed reward breakdowns, and decodable action indices — but none of it is surfaced outside the RL tensor pipeline. This milestone builds a Pydantic-based canonical state model (`GameStateSnapshot`), bidirectional I/O (export and injection), and a text narration layer for LLM evaluation.
 
-The build order follows dependency: the canonical schema first (everything depends on it), then state injection (the "input" side of bidirectional I/O), then LLM text (builds on the data captured in the snapshot). Event streaming and replay are deferred — they require a stable schema and are lower priority than the user's core goals of bidirectional state I/O and LLM-interpretable representation.
+The build order follows dependency: the canonical schema first (everything depends on it), then state injection (the "input" side of bidirectional I/O), then LLM text (builds on the data captured in the snapshot). Event streaming and replay build on the stable schema established in Phases 1–3. A final validation phase verifies all milestone requirements and success criteria end-to-end.
 
 ## Phases
 
 - [x] **Phase 1: Canonical State Model & Export** — Pydantic `GameStateSnapshot` projected from `BattleView`, JSON serialisation, `WargameEnv.to_snapshot()`, combat/action metadata capture (completed 2026-05-23)
 - [x] **Phase 2: State Injection & Bidirectional I/O** — `GameClock.set_state()`, `WargameEnv.load_state(snapshot)`, validation, derive computed fields from injected state (completed 2026-05-23)
 - [x] **Phase 3: LLM-Readable Text Representation** — Action descriptions, combat narrative, step narrator, reward breakdown text for LLM evaluation (completed 2026-05-23)
-- [ ] ~~**Phase 4: Event Streaming & Replay**~~ — Deferred: append-only event log, delta encoding, deterministic replay, pluggable codec interface
+- [ ] **Phase 4: Event Streaming & Replay** — Append-only event log, delta encoding, deterministic replay, pluggable codec interface
+- [ ] **Phase 5: Milestone Validation** — End-to-end verification of all v9 requirements and success criteria across Phases 1–4
 
 ## Phase Details
 
@@ -53,28 +54,38 @@ Plans:
 **Plans**: Implemented directly (no formal plan — code landed in v9-01 branch)
 **Key commits**: `ee30c1b` — `StepNarrator`, public `describe_action` API, 8 tests
 
-### Phase 4: Event Streaming & Replay (Deferred)
+### Phase 4: Event Streaming & Replay
 **Goal**: A complete match history can be recorded as an ordered event stream and replayed deterministically
-**Depends on**: Phase 1 (stable schema)
+**Depends on**: Phase 1 (stable schema — now complete)
 **Requirements**: SGS-03, SGS-05, SGS-06
 **Success Criteria** (what must be TRUE):
   1. A `StateExporter` protocol with `on_reset()` / `on_step()` hooks produces an append-only event log recording the full match
   2. Delta encoding represents state updates efficiently (full snapshots at anchors, granular deltas between them)
   3. Deterministic replay: applying the event log from a known initial configuration reconstructs any requested historical state
   4. A pluggable formatter registry (extending SGS-04) allows alternative encodings behind a shared codec interface
-**Note**: This phase is deferred — not planned for immediate execution. SGS-03, SGS-05, SGS-06 are lower priority per user direction. The schema must stabilise through Phases 1–3 before building streaming and replay on top of it.
+**Plans**: TBD
+
+### Phase 5: Milestone Validation
+**Goal**: All v9 requirements and phase success criteria are verified end-to-end against the live codebase
+**Depends on**: Phases 1–4
+**Requirements**: All SGS-* requirements
+**Success Criteria** (what must be TRUE):
+  1. Every SGS-* requirement marked Complete has a passing test or verifiable evidence
+  2. All phase success criteria (Phases 1–4) hold against the current codebase
+  3. Round-trip and replay scenarios exercise the full pipeline: snapshot → inject → step → stream → replay
+  4. Requirements traceability table in REQUIREMENTS.md is fully updated
 **Plans**: TBD
 
 ## Progress
 
 **Execution Order:**
-Phases execute in numeric order: 1 → 2 → 3
+Phases execute in numeric order: 1 → 2 → 3 → 4 → 5
 (Phases 2 and 3 are independent after Phase 1 and can execute in parallel)
-Phase 4 is deferred.
 
 | Phase | Plans Complete | Status | Completed |
 |-------|----------------|--------|-----------|
 | 1. Canonical State Model & Export | 1/1 | Complete | 2026-05-23 |
 | 2. State Injection & Bidirectional I/O | 1/1 | Complete | 2026-05-23 |
 | 3. LLM-Readable Text Representation | 1/1 | Complete | 2026-05-23 |
-| 4. Event Streaming & Replay | - | Deferred | - |
+| 4. Event Streaming & Replay | 0/0 | Not started | - |
+| 5. Milestone Validation | 0/0 | Not started | - |

--- a/Justfile
+++ b/Justfile
@@ -99,6 +99,30 @@ profile env_config_path model='' max_epochs='':
 		{{ if model != "" { "--network-type " + model } else { "" } }} \
 		{{ if max_epochs != "" { "--max-epochs " + max_epochs } else { "" } }}
 
+# Record a short training run with event logging (E2E demo: 1 epoch, no wandb)
+record env_config_path='examples/env_config/4_models_2_objectives_fixed.yaml':
+	uv run train.py --record-events --max-epochs 1 --no-wandb --env-config-path {{env_config_path}}
+
+# Replay a recorded match event log (narrate all steps)
+replay file:
+	uv run replay_events.py narrate {{file}}
+
+# Show summary of a recorded match event log
+replay-summary file:
+	uv run replay_events.py summary {{file}}
+
+# Analyze a recorded match for training evaluation
+analyze file:
+	uv run analyze_events.py report {{file}}
+
+# Analyze a recorded match (JSON output for programmatic use)
+analyze-json file:
+	uv run analyze_events.py report {{file}} --json
+
+# Compare multiple recorded matches side-by-side
+analyze-compare +files:
+	uv run analyze_events.py compare {{files}}
+
 # Run a test env in isolation with random action
 test-env:
 	uv run main.py --env_test

--- a/analyze_events.py
+++ b/analyze_events.py
@@ -2,9 +2,9 @@
 """Analyze recorded match event logs for training evaluation.
 
 Usage:
-    python analyze_events.py report recordings/my_events.json
-    python analyze_events.py report recordings/my_events.json --json
-    python analyze_events.py compare recordings/run1.json recordings/run2.json
+    python analyze_events.py report recordings/my_events.jsonl
+    python analyze_events.py report recordings/my_events.jsonl --json
+    python analyze_events.py compare recordings/run1.jsonl recordings/run2.jsonl
 """
 
 from __future__ import annotations
@@ -38,7 +38,7 @@ def _load_and_analyze(file_path: str) -> MatchAnalysis:
 
 @app.command()
 def report(
-    file_path: str = typer.Argument(help="Path to the recorded event log JSON file"),
+    file_path: str = typer.Argument(help="Path to the recorded event log JSONL file"),
     json_output: bool = typer.Option(
         False, "--json", help="Output as JSON instead of human-readable text"
     ),
@@ -55,7 +55,7 @@ def report(
 @app.command()
 def compare(
     file_paths: list[str] = typer.Argument(
-        help="Paths to event log JSON files to compare"
+        help="Paths to event log JSONL files to compare"
     ),
 ) -> None:
     """Compare multiple recorded matches side-by-side."""

--- a/analyze_events.py
+++ b/analyze_events.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Analyze recorded match event logs for training evaluation.
+
+Usage:
+    python analyze_events.py report recordings/my_events.json
+    python analyze_events.py report recordings/my_events.json --json
+    python analyze_events.py compare recordings/run1.json recordings/run2.json
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from wargame_rl.wargame.envs.state import (
+    JsonMatchCodec,
+    MatchAnalysis,
+    ReplayController,
+    analyze_match,
+)
+
+app = typer.Typer(pretty_exceptions_enable=False)
+
+
+def _load_and_analyze(file_path: str) -> MatchAnalysis:
+    """Load an event log and produce a MatchAnalysis."""
+    path = Path(file_path)
+    if not path.exists():
+        raise typer.BadParameter(f"File not found: {file_path}")
+
+    codec = JsonMatchCodec()
+    event_log = codec.decode(path.read_bytes())
+    controller = ReplayController(event_log)
+    snapshots = controller.iter_snapshots()
+    return analyze_match(snapshots, file_name=path.name)
+
+
+@app.command()
+def report(
+    file_path: str = typer.Argument(help="Path to the recorded event log JSON file"),
+    json_output: bool = typer.Option(
+        False, "--json", help="Output as JSON instead of human-readable text"
+    ),
+) -> None:
+    """Analyze a single recorded match and print a structured report."""
+    analysis = _load_and_analyze(file_path)
+
+    if json_output:
+        print(analysis.model_dump_json(indent=2))
+    else:
+        print(analysis.to_text())
+
+
+@app.command()
+def compare(
+    file_paths: list[str] = typer.Argument(
+        help="Paths to event log JSON files to compare"
+    ),
+) -> None:
+    """Compare multiple recorded matches side-by-side."""
+    if len(file_paths) < 2:
+        typer.echo("Need at least 2 files to compare.", err=True)
+        raise typer.Exit(1)
+
+    analyses = [_load_and_analyze(f) for f in file_paths]
+
+    # Header
+    col_width = 22
+    header = f"{'Metric':<30}"
+    for a in analyses:
+        name = (
+            a.file[:col_width]
+            if len(a.file) <= col_width
+            else a.file[: col_width - 1] + "…"
+        )
+        header += f" {name:>{col_width}}"
+    print(header)
+    print("=" * len(header))
+
+    rows: list[tuple[str, list[str]]] = [
+        ("Steps", [str(a.steps) for a in analyses]),
+        ("Outcome", [a.outcome for a in analyses]),
+        ("Obj approach rate", [f"{a.objective_approach_rate:.1%}" for a in analyses]),
+        ("Idle rate", [f"{a.idle_rate:.1%}" for a in analyses]),
+        ("Edge contact rate", [f"{a.edge_contact_rate:.1%}" for a in analyses]),
+        ("Mean dist to obj", [f"{a.mean_distance_to_objective:.1f}" for a in analyses]),
+        ("Mean group distance", [f"{a.mean_group_distance:.1f}" for a in analyses]),
+        (
+            "Time to first obj",
+            [str(a.time_to_first_objective or "never") for a in analyses],
+        ),
+        ("VP per step", [f"{a.vp_per_step:.3f}" for a in analyses]),
+        (
+            "Target sel. opt.",
+            [_fmt_opt(a.target_selection_optimality) for a in analyses],
+        ),
+        ("Movement violations", [str(a.movement_violations) for a in analyses]),
+        ("Bounds violations", [str(a.bounds_violations) for a in analyses]),
+        ("Action entropy", [f"{a.action_entropy:.2f}" for a in analyses]),
+        ("Oscillation rate", [f"{a.oscillation_rate:.1%}" for a in analyses]),
+        ("Stagnation", [str(a.stagnation_detected) for a in analyses]),
+        ("TACTICAL SCORE", [f"{a.tactical_score:.0f}/100" for a in analyses]),
+    ]
+
+    for label, values in rows:
+        row = f"{label:<30}"
+        for v in values:
+            row += f" {v:>{col_width}}"
+        print(row)
+
+    # Issues section
+    print()
+    for a in analyses:
+        if a.issues:
+            print(f"Issues ({a.file}):")
+            for issue in a.issues:
+                print(f"  - {issue}")
+
+
+def _fmt_opt(v: float | None) -> str:
+    if v is None:
+        return "N/A"
+    return f"{v:.1%}"
+
+
+if __name__ == "__main__":
+    app()

--- a/docs/game-state-io.md
+++ b/docs/game-state-io.md
@@ -1,0 +1,232 @@
+# Game State I/O & Analysis
+
+This document describes the structured game state system — how match data flows in and out of the environment, what formats it takes, and what analysis can be built on top.
+
+## Motivation
+
+The RL training pipeline produces tensor observations optimised for neural networks: normalised floats, one-hot encodings, compressed representations. These are lossy and opaque — useless for evaluating whether an agent's behaviour is tactically sound, rule-compliant, or improving across training runs.
+
+The state I/O layer provides a **parallel output path** that preserves the complete, human- and machine-readable game state. It does not replace or interfere with the RL tensor pipeline; it runs alongside it and is disabled by default (zero overhead during training unless explicitly opted in).
+
+## Architecture
+
+The `envs/state/` package sits at the same dependency level as `renders/` and `reward/`:
+
+```
+domain/  →  types/  (only)
+                ↑
+    ┌───────────┼───────────────────────┐
+    │           │                       │
+reward/     renders/     state/         env_components/
+    │           │           │               │
+    └───────────┴───────────┴───────────────┘
+                        ↑
+                   WargameEnv (facade)
+```
+
+`state/` depends only on `BattleView` (via snapshot data) and `types/`. It never imports from `env_components`, `reward`, or `renders`.
+
+## Module Layout
+
+```
+wargame_rl/wargame/envs/state/
+├── __init__.py         # Public API re-exports
+├── snapshot.py         # GameStateSnapshot model, build_snapshot(), validation, SnapshotEncoder
+├── events.py           # StateDelta, ResetEvent, StepEvent, compute_delta(), apply_delta()
+├── event_log.py        # EventLog: append-only accumulator with anchor snapshots
+├── exporter.py         # StateExporter protocol, EventLogExporter
+├── replay.py           # ReplayController: seek to any step from an EventLog
+├── codecs.py           # MatchCodec protocol, JsonMatchCodec, CODEC_REGISTRY
+├── narrator.py         # StepNarrator: LLM-readable text summaries
+└── analysis.py         # MatchAnalysis model, analyze_match()
+```
+
+## Data Flow
+
+### Recording
+
+```
+WargameEnv.reset() ──→ to_snapshot() ──→ exporter.on_reset(snapshot)
+                                                    │
+WargameEnv.step()  ──→ to_snapshot() ──→ exporter.on_step(snapshot)
+                                                    │
+                                                    ▼
+                                         EventLog (in memory)
+                                                    │
+                                                    ▼
+                                         JsonMatchCodec.encode()
+                                                    │
+                                                    ▼
+                                         recordings/xxx_events.json
+```
+
+### Replay & Analysis
+
+```
+recordings/xxx_events.json
+        │
+        ▼
+JsonMatchCodec.decode()
+        │
+        ▼
+    EventLog
+        │
+        ├──→ ReplayController.seek(step)  ──→ GameStateSnapshot
+        │
+        ├──→ ReplayController.iter_snapshots() ──→ [GameStateSnapshot, ...]
+        │                                                    │
+        │                                                    ▼
+        │                                          analyze_match()
+        │                                                    │
+        │                                                    ▼
+        │                                          MatchAnalysis (JSON/text)
+        │
+        └──→ StepNarrator.narrate(snapshot) ──→ Human-readable text
+```
+
+## Key Abstractions
+
+### GameStateSnapshot
+
+A complete, serialisable Pydantic model of the game at one point in time. Contains:
+
+- Board dimensions, clock state, round/phase
+- All player and opponent model states (position, wounds, weapons, objective distances)
+- Objective states (control, models in range)
+- Actions taken (raw integers + decoded descriptions)
+- Combat results with analytical context (expected damage, hit/wound probabilities)
+- Reward breakdown (per-calculator contributions, active phase)
+- VP state, termination flags
+
+This is the "universal interchange format" — everything downstream operates on snapshots.
+
+### StateExporter Protocol
+
+```python
+class StateExporter(Protocol):
+    def on_reset(self, snapshot: GameStateSnapshot) -> None: ...
+    def on_step(self, snapshot: GameStateSnapshot) -> None: ...
+```
+
+The env holds an optional list of exporters. When non-empty, `to_snapshot()` is called at the end of `reset()` and `step()`, and each exporter is notified. This is identical to how the renderer is wired — a parallel output sink.
+
+### EventLog & Delta Encoding
+
+The EventLog stores an episode as:
+- **ResetEvent**: full initial snapshot (anchor)
+- **StepEvent**: granular delta (only changed fields) + optional full anchor
+
+Anchors are inserted every N steps (configurable, default 10). This enables efficient random-access: find the nearest anchor, apply forward deltas.
+
+The delta representation (`StateDelta`) captures per-step changes at field level — model positions that moved, VP that changed, combat results, reward. Unchanged fields are `None` and occupy no space.
+
+### Codec Registry
+
+```python
+CODEC_REGISTRY: dict[str, type[MatchCodec]] = {
+    "json": JsonMatchCodec,
+}
+```
+
+Follows the same registry pattern as reward calculators and opponent policies. New codecs (e.g., MessagePack, Protobuf) can be registered without changing existing code. Each codec implements `encode(EventLog) -> bytes` and `decode(bytes) -> EventLog`.
+
+### ReplayController
+
+Provides random-access state reconstruction:
+- `seek(step)` — reconstruct `GameStateSnapshot` at any recorded step
+- `iter_snapshots()` — full ordered list of all states
+- `snapshot_range(start, end)` — subset reconstruction
+
+Uses anchor+delta architecture internally for efficiency.
+
+## Analysis Layer
+
+The `analyze_match()` function takes a list of snapshots and produces a `MatchAnalysis` — a structured Pydantic model covering:
+
+| Dimension | Metrics |
+|-----------|---------|
+| **Movement efficiency** | Objective approach rate, idle rate, edge contact rate, mean distance to objective |
+| **Tactical quality** | Group cohesion (inter-model distance), time to first objective, VP/step, target selection optimality |
+| **Rule compliance** | Movement violations (teleportation), bounds violations |
+| **Degenerate behavior** | Action entropy, oscillation rate, reward stagnation |
+| **Composite** | Tactical score (0-100), issue flags |
+
+The analysis output is available as:
+- Human-readable text (terminal report)
+- JSON (programmatic consumption, AI evaluation)
+- Comparison tables (multiple runs side-by-side)
+
+## CLI Tools
+
+| Command | Purpose |
+|---------|---------|
+| `just record <config>` | Train 1 epoch with event recording (quick E2E test) |
+| `just replay <file>` | Narrate a recorded match step-by-step |
+| `just replay-summary <file>` | Match metadata overview |
+| `just analyze <file>` | Full analysis report (text) |
+| `just analyze-json <file>` | Analysis report as JSON |
+| `just analyze-compare f1 f2` | Side-by-side metric comparison |
+
+Training and simulation also support `--record-events` for production use:
+```bash
+just train config.yaml           # normal training
+just train config.yaml --record-events  # + event log
+```
+
+## Extension Points
+
+### Adding a new analysis metric
+
+1. Add the field to `MatchAnalysis` in `analysis.py`
+2. Compute it in the relevant `_analyze_*` function (or add a new pass)
+3. Optionally integrate it into the composite score and issue detection
+
+### Adding a new codec
+
+1. Implement the `MatchCodec` protocol (encode/decode/content_type)
+2. Register in `CODEC_REGISTRY`
+3. Available immediately via `build_codec("my_format")`
+
+### Adding a new exporter type
+
+1. Implement the `StateExporter` protocol (on_reset/on_step)
+2. Pass instances to `WargameEnv(state_exporters=[...])` or via `create_environment()`
+
+Examples: streaming exporter (WebSocket), database writer, Wandb artifact logger.
+
+### Building custom analysis pipelines
+
+The raw building blocks are fully composable:
+
+```python
+from wargame_rl.wargame.envs.state import (
+    JsonMatchCodec,
+    ReplayController,
+    StepNarrator,
+    analyze_match,
+)
+
+# Load
+codec = JsonMatchCodec()
+log = codec.decode(Path("recording.json").read_bytes())
+ctrl = ReplayController(log)
+
+# Seek to specific moment
+snap = ctrl.seek(step=42)
+
+# Narrate for LLM consumption
+narrator = StepNarrator()
+text = narrator.narrate(snap)
+
+# Full analysis
+report = analyze_match(ctrl.iter_snapshots())
+print(report.model_dump_json(indent=2))
+```
+
+## Design Principles
+
+1. **Zero cost when disabled** — exporters list is empty by default; no `to_snapshot()` call, no overhead.
+2. **Parallel to RL pipeline** — state I/O never touches `observation_to_tensor()`, Lightning modules, or checkpoints.
+3. **Snapshot is the universal format** — everything operates on `GameStateSnapshot`. New consumers just need the snapshot.
+4. **Registry pattern for extension** — codecs, exporters, and analyzers all follow the same pattern used by reward calculators.
+5. **Interoperable** — JSON output readable by any language, LLM, or tool. No framework lock-in.

--- a/docs/game-state-io.md
+++ b/docs/game-state-io.md
@@ -36,7 +36,7 @@ wargame_rl/wargame/envs/state/
 ├── event_log.py        # EventLog: append-only accumulator with anchor snapshots
 ├── exporter.py         # StateExporter protocol, EventLogExporter
 ├── replay.py           # ReplayController: seek to any step from an EventLog
-├── codecs.py           # MatchCodec protocol, JsonMatchCodec, CODEC_REGISTRY
+├── codecs.py           # MatchCodec protocol, JsonMatchCodec (JSONL), CODEC_REGISTRY
 ├── narrator.py         # StepNarrator: LLM-readable text summaries
 └── analysis.py         # MatchAnalysis model, analyze_match()
 ```
@@ -57,13 +57,13 @@ WargameEnv.step()  ──→ to_snapshot() ──→ exporter.on_step(snapshot)
                                          JsonMatchCodec.encode()
                                                     │
                                                     ▼
-                                         recordings/xxx_events.json
+                                         recordings/xxx_events.jsonl
 ```
 
 ### Replay & Analysis
 
 ```
-recordings/xxx_events.json
+recordings/xxx_events.jsonl
         │
         ▼
 JsonMatchCodec.decode()
@@ -226,11 +226,13 @@ The delta representation (`StateDelta`) captures per-step changes at field level
 
 ```python
 CODEC_REGISTRY: dict[str, type[MatchCodec]] = {
-    "json": JsonMatchCodec,
+    "json": JsonMatchCodec,  # JSONL (newline-delimited JSON)
 }
 ```
 
 Follows the same registry pattern as reward calculators and opponent policies. New codecs (e.g., MessagePack, Protobuf) can be registered without changing existing code. Each codec implements `encode(EventLog) -> bytes` and `decode(bytes) -> EventLog`.
+
+The default `JsonMatchCodec` uses **JSONL** (newline-delimited JSON, one object per line). The first line is a header with version and anchor_interval; subsequent lines are individual events. This enables streaming writes, crash-safe recording, and easy inspection with standard tools (`head`, `tail`, `wc -l`, `jq`).
 
 ### ReplayController
 
@@ -310,7 +312,7 @@ from wargame_rl.wargame.envs.state import (
 
 # Load
 codec = JsonMatchCodec()
-log = codec.decode(Path("recording.json").read_bytes())
+log = codec.decode(Path("recording.jsonl").read_bytes())
 ctrl = ReplayController(log)
 
 # Seek to specific moment
@@ -331,4 +333,4 @@ print(report.model_dump_json(indent=2))
 2. **Parallel to RL pipeline** — state I/O never touches `observation_to_tensor()`, Lightning modules, or checkpoints.
 3. **Snapshot is the universal format** — everything operates on `GameStateSnapshot`. New consumers just need the snapshot.
 4. **Registry pattern for extension** — codecs, exporters, and analyzers all follow the same pattern used by reward calculators.
-5. **Interoperable** — JSON output readable by any language, LLM, or tool. No framework lock-in.
+5. **Interoperable** — JSONL output readable by any language, LLM, or tool. No framework lock-in. Standard tools (`head`, `tail`, `jq`) work out of the box.

--- a/docs/game-state-io.md
+++ b/docs/game-state-io.md
@@ -88,17 +88,119 @@ JsonMatchCodec.decode()
 
 ### GameStateSnapshot
 
-A complete, serialisable Pydantic model of the game at one point in time. Contains:
+> Source: [`wargame_rl/wargame/envs/state/snapshot.py`](../wargame_rl/wargame/envs/state/snapshot.py)
 
-- Board dimensions, clock state, round/phase
-- All player and opponent model states (position, wounds, weapons, objective distances)
-- Objective states (control, models in range)
-- Actions taken (raw integers + decoded descriptions)
-- Combat results with analytical context (expected damage, hit/wound probabilities)
-- Reward breakdown (per-calculator contributions, active phase)
-- VP state, termination flags
+A complete, serialisable Pydantic model of the game at one point in time. This is the "universal interchange format" — everything downstream operates on snapshots.
 
-This is the "universal interchange format" — everything downstream operates on snapshots.
+#### Schema
+
+```python
+class GameStateSnapshot(BaseModel):
+    schema_version: str = "1.1"
+    step: int
+    max_steps: int
+    clock: ClockSnapshot
+    n_rounds: int
+    board_width: int
+    board_height: int
+    player_models: list[ModelSnapshot]
+    opponent_models: list[ModelSnapshot]
+    objectives: list[ObjectiveSnapshot]
+    deployment_zone: list[int]
+    opponent_deployment_zone: list[int]
+    player_vp: int
+    opponent_vp: int
+    player_vp_delta: int
+    opponent_vp_delta: int
+    objective_control: list[str]
+    player_actions: list[int] | None
+    opponent_actions: list[int] | None
+    player_action_descriptions: list[str] | None
+    player_combat_results: list[CombatResultSnapshot]
+    opponent_combat_results: list[CombatResultSnapshot]
+    reward: RewardSnapshot
+    is_terminated: bool
+    is_truncated: bool
+    player_alive_count: int
+    opponent_alive_count: int
+    player_total_wounds: int
+    opponent_total_wounds: int
+    mission_type: str
+    mission_params: dict[str, int | float | str]
+```
+
+#### Sub-models
+
+```python
+class ClockSnapshot(BaseModel):
+    game_phase: str          # "deployment" | "battle"
+    battle_round: int | None
+    active_player: str | None
+    battle_phase: str | None # "command" | "movement" | "shooting" | ...
+
+class ModelSnapshot(BaseModel):
+    location: list[int]
+    previous_location: list[int] | None
+    group_id: int
+    alive: bool
+    current_wounds: int
+    max_wounds: int
+    toughness: int
+    save: int
+    advanced_this_turn: bool
+    weapons: list[WeaponSnapshot]
+    distances_to_objectives: list[float]
+    at_objective: list[bool]
+    closest_objective_idx: int | None
+    closest_objective_distance: float | None
+
+class ObjectiveSnapshot(BaseModel):
+    location: list[int]
+    radius_size: int
+    player_models_in_range: list[int]
+    opponent_models_in_range: list[int]
+
+class WeaponSnapshot(BaseModel):
+    weapon_range: int
+    attacks: int
+    ballistic_skill: int
+    strength: int
+    ap: int
+    damage: int
+
+class CombatResultSnapshot(BaseModel):
+    attacker_idx: int
+    target_idx: int
+    hits: int
+    wounds: int
+    unsaved: int
+    damage_dealt: int
+    expected_damage: float
+    hit_probability: float
+    wound_probability: float
+
+class RewardSnapshot(BaseModel):
+    total: float | None
+    breakdown: dict[str, float]
+    phase_name: str
+    phase_index: int
+```
+
+#### Field summary
+
+| Group | Fields | Purpose |
+|-------|--------|---------|
+| **Timing** | `step`, `max_steps`, `clock`, `n_rounds` | Where in the episode and game clock |
+| **Board** | `board_width`, `board_height`, `deployment_zone`, `opponent_deployment_zone` | Static geometry |
+| **Units** | `player_models`, `opponent_models` | Full per-model state inc. weapons, wounds, distances |
+| **Objectives** | `objectives`, `objective_control` | Positions, radii, ownership |
+| **Actions** | `player_actions`, `opponent_actions`, `player_action_descriptions` | Raw + decoded actions taken |
+| **Combat** | `player_combat_results`, `opponent_combat_results` | Hits, wounds, damage with expected-value analytics |
+| **Reward** | `reward` | Per-calculator breakdown and active phase |
+| **VP** | `player_vp`, `opponent_vp`, `*_vp_delta` | Victory point state and step-wise change |
+| **Terminal** | `is_terminated`, `is_truncated` | Episode end flags |
+| **Attrition** | `player_alive_count`, `opponent_alive_count`, `*_total_wounds` | Aggregate health |
+| **Mission** | `mission_type`, `mission_params` | Active mission and its parameters |
 
 ### StateExporter Protocol
 

--- a/replay_events.py
+++ b/replay_events.py
@@ -2,9 +2,9 @@
 """Replay and inspect recorded match event logs.
 
 Usage:
-    python replay_events.py narrate recordings/my_events.json
-    python replay_events.py seek recordings/my_events.json --step 5
-    python replay_events.py summary recordings/my_events.json
+    python replay_events.py narrate recordings/my_events.jsonl
+    python replay_events.py seek recordings/my_events.jsonl --step 5
+    python replay_events.py summary recordings/my_events.jsonl
 """
 
 from __future__ import annotations
@@ -25,7 +25,7 @@ narrator = StepNarrator()
 
 
 def _load_log(file_path: str) -> ReplayController:
-    """Load an event log from a JSON file and return a ReplayController."""
+    """Load an event log from a JSONL file and return a ReplayController."""
     path = Path(file_path)
     if not path.exists():
         raise typer.BadParameter(f"File not found: {file_path}")
@@ -36,7 +36,7 @@ def _load_log(file_path: str) -> ReplayController:
 
 @app.command()
 def narrate(
-    file_path: str = typer.Argument(help="Path to the recorded event log JSON file"),
+    file_path: str = typer.Argument(help="Path to the recorded event log JSONL file"),
 ) -> None:
     """Narrate every step of a recorded match in human-readable text."""
     controller = _load_log(file_path)
@@ -51,7 +51,7 @@ def narrate(
 
 @app.command()
 def seek(
-    file_path: str = typer.Argument(help="Path to the recorded event log JSON file"),
+    file_path: str = typer.Argument(help="Path to the recorded event log JSONL file"),
     step: int = typer.Option(..., help="Step number to seek to"),
 ) -> None:
     """Reconstruct and narrate the game state at a specific step."""
@@ -67,7 +67,7 @@ def seek(
 
 @app.command()
 def summary(
-    file_path: str = typer.Argument(help="Path to the recorded event log JSON file"),
+    file_path: str = typer.Argument(help="Path to the recorded event log JSONL file"),
 ) -> None:
     """Print a summary of a recorded match."""
     path = Path(file_path)

--- a/replay_events.py
+++ b/replay_events.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Replay and inspect recorded match event logs.
+
+Usage:
+    python replay_events.py narrate recordings/my_events.json
+    python replay_events.py seek recordings/my_events.json --step 5
+    python replay_events.py summary recordings/my_events.json
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from wargame_rl.wargame.envs.state import (
+    JsonMatchCodec,
+    ReplayController,
+    StepEvent,
+    StepNarrator,
+)
+
+app = typer.Typer(pretty_exceptions_enable=False)
+narrator = StepNarrator()
+
+
+def _load_log(file_path: str) -> ReplayController:
+    """Load an event log from a JSON file and return a ReplayController."""
+    path = Path(file_path)
+    if not path.exists():
+        raise typer.BadParameter(f"File not found: {file_path}")
+    codec = JsonMatchCodec()
+    event_log = codec.decode(path.read_bytes())
+    return ReplayController(event_log)
+
+
+@app.command()
+def narrate(
+    file_path: str = typer.Argument(help="Path to the recorded event log JSON file"),
+) -> None:
+    """Narrate every step of a recorded match in human-readable text."""
+    controller = _load_log(file_path)
+    snapshots = controller.iter_snapshots()
+
+    for snapshot in snapshots:
+        print(narrator.narrate(snapshot))
+        print()
+        print("-" * 60)
+        print()
+
+
+@app.command()
+def seek(
+    file_path: str = typer.Argument(help="Path to the recorded event log JSON file"),
+    step: int = typer.Option(..., help="Step number to seek to"),
+) -> None:
+    """Reconstruct and narrate the game state at a specific step."""
+    controller = _load_log(file_path)
+    try:
+        snapshot = controller.seek(step)
+    except ValueError as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1)
+
+    print(narrator.narrate(snapshot))
+
+
+@app.command()
+def summary(
+    file_path: str = typer.Argument(help="Path to the recorded event log JSON file"),
+) -> None:
+    """Print a summary of a recorded match."""
+    path = Path(file_path)
+    if not path.exists():
+        raise typer.BadParameter(f"File not found: {file_path}")
+
+    codec = JsonMatchCodec()
+    event_log = codec.decode(path.read_bytes())
+    controller = ReplayController(event_log)
+
+    first_snap = controller.seek(controller.first_step)
+    last_snap = controller.seek(controller.last_step)
+
+    n_anchors = sum(
+        1 for e in event_log.events if isinstance(e, StepEvent) and e.anchor is not None
+    )
+
+    file_size_kb = path.stat().st_size / 1024
+
+    print(f"Match Event Log: {path.name}")
+    print(f"{'=' * 50}")
+    print(f"Total events:     {len(event_log)}")
+    print(f"Steps:            {controller.total_steps}")
+    print(f"Step range:       {controller.first_step} – {controller.last_step}")
+    print(f"Anchor snapshots: {n_anchors}")
+    print(f"Anchor interval:  {event_log.anchor_interval}")
+    print(f"File size:        {file_size_kb:.1f} KB")
+    print()
+    print(f"Board:            {first_snap.board_width}x{first_snap.board_height}")
+    print(f"Mission:          {first_snap.mission_type}")
+    print(f"Player models:    {len(first_snap.player_models)}")
+    print(f"Opponent models:  {len(first_snap.opponent_models)}")
+    print(f"Objectives:       {len(first_snap.objectives)}")
+    print()
+    print(
+        f"Final VP:         Player {last_snap.player_vp} – Opponent {last_snap.opponent_vp}"
+    )
+    print(
+        f"Final alive:      Player {last_snap.player_alive_count} – Opponent {last_snap.opponent_alive_count}"
+    )
+
+    if last_snap.is_terminated:
+        print("Outcome:          Terminated (game ended)")
+    elif last_snap.is_truncated:
+        print("Outcome:          Truncated (max steps)")
+    else:
+        print("Outcome:          In progress (recording ended mid-game)")
+
+
+if __name__ == "__main__":
+    app()

--- a/simulate.py
+++ b/simulate.py
@@ -9,11 +9,13 @@ Usage:
 
 import logging
 import os
+from pathlib import Path
 
 import typer
 from pydantic_yaml import parse_yaml_raw_as
 
 from wargame_rl.wargame.envs.renders.human import HumanRender, QuitRequested
+from wargame_rl.wargame.envs.state import EventLogExporter, JsonMatchCodec
 from wargame_rl.wargame.envs.types import WargameEnvConfig
 from wargame_rl.wargame.model.common.factory import create_environment
 from wargame_rl.wargame.model.dqn.agent import Agent
@@ -45,6 +47,7 @@ def simulate(
     render: bool = True,
     env_config_path: str | None = None,
     network_type: NetworkType = NetworkType.TRANSFORMER,
+    record_events: bool = False,
 ) -> None:
     """Run simulation with trained agent.
 
@@ -52,6 +55,7 @@ def simulate(
         checkpoint_path: Path to the trained model checkpoint
         num_episodes: Number of episodes to run
         render: Whether to render the environment
+        record_events: Whether to record the last episode as a JSON event log
     """
 
     if not os.path.exists(checkpoint_path):
@@ -61,7 +65,16 @@ def simulate(
 
     env_config = get_env_config(env_config_path, render)
     renderer = HumanRender()
-    env = create_environment(env_config=env_config, renderer=renderer)
+
+    event_exporter: EventLogExporter | None = None
+    if record_events:
+        event_exporter = EventLogExporter(anchor_interval=10)
+
+    env = create_environment(
+        env_config=env_config,
+        renderer=renderer,
+        state_exporters=[event_exporter] if event_exporter else None,
+    )
     logging.info(f"Action space: {env.action_space}")
     logging.info(f"Observation space: {env.observation_space}")
     logging.info(f"Running {num_episodes} episodes...")
@@ -139,6 +152,16 @@ def simulate(
     )
     logging.info("=" * 50)
 
+    if event_exporter and len(event_exporter.log) > 0:
+        recordings_dir = Path("recordings")
+        recordings_dir.mkdir(exist_ok=True)
+        out_path = recordings_dir / "simulate_events.json"
+        codec = JsonMatchCodec()
+        out_path.write_bytes(codec.encode(event_exporter.log))
+        logging.info(
+            f"Event log written to {out_path} ({len(event_exporter.log)} events)"
+        )
+
     env.close()
 
 
@@ -190,6 +213,10 @@ def main(
     network_type: NetworkType = typer.Option(
         NetworkType.TRANSFORMER, help="Network type to use"
     ),
+    record_events: bool = typer.Option(
+        False,
+        help="Record the last episode as a JSON event log (written to recordings/)",
+    ),
 ) -> None:
     # Handle dynamic defaults inside the function
     if checkpoint_path is None:
@@ -198,7 +225,14 @@ def main(
     if env_config_path is None:
         env_config_path = get_env_config_path_for_checkpoint(checkpoint_path)
 
-    simulate(checkpoint_path, num_episodes, render, env_config_path, network_type)
+    simulate(
+        checkpoint_path,
+        num_episodes,
+        render,
+        env_config_path,
+        network_type,
+        record_events=record_events,
+    )
 
 
 if __name__ == "__main__":

--- a/simulate.py
+++ b/simulate.py
@@ -155,7 +155,7 @@ def simulate(
     if event_exporter and len(event_exporter.log) > 0:
         recordings_dir = Path("recordings")
         recordings_dir.mkdir(exist_ok=True)
-        out_path = recordings_dir / "simulate_events.json"
+        out_path = recordings_dir / "simulate_events.jsonl"
         codec = JsonMatchCodec()
         out_path.write_bytes(codec.encode(event_exporter.log))
         logging.info(

--- a/tests/test_event_stream.py
+++ b/tests/test_event_stream.py
@@ -259,7 +259,7 @@ class TestCodecRoundTrip:
 
     def test_json_codec_content_type(self) -> None:
         codec = JsonMatchCodec()
-        assert codec.content_type() == "application/json"
+        assert codec.content_type() == "application/x-ndjson"
 
     def test_build_codec_json(self) -> None:
         codec = build_codec("json")

--- a/tests/test_event_stream.py
+++ b/tests/test_event_stream.py
@@ -1,0 +1,307 @@
+"""Tests for v9 Phase 4: Event Streaming & Replay (SGS-03, SGS-05, SGS-06)."""
+
+from __future__ import annotations
+
+import pytest
+
+from wargame_rl.wargame.envs.state import (
+    EventLog,
+    EventLogExporter,
+    GameStateSnapshot,
+    JsonMatchCodec,
+    ReplayController,
+    ResetEvent,
+    StateExporter,
+    StepEvent,
+    apply_delta,
+    build_codec,
+    compute_delta,
+)
+from wargame_rl.wargame.envs.types import WargameEnvAction, WargameEnvConfig
+from wargame_rl.wargame.envs.wargame import WargameEnv
+
+
+@pytest.fixture
+def env_with_exporter() -> tuple[WargameEnv, EventLogExporter]:
+    """Env wired with an EventLogExporter for recording."""
+    exporter = EventLogExporter(anchor_interval=5)
+    cfg = WargameEnvConfig(
+        board_width=20,
+        board_height=20,
+        number_of_wargame_models=2,
+        number_of_objectives=1,
+        number_of_battle_rounds=5,
+    )
+    env = WargameEnv(config=cfg, state_exporters=[exporter])
+    return env, exporter
+
+
+@pytest.fixture
+def recorded_log(
+    env_with_exporter: tuple[WargameEnv, EventLogExporter],
+) -> EventLog:
+    """Run a short episode and return the populated EventLog."""
+    env, exporter = env_with_exporter
+    env.reset(seed=42)
+    for _ in range(12):
+        action = WargameEnvAction(actions=env.action_space.sample())
+        _, _, terminated, truncated, _ = env.step(action)
+        if terminated or truncated:
+            break
+    return exporter.log
+
+
+class TestStateExporterProtocol:
+    """Verify StateExporter protocol conformance."""
+
+    def test_event_log_exporter_satisfies_protocol(self) -> None:
+        exporter = EventLogExporter()
+        assert isinstance(exporter, StateExporter)
+
+    def test_custom_exporter_satisfies_protocol(self) -> None:
+        class CustomExporter:
+            def on_reset(self, snapshot: GameStateSnapshot) -> None:
+                pass
+
+            def on_step(self, snapshot: GameStateSnapshot) -> None:
+                pass
+
+        assert isinstance(CustomExporter(), StateExporter)
+
+
+class TestEventLog:
+    """SGS-05: Append-only ordered event stream for a complete match."""
+
+    def test_reset_creates_initial_event(
+        self, env_with_exporter: tuple[WargameEnv, EventLogExporter]
+    ) -> None:
+        env, exporter = env_with_exporter
+        env.reset(seed=42)
+        log = exporter.log
+        assert len(log) == 1
+        assert isinstance(log.events[0], ResetEvent)
+
+    def test_steps_append_events(self, recorded_log: EventLog) -> None:
+        assert len(recorded_log) > 1
+        for event in recorded_log.events[1:]:
+            assert isinstance(event, StepEvent)
+
+    def test_events_are_ordered(self, recorded_log: EventLog) -> None:
+        steps = []
+        for event in recorded_log.events:
+            if isinstance(event, ResetEvent):
+                steps.append(event.snapshot.step)
+            else:
+                assert isinstance(event, StepEvent)
+                steps.append(event.delta.step)
+        assert steps == sorted(steps)
+
+    def test_record_step_before_reset_raises(self) -> None:
+        log = EventLog()
+        cfg = WargameEnvConfig(
+            board_width=10, board_height=10, number_of_wargame_models=1
+        )
+        env = WargameEnv(config=cfg)
+        env.reset(seed=1)
+        snapshot = env.to_snapshot()
+        with pytest.raises(
+            RuntimeError, match="record_step called before record_reset"
+        ):
+            log.record_step(snapshot)
+
+
+class TestDeltaEncoding:
+    """SGS-03: Layered change protocol with full snapshots and granular deltas."""
+
+    def test_anchors_inserted_at_interval(self, recorded_log: EventLog) -> None:
+        anchors = [
+            e
+            for e in recorded_log.events[1:]
+            if isinstance(e, StepEvent) and e.anchor is not None
+        ]
+        assert len(anchors) > 0
+
+    def test_delta_captures_changes(self) -> None:
+        cfg = WargameEnvConfig(
+            board_width=20,
+            board_height=20,
+            number_of_wargame_models=2,
+            number_of_objectives=1,
+            number_of_battle_rounds=5,
+        )
+        env = WargameEnv(config=cfg)
+        env.reset(seed=42)
+        snap_before = env.to_snapshot()
+        action = WargameEnvAction(actions=env.action_space.sample())
+        env.step(action)
+        snap_after = env.to_snapshot()
+
+        delta = compute_delta(snap_before, snap_after)
+        assert delta.step == snap_after.step
+
+    def test_apply_delta_reconstructs_state(self) -> None:
+        cfg = WargameEnvConfig(
+            board_width=20,
+            board_height=20,
+            number_of_wargame_models=2,
+            number_of_objectives=1,
+            number_of_battle_rounds=5,
+        )
+        env = WargameEnv(config=cfg)
+        env.reset(seed=42)
+        snap_before = env.to_snapshot()
+        action = WargameEnvAction(actions=env.action_space.sample())
+        env.step(action)
+        snap_after = env.to_snapshot()
+
+        delta = compute_delta(snap_before, snap_after)
+        reconstructed = apply_delta(snap_before, delta)
+
+        assert reconstructed.step == snap_after.step
+        assert reconstructed.clock == snap_after.clock
+        assert reconstructed.player_vp == snap_after.player_vp
+        assert reconstructed.opponent_vp == snap_after.opponent_vp
+        for i, (r, e) in enumerate(
+            zip(reconstructed.player_models, snap_after.player_models)
+        ):
+            assert r.location == e.location, f"player model {i} location mismatch"
+            assert r.alive == e.alive, f"player model {i} alive mismatch"
+
+    def test_delta_is_minimal(self) -> None:
+        """Delta for identical snapshots has no model deltas."""
+        cfg = WargameEnvConfig(
+            board_width=20,
+            board_height=20,
+            number_of_wargame_models=1,
+            number_of_objectives=1,
+        )
+        env = WargameEnv(config=cfg)
+        env.reset(seed=42)
+        snap = env.to_snapshot()
+        delta = compute_delta(snap, snap)
+        assert delta.player_model_deltas == []
+        assert delta.opponent_model_deltas == []
+        assert delta.clock is None
+        assert delta.player_vp is None
+
+
+class TestReplay:
+    """SGS-06: Deterministic replay from event log."""
+
+    def test_replay_seek_to_reset_step(self, recorded_log: EventLog) -> None:
+        controller = ReplayController(recorded_log)
+        first = controller.seek(controller.first_step)
+        assert isinstance(first, GameStateSnapshot)
+        reset_event = recorded_log.events[0]
+        assert isinstance(reset_event, ResetEvent)
+        assert first == reset_event.snapshot
+
+    def test_replay_seek_to_last_step(self, recorded_log: EventLog) -> None:
+        controller = ReplayController(recorded_log)
+        last = controller.seek(controller.last_step)
+        assert isinstance(last, GameStateSnapshot)
+        assert last.step == controller.last_step
+
+    def test_replay_deterministic_reconstruction(
+        self,
+        env_with_exporter: tuple[WargameEnv, EventLogExporter],
+    ) -> None:
+        """Replay must produce identical state to what was recorded."""
+        env, exporter = env_with_exporter
+        env.reset(seed=99)
+        snapshots_direct: list[GameStateSnapshot] = [env.to_snapshot()]
+        for _ in range(8):
+            action = WargameEnvAction(actions=env.action_space.sample())
+            _, _, terminated, truncated, _ = env.step(action)
+            snapshots_direct.append(env.to_snapshot())
+            if terminated or truncated:
+                break
+
+        controller = ReplayController(exporter.log)
+        for expected in snapshots_direct:
+            reconstructed = controller.seek(expected.step)
+            assert reconstructed == expected
+
+    def test_replay_iter_snapshots(self, recorded_log: EventLog) -> None:
+        controller = ReplayController(recorded_log)
+        all_snaps = controller.iter_snapshots()
+        assert len(all_snaps) == len(recorded_log)
+        assert all_snaps[0].step == controller.first_step
+        assert all_snaps[-1].step == controller.last_step
+
+    def test_empty_log_raises(self) -> None:
+        with pytest.raises(ValueError, match="empty"):
+            ReplayController(EventLog())
+
+    def test_seek_invalid_step_raises(self, recorded_log: EventLog) -> None:
+        controller = ReplayController(recorded_log)
+        with pytest.raises(ValueError):
+            controller.seek(9999)
+
+
+class TestCodecRoundTrip:
+    """Codec serialisation preserves the full event log."""
+
+    def test_json_codec_round_trip(self, recorded_log: EventLog) -> None:
+        codec = JsonMatchCodec()
+        encoded = codec.encode(recorded_log)
+        assert isinstance(encoded, bytes)
+        decoded = codec.decode(encoded)
+
+        assert len(decoded) == len(recorded_log)
+        controller_orig = ReplayController(recorded_log)
+        controller_decoded = ReplayController(decoded)
+
+        for step in range(controller_orig.first_step, controller_orig.last_step + 1):
+            orig = controller_orig.seek(step)
+            restored = controller_decoded.seek(step)
+            assert orig == restored
+
+    def test_json_codec_content_type(self) -> None:
+        codec = JsonMatchCodec()
+        assert codec.content_type() == "application/json"
+
+    def test_build_codec_json(self) -> None:
+        codec = build_codec("json")
+        assert isinstance(codec, JsonMatchCodec)
+
+    def test_build_codec_unknown_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown codec type"):
+            build_codec("unknown_format")
+
+
+class TestEnvIntegration:
+    """Env wiring: exporters receive callbacks without affecting the Gym API."""
+
+    def test_env_without_exporters_works(self) -> None:
+        cfg = WargameEnvConfig(
+            board_width=10,
+            board_height=10,
+            number_of_wargame_models=1,
+            number_of_objectives=1,
+        )
+        env = WargameEnv(config=cfg)
+        obs, info = env.reset(seed=1)
+        assert obs is not None
+        action = WargameEnvAction(actions=env.action_space.sample())
+        result = env.step(action)
+        assert len(result) == 5
+
+    def test_multiple_exporters(self) -> None:
+        exp1 = EventLogExporter(anchor_interval=3)
+        exp2 = EventLogExporter(anchor_interval=7)
+        cfg = WargameEnvConfig(
+            board_width=10,
+            board_height=10,
+            number_of_wargame_models=1,
+            number_of_objectives=1,
+            number_of_battle_rounds=3,
+        )
+        env = WargameEnv(config=cfg, state_exporters=[exp1, exp2])
+        env.reset(seed=1)
+        for _ in range(5):
+            action = WargameEnvAction(actions=env.action_space.sample())
+            env.step(action)
+
+        assert len(exp1.log) == 6
+        assert len(exp2.log) == 6

--- a/tests/test_train_resume.py
+++ b/tests/test_train_resume.py
@@ -125,7 +125,9 @@ def test_train_forwards_resume_ckpt_to_trainer(
 
     monkeypatch.setattr(train_module, "Trainer", DummyTrainer)
     monkeypatch.setattr(
-        train_module, "create_environment", lambda env_config: _make_env()
+        train_module,
+        "create_environment",
+        lambda env_config, **kwargs: _make_env(),
     )
     monkeypatch.setattr(
         train_module,

--- a/train.py
+++ b/train.py
@@ -1,14 +1,17 @@
 import os
 from enum import Enum
+from pathlib import Path
 from typing import Any, cast
 
 import torch
 import typer
+from loguru import logger as log
 from pydantic_yaml import parse_yaml_raw_as
 from pytorch_lightning import LightningModule, Trainer
 from pytorch_lightning.callbacks import Callback
 from typer.models import OptionInfo
 
+from wargame_rl.wargame.envs.state import EventLogExporter, JsonMatchCodec
 from wargame_rl.wargame.envs.types import WargameEnvConfig
 from wargame_rl.wargame.model.common import (
     EnvConfigCallback,
@@ -211,6 +214,10 @@ def train(
         None,
         help="Wandb group name to organize runs in the UI (e.g. when running multiple configs in parallel)",
     ),
+    record_events: bool = typer.Option(
+        False,
+        help="Record the last training episode as a JSON event log (written to recordings/)",
+    ),
 ) -> None:
     """Train the agent."""
     render_mode = _resolve_optional_str(render_mode)
@@ -228,7 +235,14 @@ def train(
     default_run_name = _build_default_run_base_name(algorithm, network_type, env_config)
     run_name_base = run_name if run_name else default_run_name
 
-    env = create_environment(env_config=env_config)
+    event_exporter: EventLogExporter | None = None
+    if record_events:
+        event_exporter = EventLogExporter(anchor_interval=10)
+
+    env = create_environment(
+        env_config=env_config,
+        state_exporters=[event_exporter] if event_exporter else None,
+    )
 
     if algorithm == AlgorithmType.DQN:
         dqn_config = DQNConfig()
@@ -356,6 +370,19 @@ def train(
             if warm_start_ckpt_path is not None:
                 _apply_warm_start_weights(ppo_model, warm_start_ckpt_path)
             _fit_with_optional_resume(trainer, ppo_model, resume_ckpt_path)
+
+    if event_exporter and len(event_exporter.log) > 0:
+        _write_event_log(event_exporter, run_name_base)
+
+
+def _write_event_log(exporter: EventLogExporter, run_name: str) -> None:
+    """Serialise the last recorded episode to a JSON file in recordings/."""
+    recordings_dir = Path("recordings")
+    recordings_dir.mkdir(exist_ok=True)
+    out_path = recordings_dir / f"{run_name}_events.json"
+    codec = JsonMatchCodec()
+    out_path.write_bytes(codec.encode(exporter.log))
+    log.info(f"Event log written to {out_path} ({len(exporter.log)} events)")
 
 
 if __name__ == "__main__":

--- a/train.py
+++ b/train.py
@@ -376,10 +376,10 @@ def train(
 
 
 def _write_event_log(exporter: EventLogExporter, run_name: str) -> None:
-    """Serialise the last recorded episode to a JSON file in recordings/."""
+    """Serialise the last recorded episode to a JSONL file in recordings/."""
     recordings_dir = Path("recordings")
     recordings_dir.mkdir(exist_ok=True)
-    out_path = recordings_dir / f"{run_name}_events.json"
+    out_path = recordings_dir / f"{run_name}_events.jsonl"
     codec = JsonMatchCodec()
     out_path.write_bytes(codec.encode(exporter.log))
     log.info(f"Event log written to {out_path} ({len(exporter.log)} events)")

--- a/wargame_rl/wargame/envs/state/__init__.py
+++ b/wargame_rl/wargame/envs/state/__init__.py
@@ -2,7 +2,26 @@
 
 from __future__ import annotations
 
+from wargame_rl.wargame.envs.state.analysis import MatchAnalysis, analyze_match
+from wargame_rl.wargame.envs.state.codecs import (
+    CODEC_REGISTRY,
+    JsonMatchCodec,
+    MatchCodec,
+    build_codec,
+)
+from wargame_rl.wargame.envs.state.event_log import EventLog
+from wargame_rl.wargame.envs.state.events import (
+    MatchEvent,
+    ModelDelta,
+    ResetEvent,
+    StateDelta,
+    StepEvent,
+    apply_delta,
+    compute_delta,
+)
+from wargame_rl.wargame.envs.state.exporter import EventLogExporter, StateExporter
 from wargame_rl.wargame.envs.state.narrator import StepNarrator
+from wargame_rl.wargame.envs.state.replay import ReplayController
 from wargame_rl.wargame.envs.state.snapshot import (
     GameStateSnapshot,
     JsonEncoder,
@@ -13,11 +32,28 @@ from wargame_rl.wargame.envs.state.snapshot import (
 )
 
 __all__ = [
+    "CODEC_REGISTRY",
+    "MatchAnalysis",
+    "analyze_match",
+    "EventLog",
+    "EventLogExporter",
     "GameStateSnapshot",
     "JsonEncoder",
+    "JsonMatchCodec",
+    "MatchCodec",
+    "MatchEvent",
+    "ModelDelta",
+    "ReplayController",
+    "ResetEvent",
     "SnapshotEncoder",
+    "StateDelta",
+    "StateExporter",
+    "StepEvent",
     "StepNarrator",
+    "apply_delta",
+    "build_codec",
     "build_snapshot",
+    "compute_delta",
     "describe_action",
     "validate_snapshot",
 ]

--- a/wargame_rl/wargame/envs/state/analysis.py
+++ b/wargame_rl/wargame/envs/state/analysis.py
@@ -1,0 +1,491 @@
+"""Match analysis: compute structured metrics from a recorded event log.
+
+Produces a MatchAnalysis report covering movement efficiency, tactical
+quality, rule compliance, and degenerate behavior detection.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+
+from pydantic import BaseModel, Field
+
+from wargame_rl.wargame.envs.state.snapshot import GameStateSnapshot
+
+
+class MatchAnalysis(BaseModel):
+    """Structured analysis report for a recorded match."""
+
+    file: str = ""
+    steps: int = 0
+    outcome: str = "unknown"
+
+    # Movement efficiency
+    objective_approach_rate: float = Field(
+        default=0.0,
+        description="Fraction of steps where closest objective distance decreased",
+    )
+    idle_rate: float = Field(
+        default=0.0, description="Fraction of steps where Stay was chosen"
+    )
+    edge_contact_rate: float = Field(
+        default=0.0, description="Fraction of model-steps at board edge"
+    )
+    mean_distance_to_objective: float = Field(
+        default=0.0,
+        description="Average closest-objective distance across all model-steps",
+    )
+
+    # Tactical quality
+    mean_group_distance: float = Field(
+        default=0.0, description="Average pairwise distance between player models"
+    )
+    time_to_first_objective: int | None = Field(
+        default=None,
+        description="First step where any player model reaches an objective",
+    )
+    vp_per_step: float = Field(
+        default=0.0, description="Total VP gained divided by episode steps"
+    )
+    target_selection_optimality: float | None = Field(
+        default=None,
+        description="Fraction of attacks that chose the highest expected-damage target",
+    )
+
+    # Rule compliance
+    movement_violations: int = Field(
+        default=0, description="Steps where a model moved further than max speed allows"
+    )
+    bounds_violations: int = Field(
+        default=0, description="Snapshots where a model is outside board bounds"
+    )
+
+    # Degenerate behavior
+    action_entropy: float = Field(
+        default=0.0, description="Shannon entropy of action distribution (bits)"
+    )
+    oscillation_rate: float = Field(
+        default=0.0,
+        description="Fraction of models that returned to a previous position within 3 steps",
+    )
+    stagnation_detected: bool = Field(
+        default=False,
+        description="True if cumulative reward did not improve in the second half",
+    )
+
+    # Summary
+    tactical_score: float = Field(default=0.0, description="Composite score 0-100")
+    issues: list[str] = Field(
+        default_factory=list, description="Human-readable issue flags"
+    )
+
+    def to_text(self) -> str:
+        """Render as human-readable terminal report."""
+        lines = [
+            f"Match Analysis: {self.file}",
+            "=" * 60,
+            f"Steps: {self.steps} | Outcome: {self.outcome}",
+            "",
+            "MOVEMENT EFFICIENCY",
+            f"  Objective approach rate: {self.objective_approach_rate:.1%}",
+            f"  Idle rate:               {self.idle_rate:.1%}",
+            f"  Edge contact rate:       {self.edge_contact_rate:.1%}",
+            f"  Mean dist to objective:  {self.mean_distance_to_objective:.1f}",
+            "",
+            "TACTICAL QUALITY",
+            f"  Mean group distance:     {self.mean_group_distance:.1f}",
+            f"  Time to first objective: {self.time_to_first_objective or 'never'}",
+            f"  VP per step:             {self.vp_per_step:.3f}",
+            f"  Target selection opt.:   {_fmt_opt(self.target_selection_optimality)}",
+            "",
+            "RULE COMPLIANCE",
+            f"  Movement violations:     {self.movement_violations}",
+            f"  Bounds violations:       {self.bounds_violations}",
+            "",
+            "DEGENERATE BEHAVIOR",
+            f"  Action entropy:          {self.action_entropy:.2f} bits",
+            f"  Oscillation rate:        {self.oscillation_rate:.1%}",
+            f"  Stagnation detected:     {self.stagnation_detected}",
+            "",
+            f"TACTICAL SCORE: {self.tactical_score:.0f} / 100",
+        ]
+        if self.issues:
+            lines.append("")
+            lines.append("ISSUES:")
+            for issue in self.issues:
+                lines.append(f"  - {issue}")
+        return "\n".join(lines)
+
+
+def _fmt_opt(v: float | None) -> str:
+    if v is None:
+        return "N/A (no combat)"
+    return f"{v:.1%}"
+
+
+def analyze_match(
+    snapshots: list[GameStateSnapshot],
+    file_name: str = "",
+    max_speed: int = 6,
+) -> MatchAnalysis:
+    """Compute all analysis metrics from an ordered list of snapshots.
+
+    Args:
+        snapshots: Ordered snapshots from ReplayController.iter_snapshots()
+        file_name: Source filename for the report
+        max_speed: Maximum movement distance per step (from env config n_speed_bins)
+    """
+    if not snapshots:
+        return MatchAnalysis(file=file_name)
+
+    first = snapshots[0]
+    last = snapshots[-1]
+    n_steps = len(snapshots) - 1
+
+    outcome = "in_progress"
+    if last.is_terminated:
+        outcome = "terminated"
+    elif last.is_truncated:
+        outcome = "truncated"
+
+    board_w = first.board_width
+    board_h = first.board_height
+
+    # Compute per-dimension metrics
+    movement = _analyze_movement(snapshots, board_w, board_h, max_speed)
+    tactical = _analyze_tactical(snapshots)
+    rules = _analyze_rules(snapshots, board_w, board_h, max_speed)
+    degenerate = _analyze_degenerate(snapshots)
+
+    # Composite score
+    issues: list[str] = []
+    score = 50.0
+
+    if movement.objective_approach_rate > 0.5:
+        score += 15
+    elif movement.objective_approach_rate < 0.2:
+        score -= 15
+        issues.append(
+            f"Low objective approach rate ({movement.objective_approach_rate:.0%})"
+        )
+
+    if movement.idle_rate > 0.3:
+        score -= 10
+        issues.append(f"High idle rate ({movement.idle_rate:.0%})")
+
+    if tactical.time_to_first_objective is not None:
+        ratio = tactical.time_to_first_objective / max(n_steps, 1)
+        if ratio < 0.5:
+            score += 10
+        elif ratio > 0.9:
+            issues.append("Reached objective very late in episode")
+
+    if tactical.vp_per_step > 0:
+        score += 10
+
+    if rules.movement_violations > 0:
+        score -= 10
+        issues.append(f"{rules.movement_violations} movement violations detected")
+    if rules.bounds_violations > 0:
+        score -= 10
+        issues.append(f"{rules.bounds_violations} bounds violations detected")
+
+    if degenerate.action_entropy < 1.0:
+        score -= 15
+        issues.append(
+            f"Very low action entropy ({degenerate.action_entropy:.2f} bits) — likely stuck"
+        )
+    elif degenerate.action_entropy < 2.0:
+        score -= 5
+        issues.append(f"Low action diversity ({degenerate.action_entropy:.2f} bits)")
+
+    if degenerate.oscillation_rate > 0.3:
+        score -= 10
+        issues.append(f"High oscillation ({degenerate.oscillation_rate:.0%})")
+
+    if degenerate.stagnation_detected:
+        score -= 10
+        issues.append("Reward stagnation in second half of episode")
+
+    if movement.edge_contact_rate > 0.3:
+        score -= 5
+        issues.append(f"Frequent edge contact ({movement.edge_contact_rate:.0%})")
+
+    score = max(0.0, min(100.0, score))
+
+    return MatchAnalysis(
+        file=file_name,
+        steps=n_steps,
+        outcome=outcome,
+        objective_approach_rate=movement.objective_approach_rate,
+        idle_rate=movement.idle_rate,
+        edge_contact_rate=movement.edge_contact_rate,
+        mean_distance_to_objective=movement.mean_distance_to_objective,
+        mean_group_distance=tactical.mean_group_distance,
+        time_to_first_objective=tactical.time_to_first_objective,
+        vp_per_step=tactical.vp_per_step,
+        target_selection_optimality=tactical.target_selection_optimality,
+        movement_violations=rules.movement_violations,
+        bounds_violations=rules.bounds_violations,
+        action_entropy=degenerate.action_entropy,
+        oscillation_rate=degenerate.oscillation_rate,
+        stagnation_detected=degenerate.stagnation_detected,
+        tactical_score=score,
+        issues=issues,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal analysis passes
+# ---------------------------------------------------------------------------
+
+
+class _MovementMetrics(BaseModel):
+    objective_approach_rate: float = 0.0
+    idle_rate: float = 0.0
+    edge_contact_rate: float = 0.0
+    mean_distance_to_objective: float = 0.0
+
+
+class _TacticalMetrics(BaseModel):
+    mean_group_distance: float = 0.0
+    time_to_first_objective: int | None = None
+    vp_per_step: float = 0.0
+    target_selection_optimality: float | None = None
+
+
+class _RuleMetrics(BaseModel):
+    movement_violations: int = 0
+    bounds_violations: int = 0
+
+
+class _DegenerateMetrics(BaseModel):
+    action_entropy: float = 0.0
+    oscillation_rate: float = 0.0
+    stagnation_detected: bool = False
+
+
+def _analyze_movement(
+    snapshots: list[GameStateSnapshot],
+    board_w: int,
+    board_h: int,
+    max_speed: int,
+) -> _MovementMetrics:
+    if len(snapshots) < 2:
+        return _MovementMetrics()
+
+    approach_count = 0
+    total_comparisons = 0
+    idle_count = 0
+    total_actions = 0
+    edge_count = 0
+    total_model_steps = 0
+    all_distances: list[float] = []
+
+    for i in range(1, len(snapshots)):
+        prev = snapshots[i - 1]
+        cur = snapshots[i]
+
+        # Action analysis
+        if cur.player_action_descriptions:
+            for desc in cur.player_action_descriptions:
+                total_actions += 1
+                if desc == "Stay":
+                    idle_count += 1
+
+        # Per-model metrics
+        for m_idx, (prev_m, cur_m) in enumerate(
+            zip(prev.player_models, cur.player_models)
+        ):
+            if not cur_m.alive:
+                continue
+            total_model_steps += 1
+
+            # Edge contact
+            x, y = cur_m.location
+            if x <= 0 or x >= board_w - 1 or y <= 0 or y >= board_h - 1:
+                edge_count += 1
+
+            # Objective approach
+            if (
+                prev_m.closest_objective_distance is not None
+                and cur_m.closest_objective_distance is not None
+            ):
+                total_comparisons += 1
+                if cur_m.closest_objective_distance < prev_m.closest_objective_distance:
+                    approach_count += 1
+
+            # Distance tracking
+            if cur_m.closest_objective_distance is not None:
+                all_distances.append(cur_m.closest_objective_distance)
+
+    return _MovementMetrics(
+        objective_approach_rate=(
+            approach_count / total_comparisons if total_comparisons > 0 else 0.0
+        ),
+        idle_rate=idle_count / total_actions if total_actions > 0 else 0.0,
+        edge_contact_rate=edge_count / total_model_steps
+        if total_model_steps > 0
+        else 0.0,
+        mean_distance_to_objective=(
+            sum(all_distances) / len(all_distances) if all_distances else 0.0
+        ),
+    )
+
+
+def _analyze_tactical(snapshots: list[GameStateSnapshot]) -> _TacticalMetrics:
+    if not snapshots:
+        return _TacticalMetrics()
+
+    # Group cohesion
+    group_distances: list[float] = []
+    time_to_first_obj: int | None = None
+    total_optimal = 0
+    total_attacks = 0
+
+    for snap in snapshots:
+        alive_models = [m for m in snap.player_models if m.alive]
+        if len(alive_models) >= 2:
+            pairwise = []
+            for i in range(len(alive_models)):
+                for j in range(i + 1, len(alive_models)):
+                    dx = alive_models[i].location[0] - alive_models[j].location[0]
+                    dy = alive_models[i].location[1] - alive_models[j].location[1]
+                    pairwise.append(math.sqrt(dx * dx + dy * dy))
+            if pairwise:
+                group_distances.append(sum(pairwise) / len(pairwise))
+
+        # Time to first objective
+        if time_to_first_obj is None:
+            for m in snap.player_models:
+                if m.alive and any(m.at_objective):
+                    time_to_first_obj = snap.step
+                    break
+
+        # Target selection optimality
+        if snap.player_combat_results:
+            by_attacker: dict[int, list[float]] = {}
+            for cr in snap.player_combat_results:
+                by_attacker.setdefault(cr.attacker_idx, []).append(cr.expected_damage)
+
+            for damages in by_attacker.values():
+                total_attacks += 1
+                if len(damages) == 1:
+                    total_optimal += 1
+                else:
+                    actual = damages[0]
+                    best = max(damages)
+                    if actual >= best - 1e-6:
+                        total_optimal += 1
+
+    # VP efficiency
+    first = snapshots[0]
+    last = snapshots[-1]
+    n_steps = len(snapshots) - 1
+    vp_gained = last.player_vp - first.player_vp
+    vp_per_step = vp_gained / n_steps if n_steps > 0 else 0.0
+
+    return _TacticalMetrics(
+        mean_group_distance=(
+            sum(group_distances) / len(group_distances) if group_distances else 0.0
+        ),
+        time_to_first_objective=time_to_first_obj,
+        vp_per_step=vp_per_step,
+        target_selection_optimality=(
+            total_optimal / total_attacks if total_attacks > 0 else None
+        ),
+    )
+
+
+def _analyze_rules(
+    snapshots: list[GameStateSnapshot],
+    board_w: int,
+    board_h: int,
+    max_speed: int,
+) -> _RuleMetrics:
+    movement_violations = 0
+    bounds_violations = 0
+
+    for i, snap in enumerate(snapshots):
+        for side_models in (snap.player_models, snap.opponent_models):
+            for m in side_models:
+                if not m.alive:
+                    continue
+                x, y = m.location
+                if x < 0 or x >= board_w or y < 0 or y >= board_h:
+                    bounds_violations += 1
+
+        # Movement distance check (compare to previous step)
+        if i > 0:
+            prev = snapshots[i - 1]
+            for prev_m, cur_m in zip(prev.player_models, snap.player_models):
+                if not cur_m.alive or not prev_m.alive:
+                    continue
+                dx = cur_m.location[0] - prev_m.location[0]
+                dy = cur_m.location[1] - prev_m.location[1]
+                dist = math.sqrt(dx * dx + dy * dy)
+                if dist > max_speed + 0.5:
+                    movement_violations += 1
+
+    return _RuleMetrics(
+        movement_violations=movement_violations,
+        bounds_violations=bounds_violations,
+    )
+
+
+def _analyze_degenerate(snapshots: list[GameStateSnapshot]) -> _DegenerateMetrics:
+    if len(snapshots) < 2:
+        return _DegenerateMetrics()
+
+    # Action entropy
+    action_counts: Counter[str] = Counter()
+    for snap in snapshots:
+        if snap.player_action_descriptions:
+            for desc in snap.player_action_descriptions:
+                action_counts[desc] += 1
+
+    total_actions = sum(action_counts.values())
+    entropy = 0.0
+    if total_actions > 0:
+        for count in action_counts.values():
+            p = count / total_actions
+            if p > 0:
+                entropy -= p * math.log2(p)
+
+    # Oscillation detection (model returns to a position within 3 steps)
+    oscillation_events = 0
+    total_model_steps = 0
+    for m_idx in range(len(snapshots[0].player_models)):
+        recent_positions: list[tuple[int, int]] = []
+        for snap in snapshots:
+            if m_idx >= len(snap.player_models):
+                continue
+            m = snap.player_models[m_idx]
+            if not m.alive:
+                continue
+            pos = (m.location[0], m.location[1])
+            total_model_steps += 1
+            if pos in recent_positions[:-1]:
+                oscillation_events += 1
+            recent_positions.append(pos)
+            if len(recent_positions) > 4:
+                recent_positions.pop(0)
+
+    # Stagnation: compare cumulative reward in first vs second half
+    rewards = [s.reward.total for s in snapshots[1:] if s.reward.total is not None]
+    stagnation = False
+    if len(rewards) >= 4:
+        mid = len(rewards) // 2
+        first_half_avg = sum(rewards[:mid]) / mid
+        second_half_avg = sum(rewards[mid:]) / (len(rewards) - mid)
+        if second_half_avg <= first_half_avg + 0.001:
+            stagnation = True
+
+    return _DegenerateMetrics(
+        action_entropy=entropy,
+        oscillation_rate=(
+            oscillation_events / total_model_steps if total_model_steps > 0 else 0.0
+        ),
+        stagnation_detected=stagnation,
+    )

--- a/wargame_rl/wargame/envs/state/codecs.py
+++ b/wargame_rl/wargame/envs/state/codecs.py
@@ -35,30 +35,37 @@ class MatchCodec(Protocol):
 
 
 class JsonMatchCodec:
-    """JSON codec for match event logs.
+    """JSONL codec for match event logs.
 
-    Serialises the full event list as a JSON array with metadata.
+    Serialises each event as a separate JSON line (newline-delimited JSON).
+    First line is a header with version and anchor_interval metadata.
     """
 
     def encode(self, event_log: EventLog) -> bytes:
-        """Serialise an EventLog to JSON bytes."""
-        payload: dict[str, Any] = {
+        """Serialise an EventLog to JSONL bytes (one JSON object per line)."""
+        lines: list[str] = []
+        header: dict[str, Any] = {
+            "type": "header",
             "version": "1.0",
             "anchor_interval": event_log.anchor_interval,
-            "events": [
-                _event_adapter.dump_python(e, mode="python") for e in event_log.events
-            ],
         }
-        return json.dumps(payload, default=_json_default).encode("utf-8")
+        lines.append(json.dumps(header))
+        for event in event_log.events:
+            raw = _event_adapter.dump_python(event, mode="python")
+            lines.append(json.dumps(raw, default=_json_default))
+        return ("\n".join(lines) + "\n").encode("utf-8")
 
     def decode(self, data: bytes) -> EventLog:
-        """Deserialise JSON bytes into an EventLog."""
-        payload = json.loads(data)
-        anchor_interval = payload.get("anchor_interval", 10)
+        """Deserialise JSONL bytes into an EventLog."""
+        text = data.decode("utf-8")
+        lines = [line for line in text.splitlines() if line.strip()]
+
+        header = json.loads(lines[0])
+        anchor_interval = header.get("anchor_interval", 10)
         log = EventLog(anchor_interval=anchor_interval)
 
-        raw_events = payload["events"]
-        for raw in raw_events:
+        for line in lines[1:]:
+            raw = json.loads(line)
             event = _event_adapter.validate_python(raw)
             if isinstance(event, ResetEvent):
                 log.record_reset(event.snapshot)
@@ -74,7 +81,7 @@ class JsonMatchCodec:
         return log
 
     def content_type(self) -> str:
-        return "application/json"
+        return "application/x-ndjson"
 
 
 def _json_default(obj: object) -> Any:

--- a/wargame_rl/wargame/envs/state/codecs.py
+++ b/wargame_rl/wargame/envs/state/codecs.py
@@ -1,0 +1,106 @@
+"""Pluggable codec registry for serialising and deserialising EventLogs.
+
+Extends the SnapshotEncoder pattern (SGS-04) with full match-level codecs
+that handle the entire event stream, not just individual snapshots.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Protocol, runtime_checkable
+
+from pydantic import TypeAdapter
+
+from wargame_rl.wargame.envs.state.event_log import EventLog
+from wargame_rl.wargame.envs.state.events import MatchEvent, ResetEvent, StepEvent
+
+_event_adapter: TypeAdapter[MatchEvent] = TypeAdapter(MatchEvent)
+
+
+@runtime_checkable
+class MatchCodec(Protocol):
+    """Protocol for encoding/decoding complete match event logs."""
+
+    def encode(self, event_log: EventLog) -> bytes:
+        """Serialise an EventLog to bytes."""
+        ...
+
+    def decode(self, data: bytes) -> EventLog:
+        """Deserialise bytes back into an EventLog."""
+        ...
+
+    def content_type(self) -> str:
+        """MIME type for the encoded format."""
+        ...
+
+
+class JsonMatchCodec:
+    """JSON codec for match event logs.
+
+    Serialises the full event list as a JSON array with metadata.
+    """
+
+    def encode(self, event_log: EventLog) -> bytes:
+        """Serialise an EventLog to JSON bytes."""
+        payload: dict[str, Any] = {
+            "version": "1.0",
+            "anchor_interval": event_log.anchor_interval,
+            "events": [
+                _event_adapter.dump_python(e, mode="python") for e in event_log.events
+            ],
+        }
+        return json.dumps(payload, default=_json_default).encode("utf-8")
+
+    def decode(self, data: bytes) -> EventLog:
+        """Deserialise JSON bytes into an EventLog."""
+        payload = json.loads(data)
+        anchor_interval = payload.get("anchor_interval", 10)
+        log = EventLog(anchor_interval=anchor_interval)
+
+        raw_events = payload["events"]
+        for raw in raw_events:
+            event = _event_adapter.validate_python(raw)
+            if isinstance(event, ResetEvent):
+                log.record_reset(event.snapshot)
+            elif isinstance(event, StepEvent):
+                if event.anchor is not None:
+                    log.record_step(event.anchor)
+                else:
+                    from wargame_rl.wargame.envs.state.events import apply_delta
+
+                    assert log._last_snapshot is not None
+                    reconstructed = apply_delta(log._last_snapshot, event.delta)
+                    log.record_step(reconstructed)
+        return log
+
+    def content_type(self) -> str:
+        return "application/json"
+
+
+def _json_default(obj: object) -> Any:
+    """Handle non-standard types during JSON serialisation."""
+    if hasattr(obj, "model_dump"):
+        return obj.model_dump()  # type: ignore[union-attr]
+    raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+CODEC_REGISTRY: dict[str, type[MatchCodec]] = {
+    "json": JsonMatchCodec,  # type: ignore[dict-item]
+}
+
+
+def build_codec(codec_type: str) -> MatchCodec:
+    """Build a codec instance by registry key.
+
+    Raises:
+        ValueError: If codec_type is not registered.
+    """
+    cls = CODEC_REGISTRY.get(codec_type)
+    if cls is None:
+        available = ", ".join(sorted(CODEC_REGISTRY.keys()))
+        raise ValueError(f"Unknown codec type '{codec_type}'. Available: {available}")
+    return cls()

--- a/wargame_rl/wargame/envs/state/event_log.py
+++ b/wargame_rl/wargame/envs/state/event_log.py
@@ -1,0 +1,127 @@
+"""Append-only event log for recording complete match histories.
+
+The EventLog accumulates MatchEvents in order, inserting full snapshot
+anchors at configurable intervals to allow efficient random-access seek.
+"""
+
+from __future__ import annotations
+
+from wargame_rl.wargame.envs.state.events import (
+    MatchEvent,
+    ResetEvent,
+    StepEvent,
+    apply_delta,
+    compute_delta,
+)
+from wargame_rl.wargame.envs.state.snapshot import GameStateSnapshot
+
+
+class EventLog:
+    """Append-only ordered event log for a single episode.
+
+    Stores a sequence of MatchEvents and provides random-access state
+    reconstruction via anchored snapshots + forward delta application.
+
+    Args:
+        anchor_interval: Insert a full snapshot anchor every N steps.
+            Lower values trade storage for faster seek. Default 10.
+    """
+
+    def __init__(self, anchor_interval: int = 10) -> None:
+        self._anchor_interval = anchor_interval
+        self._events: list[MatchEvent] = []
+        self._last_snapshot: GameStateSnapshot | None = None
+
+    @property
+    def events(self) -> list[MatchEvent]:
+        """All recorded events in order."""
+        return self._events
+
+    @property
+    def anchor_interval(self) -> int:
+        return self._anchor_interval
+
+    def __len__(self) -> int:
+        return len(self._events)
+
+    def record_reset(self, snapshot: GameStateSnapshot) -> None:
+        """Record an episode reset with its initial full snapshot."""
+        self._events = [ResetEvent(snapshot=snapshot)]
+        self._last_snapshot = snapshot
+
+    def record_step(self, snapshot: GameStateSnapshot) -> None:
+        """Record a step by computing delta from previous state.
+
+        Automatically inserts a full anchor snapshot at the configured interval.
+        """
+        if self._last_snapshot is None:
+            raise RuntimeError(
+                "record_step called before record_reset — "
+                "no previous snapshot available"
+            )
+
+        delta = compute_delta(self._last_snapshot, snapshot)
+        is_anchor = (snapshot.step % self._anchor_interval) == 0
+        event = StepEvent(
+            delta=delta,
+            anchor=snapshot if is_anchor else None,
+        )
+        self._events.append(event)
+        self._last_snapshot = snapshot
+
+    def snapshot_at(self, step: int) -> GameStateSnapshot:
+        """Reconstruct the game state at the given step number.
+
+        Finds the nearest anchor at or before the requested step, then
+        applies forward deltas to reach the target.
+
+        Raises:
+            ValueError: If step is not within the recorded range.
+        """
+        if not self._events:
+            raise ValueError("EventLog is empty")
+
+        reset_event = self._events[0]
+        assert isinstance(reset_event, ResetEvent)
+
+        if step == reset_event.snapshot.step:
+            return reset_event.snapshot
+
+        anchor_snapshot = reset_event.snapshot
+        anchor_event_idx = 0
+
+        for i in range(1, len(self._events)):
+            event = self._events[i]
+            assert isinstance(event, StepEvent)
+            if event.delta.step > step:
+                break
+            if event.anchor is not None and event.delta.step <= step:
+                anchor_snapshot = event.anchor
+                anchor_event_idx = i
+
+        state = anchor_snapshot
+        start = anchor_event_idx + 1 if anchor_event_idx > 0 else 1
+        for i in range(start, len(self._events)):
+            event = self._events[i]
+            assert isinstance(event, StepEvent)
+            if event.delta.step > step:
+                break
+            state = apply_delta(state, event.delta)
+
+        if state.step != step:
+            raise ValueError(
+                f"Step {step} not found in event log "
+                f"(range: {reset_event.snapshot.step}–{self._last_step})"
+            )
+        return state
+
+    @property
+    def _last_step(self) -> int:
+        """Step number of the most recently recorded event."""
+        if not self._events:
+            return -1
+        last = self._events[-1]
+        if isinstance(last, ResetEvent):
+            return last.snapshot.step
+        assert isinstance(last, StepEvent)
+        return last.delta.step

--- a/wargame_rl/wargame/envs/state/events.py
+++ b/wargame_rl/wargame/envs/state/events.py
@@ -1,0 +1,274 @@
+"""Event types for the append-only match event stream.
+
+Events form an ordered log of a complete match. A ResetEvent anchors the
+initial state; StepEvents record per-step deltas. Periodic anchor snapshots
+(full GameStateSnapshot embedded in a StepEvent) allow efficient seek.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, Field
+
+from wargame_rl.wargame.envs.state.snapshot import (
+    ClockSnapshot,
+    CombatResultSnapshot,
+    GameStateSnapshot,
+    ModelSnapshot,
+    RewardSnapshot,
+)
+
+
+class ModelDelta(BaseModel):
+    """Per-model state change within a single step."""
+
+    idx: int
+    location: list[int] | None = None
+    previous_location: list[int] | None = None
+    alive: bool | None = None
+    current_wounds: int | None = None
+    advanced_this_turn: bool | None = None
+    distances_to_objectives: list[float] | None = None
+    at_objective: list[bool] | None = None
+    closest_objective_idx: int | None = None
+    closest_objective_distance: float | None = None
+
+
+class StateDelta(BaseModel):
+    """Granular state change between two consecutive steps.
+
+    Only populated fields represent actual changes from the previous state.
+    """
+
+    step: int
+    clock: ClockSnapshot | None = None
+    player_model_deltas: list[ModelDelta] = Field(default_factory=list)
+    opponent_model_deltas: list[ModelDelta] = Field(default_factory=list)
+    player_vp: int | None = None
+    opponent_vp: int | None = None
+    player_vp_delta: int | None = None
+    opponent_vp_delta: int | None = None
+    objective_control: list[str] | None = None
+    player_actions: list[int] | None = None
+    opponent_actions: list[int] | None = None
+    player_action_descriptions: list[str] | None = None
+    player_combat_results: list[CombatResultSnapshot] | None = None
+    opponent_combat_results: list[CombatResultSnapshot] | None = None
+    reward: RewardSnapshot | None = None
+    is_terminated: bool | None = None
+    is_truncated: bool | None = None
+    player_alive_count: int | None = None
+    opponent_alive_count: int | None = None
+    player_total_wounds: int | None = None
+    opponent_total_wounds: int | None = None
+
+
+class ResetEvent(BaseModel):
+    """Marks episode start with a full state snapshot as the anchor."""
+
+    type: Literal["reset"] = "reset"
+    snapshot: GameStateSnapshot
+
+
+class StepEvent(BaseModel):
+    """Records a single env step as either a delta or a full anchor snapshot."""
+
+    type: Literal["step"] = "step"
+    delta: StateDelta
+    anchor: GameStateSnapshot | None = None
+
+
+MatchEvent = Annotated[
+    ResetEvent | StepEvent,
+    Field(discriminator="type"),
+]
+
+
+def compute_delta(
+    previous: GameStateSnapshot,
+    current: GameStateSnapshot,
+) -> StateDelta:
+    """Compute a StateDelta representing changes from previous to current."""
+    delta = StateDelta(step=current.step)
+
+    if current.clock != previous.clock:
+        delta.clock = current.clock
+
+    if current.player_vp != previous.player_vp:
+        delta.player_vp = current.player_vp
+    if current.opponent_vp != previous.opponent_vp:
+        delta.opponent_vp = current.opponent_vp
+    if current.player_vp_delta != previous.player_vp_delta:
+        delta.player_vp_delta = current.player_vp_delta
+    if current.opponent_vp_delta != previous.opponent_vp_delta:
+        delta.opponent_vp_delta = current.opponent_vp_delta
+
+    if current.objective_control != previous.objective_control:
+        delta.objective_control = current.objective_control
+
+    if current.player_actions != previous.player_actions:
+        delta.player_actions = current.player_actions
+    if current.opponent_actions != previous.opponent_actions:
+        delta.opponent_actions = current.opponent_actions
+    if current.player_action_descriptions != previous.player_action_descriptions:
+        delta.player_action_descriptions = current.player_action_descriptions
+
+    if current.player_combat_results != previous.player_combat_results:
+        delta.player_combat_results = current.player_combat_results
+    if current.opponent_combat_results != previous.opponent_combat_results:
+        delta.opponent_combat_results = current.opponent_combat_results
+
+    if current.reward != previous.reward:
+        delta.reward = current.reward
+
+    if current.is_terminated != previous.is_terminated:
+        delta.is_terminated = current.is_terminated
+    if current.is_truncated != previous.is_truncated:
+        delta.is_truncated = current.is_truncated
+
+    if current.player_alive_count != previous.player_alive_count:
+        delta.player_alive_count = current.player_alive_count
+    if current.opponent_alive_count != previous.opponent_alive_count:
+        delta.opponent_alive_count = current.opponent_alive_count
+    if current.player_total_wounds != previous.player_total_wounds:
+        delta.player_total_wounds = current.player_total_wounds
+    if current.opponent_total_wounds != previous.opponent_total_wounds:
+        delta.opponent_total_wounds = current.opponent_total_wounds
+
+    for i, (prev_m, cur_m) in enumerate(
+        zip(previous.player_models, current.player_models)
+    ):
+        md = _compute_model_delta(i, prev_m, cur_m)
+        if md is not None:
+            delta.player_model_deltas.append(md)
+
+    for i, (prev_m, cur_m) in enumerate(
+        zip(previous.opponent_models, current.opponent_models)
+    ):
+        md = _compute_model_delta(i, prev_m, cur_m)
+        if md is not None:
+            delta.opponent_model_deltas.append(md)
+
+    return delta
+
+
+def apply_delta(
+    snapshot: GameStateSnapshot,
+    delta: StateDelta,
+) -> GameStateSnapshot:
+    """Apply a StateDelta to a snapshot, producing the next state."""
+    updates: dict[str, object] = {"step": delta.step}
+
+    if delta.clock is not None:
+        updates["clock"] = delta.clock
+    if delta.player_vp is not None:
+        updates["player_vp"] = delta.player_vp
+    if delta.opponent_vp is not None:
+        updates["opponent_vp"] = delta.opponent_vp
+    if delta.player_vp_delta is not None:
+        updates["player_vp_delta"] = delta.player_vp_delta
+    if delta.opponent_vp_delta is not None:
+        updates["opponent_vp_delta"] = delta.opponent_vp_delta
+    if delta.objective_control is not None:
+        updates["objective_control"] = delta.objective_control
+    if delta.player_actions is not None:
+        updates["player_actions"] = delta.player_actions
+    if delta.opponent_actions is not None:
+        updates["opponent_actions"] = delta.opponent_actions
+    if delta.player_action_descriptions is not None:
+        updates["player_action_descriptions"] = delta.player_action_descriptions
+    if delta.player_combat_results is not None:
+        updates["player_combat_results"] = delta.player_combat_results
+    if delta.opponent_combat_results is not None:
+        updates["opponent_combat_results"] = delta.opponent_combat_results
+    if delta.reward is not None:
+        updates["reward"] = delta.reward
+    if delta.is_terminated is not None:
+        updates["is_terminated"] = delta.is_terminated
+    if delta.is_truncated is not None:
+        updates["is_truncated"] = delta.is_truncated
+    if delta.player_alive_count is not None:
+        updates["player_alive_count"] = delta.player_alive_count
+    if delta.opponent_alive_count is not None:
+        updates["opponent_alive_count"] = delta.opponent_alive_count
+    if delta.player_total_wounds is not None:
+        updates["player_total_wounds"] = delta.player_total_wounds
+    if delta.opponent_total_wounds is not None:
+        updates["opponent_total_wounds"] = delta.opponent_total_wounds
+
+    if delta.player_model_deltas:
+        p_models = list(snapshot.player_models)
+        for md in delta.player_model_deltas:
+            p_models[md.idx] = _apply_model_delta(p_models[md.idx], md)
+        updates["player_models"] = p_models
+
+    if delta.opponent_model_deltas:
+        o_models = list(snapshot.opponent_models)
+        for md in delta.opponent_model_deltas:
+            o_models[md.idx] = _apply_model_delta(o_models[md.idx], md)
+        updates["opponent_models"] = o_models
+
+    result: GameStateSnapshot = snapshot.model_copy(update=updates)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _compute_model_delta(
+    idx: int,
+    prev: ModelSnapshot,
+    cur: ModelSnapshot,
+) -> ModelDelta | None:
+    """Compute delta for a single model. Returns None if unchanged."""
+    changes: dict[str, object] = {}
+    if cur.location != prev.location:
+        changes["location"] = cur.location
+    if cur.previous_location != prev.previous_location:
+        changes["previous_location"] = cur.previous_location
+    if cur.alive != prev.alive:
+        changes["alive"] = cur.alive
+    if cur.current_wounds != prev.current_wounds:
+        changes["current_wounds"] = cur.current_wounds
+    if cur.advanced_this_turn != prev.advanced_this_turn:
+        changes["advanced_this_turn"] = cur.advanced_this_turn
+    if cur.distances_to_objectives != prev.distances_to_objectives:
+        changes["distances_to_objectives"] = cur.distances_to_objectives
+    if cur.at_objective != prev.at_objective:
+        changes["at_objective"] = cur.at_objective
+    if cur.closest_objective_idx != prev.closest_objective_idx:
+        changes["closest_objective_idx"] = cur.closest_objective_idx
+    if cur.closest_objective_distance != prev.closest_objective_distance:
+        changes["closest_objective_distance"] = cur.closest_objective_distance
+
+    if not changes:
+        return None
+    return ModelDelta(idx=idx, **changes)
+
+
+def _apply_model_delta(model: ModelSnapshot, md: ModelDelta) -> ModelSnapshot:
+    """Apply a ModelDelta to a ModelSnapshot."""
+    updates: dict[str, object] = {}
+    if md.location is not None:
+        updates["location"] = md.location
+    if md.previous_location is not None:
+        updates["previous_location"] = md.previous_location
+    if md.alive is not None:
+        updates["alive"] = md.alive
+    if md.current_wounds is not None:
+        updates["current_wounds"] = md.current_wounds
+    if md.advanced_this_turn is not None:
+        updates["advanced_this_turn"] = md.advanced_this_turn
+    if md.distances_to_objectives is not None:
+        updates["distances_to_objectives"] = md.distances_to_objectives
+    if md.at_objective is not None:
+        updates["at_objective"] = md.at_objective
+    if md.closest_objective_idx is not None:
+        updates["closest_objective_idx"] = md.closest_objective_idx
+    if md.closest_objective_distance is not None:
+        updates["closest_objective_distance"] = md.closest_objective_distance
+    result: ModelSnapshot = model.model_copy(update=updates)
+    return result

--- a/wargame_rl/wargame/envs/state/events.py
+++ b/wargame_rl/wargame/envs/state/events.py
@@ -7,7 +7,7 @@ initial state; StepEvents record per-step deltas. Periodic anchor snapshots
 
 from __future__ import annotations
 
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -224,7 +224,7 @@ def _compute_model_delta(
     cur: ModelSnapshot,
 ) -> ModelDelta | None:
     """Compute delta for a single model. Returns None if unchanged."""
-    changes: dict[str, object] = {}
+    changes: dict[str, Any] = {}
     if cur.location != prev.location:
         changes["location"] = cur.location
     if cur.previous_location != prev.previous_location:
@@ -251,7 +251,7 @@ def _compute_model_delta(
 
 def _apply_model_delta(model: ModelSnapshot, md: ModelDelta) -> ModelSnapshot:
     """Apply a ModelDelta to a ModelSnapshot."""
-    updates: dict[str, object] = {}
+    updates: dict[str, Any] = {}
     if md.location is not None:
         updates["location"] = md.location
     if md.previous_location is not None:

--- a/wargame_rl/wargame/envs/state/exporter.py
+++ b/wargame_rl/wargame/envs/state/exporter.py
@@ -1,0 +1,50 @@
+"""StateExporter protocol and EventLogExporter implementation.
+
+The StateExporter protocol defines lifecycle hooks that WargameEnv calls
+after reset() and step(). EventLogExporter is the concrete implementation
+that records events into an EventLog.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from wargame_rl.wargame.envs.state.event_log import EventLog
+from wargame_rl.wargame.envs.state.snapshot import GameStateSnapshot
+
+
+@runtime_checkable
+class StateExporter(Protocol):
+    """Protocol for receiving game state at env lifecycle points."""
+
+    def on_reset(self, snapshot: GameStateSnapshot) -> None:
+        """Called after env.reset() with the initial state snapshot."""
+        ...
+
+    def on_step(self, snapshot: GameStateSnapshot) -> None:
+        """Called after env.step() with the post-step state snapshot."""
+        ...
+
+
+class EventLogExporter:
+    """Concrete StateExporter that records events into an EventLog.
+
+    Args:
+        anchor_interval: Full snapshot anchor frequency. See EventLog.
+    """
+
+    def __init__(self, anchor_interval: int = 10) -> None:
+        self._log = EventLog(anchor_interval=anchor_interval)
+
+    @property
+    def log(self) -> EventLog:
+        """Access the underlying EventLog for replay or serialisation."""
+        return self._log
+
+    def on_reset(self, snapshot: GameStateSnapshot) -> None:
+        """Record episode reset."""
+        self._log.record_reset(snapshot)
+
+    def on_step(self, snapshot: GameStateSnapshot) -> None:
+        """Record a step event."""
+        self._log.record_step(snapshot)

--- a/wargame_rl/wargame/envs/state/replay.py
+++ b/wargame_rl/wargame/envs/state/replay.py
@@ -1,0 +1,109 @@
+"""Deterministic replay controller for reconstructing historical game states.
+
+Given an EventLog, the ReplayController can seek to any recorded step by
+finding the nearest anchor snapshot and applying forward deltas.
+"""
+
+from __future__ import annotations
+
+from wargame_rl.wargame.envs.state.event_log import EventLog
+from wargame_rl.wargame.envs.state.snapshot import GameStateSnapshot
+
+
+class ReplayController:
+    """Reconstructs game states from an EventLog.
+
+    Supports random-access seek to any step recorded in the log,
+    sequential iteration, and range queries.
+
+    Args:
+        event_log: A populated EventLog containing at least a reset event.
+    """
+
+    def __init__(self, event_log: EventLog) -> None:
+        if len(event_log) == 0:
+            raise ValueError("Cannot replay an empty EventLog")
+        self._log = event_log
+
+    @property
+    def event_log(self) -> EventLog:
+        return self._log
+
+    @property
+    def first_step(self) -> int:
+        """First recorded step number (from the reset event)."""
+        from wargame_rl.wargame.envs.state.events import ResetEvent
+
+        first = self._log.events[0]
+        assert isinstance(first, ResetEvent)
+        return first.snapshot.step
+
+    @property
+    def last_step(self) -> int:
+        """Last recorded step number."""
+        from wargame_rl.wargame.envs.state.events import ResetEvent, StepEvent
+
+        last = self._log.events[-1]
+        if isinstance(last, ResetEvent):
+            return last.snapshot.step
+        assert isinstance(last, StepEvent)
+        return last.delta.step
+
+    @property
+    def total_steps(self) -> int:
+        """Number of step events (excluding the reset)."""
+        return len(self._log) - 1
+
+    def seek(self, step: int) -> GameStateSnapshot:
+        """Reconstruct the game state at the given step.
+
+        Raises:
+            ValueError: If step is outside the recorded range.
+        """
+        return self._log.snapshot_at(step)
+
+    def iter_snapshots(self) -> list[GameStateSnapshot]:
+        """Reconstruct all snapshots in order (reset + every step).
+
+        Returns a list of GameStateSnapshot for the entire episode.
+        Useful for full replay or analysis pipelines.
+        """
+        from wargame_rl.wargame.envs.state.events import (
+            ResetEvent,
+            StepEvent,
+            apply_delta,
+        )
+
+        if not self._log.events:
+            return []
+
+        first = self._log.events[0]
+        assert isinstance(first, ResetEvent)
+        snapshots = [first.snapshot]
+        current = first.snapshot
+
+        for event in self._log.events[1:]:
+            assert isinstance(event, StepEvent)
+            current = apply_delta(current, event.delta)
+            snapshots.append(current)
+
+        return snapshots
+
+    def snapshot_range(self, start_step: int, end_step: int) -> list[GameStateSnapshot]:
+        """Reconstruct snapshots for a range of steps [start_step, end_step].
+
+        Raises:
+            ValueError: If start_step > end_step or steps are out of range.
+        """
+        if start_step > end_step:
+            raise ValueError(
+                f"start_step ({start_step}) must be <= end_step ({end_step})"
+            )
+
+        snapshots: list[GameStateSnapshot] = []
+        for step in range(start_step, end_step + 1):
+            try:
+                snapshots.append(self.seek(step))
+            except ValueError:
+                break
+        return snapshots

--- a/wargame_rl/wargame/envs/wargame.py
+++ b/wargame_rl/wargame/envs/wargame.py
@@ -48,6 +48,7 @@ from wargame_rl.wargame.envs.opponent.registry import (
 from wargame_rl.wargame.envs.renders import renderer
 from wargame_rl.wargame.envs.reward.phase_manager import RewardPhaseManager
 from wargame_rl.wargame.envs.reward.step_context import StepContext
+from wargame_rl.wargame.envs.state.exporter import StateExporter
 from wargame_rl.wargame.envs.state.snapshot import (
     GameStateSnapshot,
     build_snapshot,
@@ -81,7 +82,10 @@ class WargameEnv(gym.Env):
     metadata = {"render_modes": ["human", "rgb_array"], "render_fps": 5}
 
     def __init__(
-        self, config: WargameEnvConfig, renderer: renderer.Renderer | None = None
+        self,
+        config: WargameEnvConfig,
+        renderer: renderer.Renderer | None = None,
+        state_exporters: list[StateExporter] | None = None,
     ):
         self.board_width = config.board_width
         self.board_height = config.board_height
@@ -115,6 +119,7 @@ class WargameEnv(gym.Env):
         self._skip_phases = frozenset(config.skip_phases)
 
         self.renderer = renderer
+        self._state_exporters: list[StateExporter] = state_exporters or []
 
         self.window = None
         self.clock = None
@@ -333,6 +338,11 @@ class WargameEnv(gym.Env):
         if self.renderer is not None:
             self.renderer.setup(self)
             self.renderer.render(self)
+
+        if self._state_exporters:
+            snapshot = self.to_snapshot()
+            for exporter in self._state_exporters:
+                exporter.on_reset(snapshot)
 
         return observation, info.model_dump()
 
@@ -554,6 +564,12 @@ class WargameEnv(gym.Env):
                 self.episode_reward_breakdown.get(key, 0.0) + value
             )
         self.episode_reward_steps += 1
+
+        if self._state_exporters:
+            snapshot = self.to_snapshot()
+            for exporter in self._state_exporters:
+                exporter.on_step(snapshot)
+
         return observation, reward, is_terminated, False, info.model_dump()
 
     def to_snapshot(self) -> GameStateSnapshot:

--- a/wargame_rl/wargame/model/common/factory.py
+++ b/wargame_rl/wargame/model/common/factory.py
@@ -1,16 +1,21 @@
+from __future__ import annotations
+
 from wargame_rl.wargame.envs.renders import renderer
+from wargame_rl.wargame.envs.state.exporter import StateExporter
 from wargame_rl.wargame.envs.types import WargameEnvConfig
 from wargame_rl.wargame.envs.wargame import WargameEnv
 
 
 def create_environment(
-    env_config: WargameEnvConfig, renderer: renderer.Renderer | None = None
+    env_config: WargameEnvConfig,
+    renderer: renderer.Renderer | None = None,
+    state_exporters: list[StateExporter] | None = None,
 ) -> WargameEnv:
     """Create the Wargame environment.
 
     Returns:
         Configured gymnasium environment
     """
-    env = WargameEnv(env_config, renderer)
+    env = WargameEnv(env_config, renderer, state_exporters=state_exporters)
 
     return env


### PR DESCRIPTION
## Summary

Implements V9 Phase 4 (Event Streaming & Replay) — adds a structured game state I/O layer that records complete match histories as append-only event logs, enables deterministic replay from any step, and provides automated match analysis for training evaluation.

## Changes

**Core event stream** (`wargame_rl/wargame/envs/state/`):
- `events.py` — StateDelta, ResetEvent, StepEvent models with compute_delta/apply_delta
- `event_log.py` — EventLog accumulator with configurable anchor intervals
- `exporter.py` — StateExporter protocol + EventLogExporter
- `replay.py` — ReplayController with random-access seek
- `codecs.py` — MatchCodec protocol, JsonMatchCodec, registry
- `analysis.py` — MatchAnalysis model with movement, tactical, rule compliance, and degenerate behavior metrics

**Env integration**:
- WargameEnv accepts optional `state_exporters` list (zero overhead when empty)
- `create_environment()` factory passes through exporters

**CLI tools**:
- `--record-events` flag on both train.py and simulate.py
- `replay_events.py` — narrate, seek, summary commands
- `analyze_events.py` — report (text/JSON) and compare commands
- Justfile recipes: record, replay, analyze, analyze-json, analyze-compare

**Docs**: `docs/game-state-io.md` — full architecture, data flow, extension points

**Tests**: 22 tests covering event log, delta encoding, replay determinism, codec round-trip, env integration

## Requirements covered

- SGS-03: Layered change protocol (full snapshots + granular deltas)
- SGS-05: Append-only ordered event stream
- SGS-06: Deterministic replay