### PR TITLE
chore: archive v9.0 milestone

### DIFF
--- a/.planning/MILESTONES.md
+++ b/.planning/MILESTONES.md
@@ -1,0 +1,26 @@
+# Milestones
+
+Shipped milestones for Wargame RL. Each entry links to its archived roadmap and requirements
+in `.planning/milestones/`.
+
+---
+
+## v9.0 — Structured Game State & LLM-Readable Representation
+
+**Shipped:** 2026-06-19
+**Phases:** 5 | **Plans:** 3 formal (Phases 2–4 implemented directly) | **Requirements:** 14/14 SGS-* complete
+**PRs:** #110, #111, #114, #116
+**Archive:** [v9-ROADMAP.md](milestones/v9-ROADMAP.md) · [v9-REQUIREMENTS.md](milestones/v9-REQUIREMENTS.md)
+
+**Delivered:** A canonical, serialisable game-state model with bidirectional I/O, LLM-readable
+text narration, and an append-only event stream with deterministic replay — surfacing the
+environment's rich internal state for external APIs, scenario authoring, and LLM evaluation.
+
+**Key accomplishments:**
+1. Pydantic `GameStateSnapshot` projected from `BattleView`, exportable to JSON with a JSON Schema document (`WargameEnv.to_snapshot()`)
+2. Bidirectional I/O — `GameClock.set_state()` + `WargameEnv.load_state()` with `validate_snapshot()` and verified round-trip fidelity
+3. `StepNarrator` and public `describe_action()` produce LLM-readable per-step text with combat narrative, probabilities, expected damage, and reward-phase context
+4. Append-only event stream with delta encoding and deterministic replay behind a pluggable codec interface (JSONL)
+5. End-to-end milestone validation: 25 validation tests covering the full snapshot → inject → step → stream → replay pipeline
+
+**Stats:** new `envs/state/` module (~2,040 LOC, 9 files); ~1,615 LOC of tests; ~27 days (2026-05-23 → 2026-06-19).

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -32,6 +32,10 @@ Agents learn recognisable tactical behaviour — advancing on objectives, mainta
 - ✓ Line-of-sight query on discrete grid (Bresenham, injectable blocking, `WargameEnv.has_line_of_sight_between_cells`) — Phase 3
 - ✓ Shooting action space (target selection in ActionRegistry, phase-gated masks combining LOS/range/alive, WeaponProfile config) — Phase 4
 - ✓ Shooting resolution (hit → wound → save → damage with stochastic D6 rolls, configurable weapon profiles and defensive stats, combat stats + expected damage in observation) — Phase 5
+- ✓ Canonical game-state model (`GameStateSnapshot` from `BattleView`, JSON + JSON Schema, `WargameEnv.to_snapshot()`) — v9.0
+- ✓ Bidirectional state I/O (`GameClock.set_state()`, `WargameEnv.load_state()`, `validate_snapshot()`, round-trip fidelity) — v9.0
+- ✓ LLM-readable text representation (`StepNarrator`, public `describe_action()`, combat narrative with probabilities/expected damage, reward-phase context) — v9.0
+- ✓ Append-only event stream with delta encoding and deterministic replay behind a pluggable codec interface — v9.0
 
 ### Active
 
@@ -121,14 +125,11 @@ the current one finishes.
 - [ ] Web replay viewer (browser-based, replacing/complementing Pygame)
 - [ ] Community scenario library (env configs for classic missions)
 
-#### v9.0 — Structured game state & event streaming [NEXT · HIGH]
+#### v9.0 — Structured game state & event streaming [✅ SHIPPED 2026-06-19]
 
-- [ ] **Canonical state model** — Programmatic representation of the full game (board, models, objectives, phase, scores, etc.) derived from domain / `BattleView`, independent of raw tensors
-- [ ] **API- and LLM-ready text** — Stable field names, documented semantics, and schema versioning so the same payload suits HTTP/streaming APIs and LLM validation of legality and consistency
-- [ ] **Layered change protocol** — Efficient encoding of state updates: full snapshots where needed, plus granular deltas at the right abstraction level (turn, step, sub-step) without redundant bulk
-- [ ] **Pluggable serialisation** — Default JSON; clear extension points for alternative encodings (e.g. binary or compact formats) behind a shared interface
-- [ ] **Append-only event stream** — Ordered events that record match history end-to-end and can be stored or streamed to consumers
-- [ ] **Deterministic replay / fast-forward** — Apply the event log (or snapshot + tail) from a known initial configuration to reconstruct any past state or seek to a checkpoint
+Complete — see `.planning/milestones/v9-ROADMAP.md`. All 14 SGS-* requirements verified with
+test evidence. Delivered: canonical `GameStateSnapshot`, bidirectional I/O, LLM-readable
+narration, and an append-only event stream with deterministic replay.
 
 #### Foundation (cross-cutting, slotted into milestones as needed)
 
@@ -156,7 +157,7 @@ This is a brownfield project with a working environment, two RL algorithms, and 
 
 The project models a tabletop miniatures wargame with detailed rules (see `docs/tabletop-rules-reference.md`). The environment currently implements movement and objective control. The long-term vision spans nine milestone tracks (v1.0–v9.0) progressing from ranged combat through terrain, advanced movement, weapon diversity, morale, tactical resources, adversarial self-play, scale, and structured programmatic state with event streaming for APIs and LLMs (v9.0). Melee combat is explicitly out of scope.
 
-**Current priorities:** v1.0 (Ranged Combat) and v7.0 (Adversarial Play) are active WIP. v2.0 (Terrain) and v9.0 (Structured State) are next up after current work lands. v3.0/v4.0 are low priority; v5.0/v6.0/v8.0 are lowest priority. Future milestones are captured in the Active requirements above and will be created via `/gsd-new-milestone` as each completes.
+**Current priorities:** v9.0 (Structured State) shipped 2026-06-19. v1.0 (Ranged Combat) is complete except the deferred Phase 6 (Combat Reward & Curriculum). v7.0 (Adversarial Play) is active WIP and v2.0 (Terrain) is next up. v3.0/v4.0 are low priority; v5.0/v6.0/v8.0 are lowest priority. Future milestones are captured in the Active requirements above and will be created via `/gsd-new-milestone` as each completes.
 
 ## Constraints
 
@@ -178,6 +179,10 @@ The project models a tabletop miniatures wargame with detailed rules (see `docs/
 | Reward phases for curriculum learning | Breaks sparse reward problem into learnable stages | ✓ Good |
 | Skip non-movement phases by default | Keeps training fast until mechanics are implemented | ✓ Good |
 | Phase 3 LOS: interior cells only for blocking; optional YAML `blocking_mask`; single `domain/los.py` | Matches tabletop-style trace; v2 terrain maps onto mask; no duplicate Bresenham in render | ✓ Good |
+| v9.0: canonical `GameStateSnapshot` projected from `BattleView`, decoupled from RL observation tensors | Same data serves two consumers (RL pipeline + external/LLM) without coupling | ✓ Good |
+| v9.0: default JSON encoding behind a pluggable codec interface (event log uses JSONL) | Extensible to binary/compact formats without changing the canonical model | ✓ Good |
+| v9.0: combat results carry attacker-target pairing + analytical context (probabilities, expected damage) | Enables an LLM to judge whether the agent chose the optimal target | ✓ Good |
+| v9.0: append-only event stream with delta encoding between full-snapshot anchors; deterministic replay | Compact history + reproducible seek/fast-forward from a known initial configuration | ✓ Good |
 
 ## Evolution
 
@@ -197,4 +202,4 @@ This document evolves at phase transitions and milestone boundaries.
 4. Update Context with current state
 
 ---
-*Last updated: 2026-04-06 — Phase 5 complete: shooting resolution with stochastic D6 attack sequence, configurable weapon/defense stats, combat observation features*
+*Last updated: 2026-06-19 — v9.0 milestone complete: structured game state, bidirectional I/O, LLM-readable narration, and event streaming with deterministic replay (14/14 SGS-* verified)*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -88,35 +88,10 @@ Deferred to future milestones. Tracked but not in current roadmap.
 - **SCALE-02**: Web replay viewer
 - **SCALE-03**: Community scenario library
 
-### Structured state & events (v9.0)
+### Structured state & events (v9.0) — ✅ SHIPPED 2026-06-19
 
-Roadmap: `.planning/v9-ROADMAP.md`
-
-#### Canonical State & Export
-
-- [x] **SGS-01**: A canonical programmatic game-state model exists (board, entities, phase, scoring, etc.), sourced from domain / read-only views, not tied to RL observation tensors
-- [x] **SGS-02**: Serialised state is suitable for external APIs and for LLM-facing validation (stable identifiers, documented semantics, explicit schema version)
-- [x] **SGS-04**: Default encoding is JSON; a codec or encoder interface allows additional formats without changing the canonical model
-
-#### State Injection (new — discovered during v9.0 research)
-
-- [x] **SGS-07**: `GameClock.set_state()` can position the clock at any valid round/phase/player combination for state injection
-- [x] **SGS-08**: `WargameEnv.load_state(snapshot)` constructs a mid-episode environment from a `GameStateSnapshot`, recomputing derived state
-- [x] **SGS-09**: Round-trip state fidelity: `to_snapshot()` → `load_state()` → `to_snapshot()` produces identical output
-
-#### LLM Text Representation (new — discovered during v9.0 research)
-
-- [x] **SGS-10**: `describe_action()` method produces human/LLM-readable text for any action integer (e.g. "Move NE at speed 4", "Shoot at opponent 1")
-- [x] **SGS-11**: Combat results include attacker-target pairing and analytical context (probabilities, expected damage) for LLM evaluation
-- [x] **SGS-12**: Opponent actions are recorded before application and available in state output
-- [x] **SGS-13**: `StepNarrator` produces per-step text summaries covering state, decoded actions, combat narrative, and reward breakdown with phase context
-- [x] **SGS-14**: Reward breakdown and active reward phase name are included in state output
-
-#### Event Streaming & Replay
-
-- [x] **SGS-03**: A layered change protocol expresses updates as full snapshots and/or granular deltas at defined abstraction levels to minimise redundancy
-- [x] **SGS-05**: An append-only, ordered event stream can represent a complete match history for storage or streaming
-- [x] **SGS-06**: Replay is deterministic: events (optionally with periodic snapshots) applied from a known initial configuration reconstruct any requested historical state (fast-forward / seek)
+Completed and archived. See `.planning/milestones/v9-REQUIREMENTS.md` and
+`.planning/milestones/v9-ROADMAP.md`. All 14 SGS-* requirements verified with test evidence.
 
 ## Out of Scope
 
@@ -166,30 +141,9 @@ Roadmap: `.planning/v9-ROADMAP.md`
 - Mapped to phases: 26 ✓
 - Unmapped: 0
 
-**v9.0 Coverage (structured state & events):**
-
-| Requirement | Phase | Status | Evidence |
-|-------------|-------|--------|----------|
-| SGS-01 | Phase 1 | Complete | `test_snapshot.py`, `test_v9_milestone_validation.py::test_sgs01` |
-| SGS-02 | Phase 3 | Complete | `test_snapshot.py::TestJsonSerialisation`, `test_v9_milestone_validation.py::test_sgs02` |
-| SGS-03 | Phase 4 | Complete | `test_event_stream.py::TestDeltaEncoding`, `test_v9_milestone_validation.py::test_sgs03` |
-| SGS-04 | Phase 1 | Complete | `test_snapshot.py::TestEncoder`, `test_event_stream.py::TestCodecRoundTrip`, `test_v9_milestone_validation.py::test_sgs04` |
-| SGS-05 | Phase 4 | Complete | `test_event_stream.py::TestEventLog`, `test_v9_milestone_validation.py::test_sgs05` |
-| SGS-06 | Phase 4 | Complete | `test_event_stream.py::TestReplay`, `test_v9_milestone_validation.py::test_sgs06` |
-| SGS-07 | Phase 2 | Complete | `test_state_injection.py::TestClockSetState`, `test_v9_milestone_validation.py::test_sgs07` |
-| SGS-08 | Phase 2 | Complete | `test_state_injection.py::TestLoadState`, `test_v9_milestone_validation.py::test_sgs08` |
-| SGS-09 | Phase 2 | Complete | `test_state_injection.py::TestRoundTrip`, `test_v9_milestone_validation.py::test_sgs09` |
-| SGS-10 | Phase 3 | Complete | `test_narrator.py::TestDescribeActionPublic`, `test_v9_milestone_validation.py::test_sgs10` |
-| SGS-11 | Phase 1 | Complete | `test_snapshot.py::TestCombatResults` |
-| SGS-12 | Phase 1 | Complete | `test_snapshot.py` (opponent actions) |
-| SGS-13 | Phase 3 | Complete | `test_narrator.py` (narrate tests), `test_v9_milestone_validation.py::test_sgs13` |
-| SGS-14 | Phase 1 | Complete | `test_snapshot.py::TestRewardBreakdown`, `test_v9_milestone_validation.py::test_sgs14` |
-
-- v9.0 requirements: 14 total (6 original + 8 discovered during research)
-- Complete: 14 ✓
-- Unmapped: 0
-- End-to-end pipeline validated: `test_v9_milestone_validation.py::TestEndToEndPipeline`
+**v9.0 Coverage (structured state & events):** Shipped 2026-06-19 — archived to
+`.planning/milestones/v9-REQUIREMENTS.md` (14/14 SGS-* complete with test evidence).
 
 ---
 *Requirements defined: 2026-04-02*
-*Last updated: 2026-06-19 — v9.0 milestone validated: all 14 SGS-* requirements complete with test evidence*
+*Last updated: 2026-06-19 — v9.0 milestone archived; v1.0 shooting requirements remain (Phase 6 deferred)*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,5 +1,10 @@
 # Roadmap: Shooting & Model Destruction
 
+## Milestones
+
+- ✅ **v9.0 Structured Game State & LLM-Readable Representation** — shipped 2026-06-19 ([archive](milestones/v9-ROADMAP.md))
+- 🚧 **v1.0 Shooting & Model Destruction** — Phases 1–5 complete; Phase 6 (Combat Reward & Curriculum) deferred (this roadmap)
+
 ## Overview
 
 This milestone adds combat to the wargame environment. Models gain durable wound state, a line-of-sight service enables target validity, the action space grows to include shooting, and combat rewards drive curriculum learning. The build order follows dependency: wounds first (shooting needs something to damage), LOS next (shooting needs validity checks), then action space, resolution, and finally rewards. Phases 2 and 3 are independent and can execute in parallel.

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,8 +3,8 @@ gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
 status: active
-stopped_at: v9 milestone complete (all 5 phases validated)
-last_updated: "2026-06-19T00:00:00.000Z"
+stopped_at: v9.0 milestone archived (all 5 phases validated, 14/14 SGS-* verified)
+last_updated: "2026-06-19T22:00:00.000Z"
 last_activity: 2026-06-19
 progress:
   total_phases: 6
@@ -20,19 +20,21 @@ progress:
 See: .planning/PROJECT.md (updated 2026-04-04)
 
 **Core value:** Agents learn recognisable tactical behaviour through reward shaping and environment design
-**Current focus:** v9 milestone complete; v1.0 Phase 6 deferred
+**Current focus:** v9.0 archived; planning next milestone (v1.0 Phase 6 deferred)
 
 ## Current Position
 
-**v1.0 (Shooting & Model Destruction):**
-Phases 1–5 complete (8/8 plans executed)
-Phase 6 deferred
+**No active milestone — between milestones.** Next: `/gsd-new-milestone`.
 
-**v9 (Structured Game State & LLM-Readable Representation):**
+**v9.0 (Structured Game State & LLM-Readable Representation): ✅ ARCHIVED 2026-06-19**
 All 5 phases complete. 14/14 SGS-* requirements verified.
+Archive: `.planning/milestones/v9-ROADMAP.md`, `.planning/milestones/v9-REQUIREMENTS.md`
 - Phases 1–3 merged 2026-05-23 (PRs #110, #111)
 - Phase 4 merged 2026-06-18 (PR #114)
-- Phase 5 (Milestone Validation) completed 2026-06-19
+- Phase 5 (Milestone Validation) merged 2026-06-19 (PR #116)
+
+**v1.0 (Shooting & Model Destruction):**
+Phases 1–5 complete (8/8 plans executed); Phase 6 (Combat Reward & Curriculum) deferred
 
 ## Performance Metrics
 

--- a/.planning/milestones/v9-REQUIREMENTS.md
+++ b/.planning/milestones/v9-REQUIREMENTS.md
@@ -1,0 +1,67 @@
+# Requirements Archive — v9.0: Structured Game State & Event Streaming
+
+**Status:** ✅ SHIPPED 2026-06-19
+**Roadmap:** `.planning/milestones/v9-ROADMAP.md`
+**Core Value:** Agents learn recognisable tactical behaviour through reward shaping and environment design
+
+This archive captures the v9.0 milestone requirements (structured state & events), all
+complete with test evidence. The v9 requirements were extracted from the shared
+`.planning/REQUIREMENTS.md` at milestone completion; the v1.0 (Shooting & Destruction)
+requirements remain in the active `REQUIREMENTS.md` because that milestone has deferred work
+(Phase 6: Combat Reward & Curriculum).
+
+## Requirements
+
+### Canonical State & Export
+
+- [x] **SGS-01**: A canonical programmatic game-state model exists (board, entities, phase, scoring, etc.), sourced from domain / read-only views, not tied to RL observation tensors
+- [x] **SGS-02**: Serialised state is suitable for external APIs and for LLM-facing validation (stable identifiers, documented semantics, explicit schema version)
+- [x] **SGS-04**: Default encoding is JSON; a codec or encoder interface allows additional formats without changing the canonical model
+
+### State Injection (discovered during v9.0 research)
+
+- [x] **SGS-07**: `GameClock.set_state()` can position the clock at any valid round/phase/player combination for state injection
+- [x] **SGS-08**: `WargameEnv.load_state(snapshot)` constructs a mid-episode environment from a `GameStateSnapshot`, recomputing derived state
+- [x] **SGS-09**: Round-trip state fidelity: `to_snapshot()` → `load_state()` → `to_snapshot()` produces identical output
+
+### LLM Text Representation (discovered during v9.0 research)
+
+- [x] **SGS-10**: `describe_action()` produces human/LLM-readable text for any action integer (e.g. "Move NE at speed 4", "Shoot at opponent 1")
+- [x] **SGS-11**: Combat results include attacker-target pairing and analytical context (probabilities, expected damage) for LLM evaluation
+- [x] **SGS-12**: Opponent actions are recorded before application and available in state output
+- [x] **SGS-13**: `StepNarrator` produces per-step text summaries covering state, decoded actions, combat narrative, and reward breakdown with phase context
+- [x] **SGS-14**: Reward breakdown and active reward phase name are included in state output
+
+### Event Streaming & Replay
+
+- [x] **SGS-03**: A layered change protocol expresses updates as full snapshots and/or granular deltas at defined abstraction levels to minimise redundancy
+- [x] **SGS-05**: An append-only, ordered event stream can represent a complete match history for storage or streaming
+- [x] **SGS-06**: Replay is deterministic: events (optionally with periodic snapshots) applied from a known initial configuration reconstruct any requested historical state (fast-forward / seek)
+
+## Traceability
+
+| Requirement | Phase | Status | Evidence |
+|-------------|-------|--------|----------|
+| SGS-01 | Phase 1 | Complete | `test_snapshot.py`, `test_v9_milestone_validation.py::test_sgs01` |
+| SGS-02 | Phase 3 | Complete | `test_snapshot.py::TestJsonSerialisation`, `test_v9_milestone_validation.py::test_sgs02` |
+| SGS-03 | Phase 4 | Complete | `test_event_stream.py::TestDeltaEncoding`, `test_v9_milestone_validation.py::test_sgs03` |
+| SGS-04 | Phase 1 | Complete | `test_snapshot.py::TestEncoder`, `test_event_stream.py::TestCodecRoundTrip`, `test_v9_milestone_validation.py::test_sgs04` |
+| SGS-05 | Phase 4 | Complete | `test_event_stream.py::TestEventLog`, `test_v9_milestone_validation.py::test_sgs05` |
+| SGS-06 | Phase 4 | Complete | `test_event_stream.py::TestReplay`, `test_v9_milestone_validation.py::test_sgs06` |
+| SGS-07 | Phase 2 | Complete | `test_state_injection.py::TestClockSetState`, `test_v9_milestone_validation.py::test_sgs07` |
+| SGS-08 | Phase 2 | Complete | `test_state_injection.py::TestLoadState`, `test_v9_milestone_validation.py::test_sgs08` |
+| SGS-09 | Phase 2 | Complete | `test_state_injection.py::TestRoundTrip`, `test_v9_milestone_validation.py::test_sgs09` |
+| SGS-10 | Phase 3 | Complete | `test_narrator.py::TestDescribeActionPublic`, `test_v9_milestone_validation.py::test_sgs10` |
+| SGS-11 | Phase 1 | Complete | `test_snapshot.py::TestCombatResults` |
+| SGS-12 | Phase 1 | Complete | `test_snapshot.py` (opponent actions) |
+| SGS-13 | Phase 3 | Complete | `test_narrator.py` (narrate tests), `test_v9_milestone_validation.py::test_sgs13` |
+| SGS-14 | Phase 1 | Complete | `test_snapshot.py::TestRewardBreakdown`, `test_v9_milestone_validation.py::test_sgs14` |
+
+**Coverage:**
+- v9.0 requirements: 14 total (6 original + 8 discovered during research)
+- Complete: 14 ✓
+- Unmapped: 0
+- End-to-end pipeline validated: `test_v9_milestone_validation.py::TestEndToEndPipeline`
+
+---
+*Archived: 2026-06-19 — v9.0 milestone complete, all 14 SGS-* requirements verified with test evidence.*

--- a/.planning/milestones/v9-ROADMAP.md
+++ b/.planning/milestones/v9-ROADMAP.md
@@ -1,10 +1,26 @@
-# Roadmap: Structured Game State & LLM-Readable Representation
+# Milestone v9.0: Structured Game State & LLM-Readable Representation
+
+**Status:** ✅ SHIPPED 2026-06-19
+**Phases:** 1–5
+**Total Plans:** 3 formal plans (Phases 2–4 implemented directly in-branch)
+**Timeline:** 2026-05-23 → 2026-06-19 (~27 days)
+**PRs:** #110, #111, #114, #116
 
 ## Overview
 
-This milestone adds programmatic state I/O and LLM-interpretable representation to the wargame environment. The codebase already contains rich structured data at every step — entity positions and wounds, game clock state, combat results, detailed reward breakdowns, and decodable action indices — but none of it is surfaced outside the RL tensor pipeline. This milestone builds a Pydantic-based canonical state model (`GameStateSnapshot`), bidirectional I/O (export and injection), and a text narration layer for LLM evaluation.
+This milestone added programmatic state I/O and LLM-interpretable representation to the
+wargame environment. The codebase already contained rich structured data at every step —
+entity positions and wounds, game clock state, combat results, detailed reward breakdowns,
+and decodable action indices — but none of it was surfaced outside the RL tensor pipeline.
+This milestone built a Pydantic-based canonical state model (`GameStateSnapshot`),
+bidirectional I/O (export and injection), a text narration layer for LLM evaluation, and an
+append-only event stream with deterministic replay.
 
-The build order follows dependency: the canonical schema first (everything depends on it), then state injection (the "input" side of bidirectional I/O), then LLM text (builds on the data captured in the snapshot). Event streaming and replay build on the stable schema established in Phases 1–3. A final validation phase verifies all milestone requirements and success criteria end-to-end.
+The build order followed dependency: the canonical schema first (everything depends on it),
+then state injection (the "input" side of bidirectional I/O), then LLM text (builds on the
+data captured in the snapshot). Event streaming and replay built on the stable schema
+established in Phases 1–3. A final validation phase verified all milestone requirements and
+success criteria end-to-end.
 
 ## Phases
 
@@ -12,7 +28,7 @@ The build order follows dependency: the canonical schema first (everything depen
 - [x] **Phase 2: State Injection & Bidirectional I/O** — `GameClock.set_state()`, `WargameEnv.load_state(snapshot)`, validation, derive computed fields from injected state (completed 2026-05-23)
 - [x] **Phase 3: LLM-Readable Text Representation** — Action descriptions, combat narrative, step narrator, reward breakdown text for LLM evaluation (completed 2026-05-23)
 - [x] **Phase 4: Event Streaming & Replay** — Append-only event log, delta encoding, deterministic replay, pluggable codec interface (completed 2026-06-18, PR #114)
-- [x] **Phase 5: Milestone Validation** — End-to-end verification of all v9 requirements and success criteria across Phases 1–4 (completed 2026-06-19)
+- [x] **Phase 5: Milestone Validation** — End-to-end verification of all v9 requirements and success criteria across Phases 1–4 (completed 2026-06-19, PR #116)
 
 ## Phase Details
 
@@ -27,7 +43,6 @@ The build order follows dependency: the canonical schema first (everything depen
   4. Combat results include attacker-target pairing (which model shot which target) — not just flat `ShootingResult` lists
   5. Opponent actions are recorded before application and available in the snapshot
 **Plans:** 1 plan
-Plans:
 - [x] v9-01-01-PLAN.md — Snapshot Pydantic models, PairedShootingResult, build_snapshot factory, to_snapshot(), encoder protocol, tests
 
 ### Phase 2: State Injection & Bidirectional I/O
@@ -56,7 +71,7 @@ Plans:
 
 ### Phase 4: Event Streaming & Replay
 **Goal**: A complete match history can be recorded as an ordered event stream and replayed deterministically
-**Depends on**: Phase 1 (stable schema — now complete)
+**Depends on**: Phase 1 (stable schema)
 **Requirements**: SGS-03, SGS-05, SGS-06
 **Success Criteria** (what must be TRUE):
   1. A `StateExporter` protocol with `on_reset()` / `on_step()` hooks produces an append-only event log recording the full match ✓
@@ -76,22 +91,38 @@ Plans:
   3. Round-trip and replay scenarios exercise the full pipeline: snapshot → inject → step → stream → replay ✓
   4. Requirements traceability table in REQUIREMENTS.md is fully updated ✓
 **Plans**: 1 plan
-Plans:
 - [x] v9-05 validation — End-to-end pipeline tests, analyze_match() coverage, requirements traceability update
 **Key tests**: `test_v9_milestone_validation.py` (25 tests: 2 E2E pipeline, 11 analyze_match, 12 SGS-* spot-checks)
 
-## Progress
+---
 
-**Execution Order:**
-Phases execute in numeric order: 1 → 2 → 3 → 4 → 5
-(Phases 2 and 3 are independent after Phase 1 and can execute in parallel)
+## Milestone Summary
 
-| Phase | Plans Complete | Status | Completed |
-|-------|----------------|--------|-----------|
-| 1. Canonical State Model & Export | 1/1 | Complete | 2026-05-23 |
-| 2. State Injection & Bidirectional I/O | 1/1 | Complete | 2026-05-23 |
-| 3. LLM-Readable Text Representation | 1/1 | Complete | 2026-05-23 |
-| 4. Event Streaming & Replay | 1/1 | Complete | 2026-06-18 |
-| 5. Milestone Validation | 1/1 | Complete | 2026-06-19 |
+**Delivered:** A canonical, serialisable game-state model with bidirectional I/O, LLM-readable
+text narration, and an append-only event stream with deterministic replay — surfacing the
+environment's rich internal state for external APIs, scenario authoring, and LLM evaluation.
 
-**Milestone v9.0 complete.** All 14 SGS-* requirements verified with test evidence.
+**Stats:**
+- Phases: 5 (3 formal plans; Phases 2–4 implemented directly in-branch)
+- Requirements: 14/14 SGS-* complete with test evidence
+- New module: `wargame_rl/wargame/envs/state/` — ~2,040 LOC across 9 files (snapshot, codecs, events, event_log, exporter, narrator, replay, analysis)
+- Tests: ~1,615 LOC across 5 test files (snapshot, state_injection, narrator, event_stream, v9_milestone_validation)
+- Timeline: 2026-05-23 → 2026-06-19 (~27 days)
+
+**Key Decisions:**
+- Canonical `GameStateSnapshot` projected from `BattleView` (read-only), decoupled from RL observation tensors — same data, two consumers
+- Default encoding JSON; pluggable codec interface for alternative formats (event log later switched to JSONL)
+- Combat results carry attacker-target pairing + analytical context (probabilities, expected damage) so an LLM can judge target selection
+- Reward breakdown text includes the active reward phase name — values are uninterpretable without it
+- Event log is append-only with delta encoding between full-snapshot anchors; replay is deterministic from a known initial configuration
+
+**Issues Resolved:**
+- mypy arg-type errors in delta construction (`c02603b`) and snapshot (`1bdcd77`)
+- Replay assertions made tolerant of delta-encoding gaps on Python 3.13 (`7690b3c`, `6196228`)
+
+**Technical Debt / Deferred:**
+- None specific to v9. Transformer shooting-head alignment and dead-entity attention masking remain cross-cutting foundation items tracked in PROJECT.md.
+
+---
+
+_For current project status, see `.planning/ROADMAP.md` and `.planning/PROJECT.md`._


### PR DESCRIPTION
## Summary

Formally archives the completed **v9.0 — Structured Game State & LLM-Readable Representation** milestone (the first formal GSD milestone archival in this repo). The milestone shipped via PRs #110, #111, #114, and #116; all 5 phases are complete and all 14 SGS-* requirements are verified with test evidence.

- Add `.planning/milestones/v9-ROADMAP.md` and `.planning/milestones/v9-REQUIREMENTS.md` archives
- Add `.planning/MILESTONES.md` milestone log with the v9.0 entry
- Move v9.0 requirements to **Validated** and log key decisions in `PROJECT.md`
- Trim the now-archived v9 section out of the active `REQUIREMENTS.md` (v1.0 shooting reqs remain, since Phase 6 is deferred)
- Add a **Milestones** section to `ROADMAP.md`; update `STATE.md` to between-milestones

This is docs/planning-only — no source or test changes. No git tag was created (the planning "v9" milestone label doesn't map onto the existing `v1.x` tag scheme; deferred per discussion).

## Test plan

- [ ] Docs-only change — verify archived links resolve (`milestones/v9-ROADMAP.md`, `milestones/v9-REQUIREMENTS.md`)
- [ ] Confirm `STATE.md` / `PROJECT.md` reflect v9.0 as shipped and v1.0 Phase 6 as deferred

Made with [Cursor](https://cursor.com)