### PR TITLE
chore: prefer justfile recipes over direct uv run

### DIFF
--- a/.cursor/rules/workflow-preferences.mdc
+++ b/.cursor/rules/workflow-preferences.mdc
@@ -7,7 +7,9 @@ alwaysApply: true
 
 ## Task Runner
 
-- Always use `just` to run tasks (train, test, lint, etc.) — never invoke `uv run` directly
+- **Always start from the Justfile.** Before running any project operation (format, lint, test, train, validate, sync, simulate, etc.), check `Justfile` for an existing recipe and use `just <recipe>` — never invoke `uv run` (or other tool wrappers) directly when a recipe exists
+- If no recipe exists for what you need, prefer adding one to the Justfile over running ad-hoc `uv run` commands; only fall back to `uv run` when a one-off is clearly not worth a recipe
+- Discover recipes with `just` / `just --list` when unsure of the name or arguments
 - Default algorithm is PPO; do not default to DQN unless explicitly asked
 - Default network type is transformer; do not default to MLP unless explicitly asked
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,10 +94,10 @@ wargame_rl/
 
 ## Coding Practice
 
-- Before saying tasks are finished, ALWAYS run `uv run ruff format` and `uv run ruff check --fix`. Fix any errors.
-- Run `uv run pytest` after large changes
-- Run `uv run pytest` after adding any tests
-- ALWAYS run `uv run pre-commit run --files <changed-files>` on files that have changed
+- Before saying tasks are finished, ALWAYS run `just format` and `just lint`. Fix any errors.
+- Run `just test` after large changes
+- Run `just test` after adding any tests
+- ALWAYS run `just format && just lint` (or `just validate`) on files that have changed; use Justfile recipes rather than `uv run` directly
 - ALWAYS add type hinting for inputs and outputs
 - Pass dependencies in; don't construct them inside classes
 - NEVER include unimportable resources
@@ -136,7 +136,7 @@ wargame_rl/
 ## Package Management
 
 - Use `uv add` to add new packages
-- Use `uv run` to run any Python commands
+- Always start from the Justfile: use `just <recipe>` for project operations; only use `uv run` when no suitable recipe exists
 
 ## Git Workflow
 


### PR DESCRIPTION
## Summary
- Strengthen agent workflow rules to always start from the Justfile before running project operations
- Align CLAUDE.md finish/test/package guidance with `just` recipes instead of direct `uv run`

## Changes
- `.cursor/rules/workflow-preferences.mdc`: require checking Justfile first; prefer adding recipes over ad-hoc `uv run`
- `CLAUDE.md`: format/lint/test and package-management notes now point at Just recipes

## Test plan
- [ ] Confirm untracked terrain files were not included in the PR
- [ ] Spot-check that agent guidance still matches existing Just recipes (`format`, `lint`, `test`, `validate`, `train`)


Made with [Cursor](https://cursor.com)