### PR TITLE
docs: translate cursor rules into claude equivalents

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: ship
+description: Creates a feature branch, commits staged changes, pushes, and opens a PR. Use when the user says "ship", "branch commit push pr", or wants to create a PR from current changes.
+---
+
+# Ship (branch, commit, push, PR)
+
+When the user invokes this skill, run the full ship workflow: **branch only from main** → commit → push → open PR → set PR description from branch changes.
+
+**Critical:** New branches must always be created from `main`. Never create a feature branch from another branch.
+
+## Steps
+
+1. **Get branch name and commit message**
+   - If the user provided them (e.g. `/ship feature/my-feature Add reward shaping`), use those.
+   - Otherwise ask: "Branch name (e.g. feature/my-feature)?" and "Commit message (imperative, e.g. Add reward shaping)?"
+
+2. **Run the ship**
+   - In the project root, run:
+     ```bash
+     just ship <branch> "<commit message>"
+     ```
+   - This checks out `main`, pulls latest, creates the new branch from `main`, stages all changes, commits with the message as both title and body, pushes, and runs `gh pr create --fill` so the PR title and description are populated from the commit.
+   - If you're not on `main`, the recipe runs `git checkout main` and `git pull` first so the new branch is always created from up-to-date `main`.
+
+3. **Set PR description from branch changes**
+   - After the PR is created, generate a short description from the changes in the branch (vs `main`).
+   - Run `git log main..HEAD --oneline` and `git diff main --stat` (or `--name-only`) to see commits and changed files.
+   - Compose a PR body that includes: (1) a short summary (one or two sentences) of what the PR does, and (2) a "Changes" section listing notable files or areas (e.g. "env: add VP to Battle and BattleView", "mission: new VP calculator and registry").
+   - Run `gh pr edit --body "<description>"` to set the PR description. Use a single-quoted or escaped multi-line string so the shell receives the body correctly.
+
+4. **If something fails**
+   - If pre-commit or commit fails, suggest running `just validate` first and fixing any issues, then try again.
+   - If the user has nothing staged and doesn't want to commit everything, suggest staging with `git add <paths>` then running `just ship` again (note: `just ship` runs `git add -A`, so they may prefer to run the git/gh steps manually for partial commits).
+
+## Branch naming (reminder)
+
+Use `feature/<topic>`, `fix/<topic>`, or `refactor/<topic>` — never commit to `main`.
+
+## PR titles
+
+Use conventional commits (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:`) followed by a space and a lower case letter — CI enforces this.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,16 @@ Reinforcement learning project that trains agents (DQN, PPO) to play tabletop wa
 - **Loguru** — logging
 - **Pygame** — human rendering
 
+## Development Tooling
+
+- **Just** — command runner (see `Justfile`)
+- **Ruff** — linter & formatter (line length 88, double quotes)
+- **Mypy** — strict type checking (`disallow_untyped_defs`, `no_implicit_optional`)
+- **isort** — import sorting (Black profile)
+- **autoflake** — removes unused imports
+- **Pytest** — testing
+- **Pre-commit** — hooks for all of the above
+
 ## Project Layout
 
 ```
@@ -53,6 +63,8 @@ wargame_rl/
 | Full validation | `just validate` |
 | Train (PPO, default) | `just train <config.yaml>` |
 | Train (DQN) | `just train <config.yaml> dqn` |
+| Train multiple configs in parallel | `just train-multi config1.yaml config2.yaml` |
+| Ship (branch → commit → push → PR) | `just ship <branch> "<message>"` |
 | Simulate latest | `just simulate-latest` |
 | Test env (random) | `just test-env` |
 | Profile | `just profile <config.yaml> [model] [max_epochs]` |
@@ -84,6 +96,14 @@ wargame_rl/
 - Environment configs live in `examples/env_config/`
 - Algorithm configs: `DQNConfig`, `PPOConfig` in respective `config.py` files
 - Training config: `TrainingConfig` in `wargame_rl/wargame/model/dqn/config.py`
+
+### Directory-scoped guidance
+
+Detailed patterns live next to the code they govern — read them when working in these areas:
+
+- `wargame_rl/wargame/envs/CLAUDE.md` — Gymnasium env, phases, placement, opponents, rendering
+- `wargame_rl/wargame/model/CLAUDE.md` — networks, DQN/PPO, observation tensor pipeline
+- `tests/CLAUDE.md` — fixtures, test file map, per-feature coverage checklist
 
 ---
 
@@ -121,6 +141,33 @@ wargame_rl/
 - Use Python type hints for all public functions; prefer built-in generics (`list[str]`) over `typing.List`
 - Raise meaningful exceptions; never swallow exceptions silently
 
+## Python Conventions
+
+- All functions typed (mypy strict); `from __future__ import annotations`
+- Modern syntax: `str | None`, `list[int]`, `dict[str, Any]`
+- Imports: isort Black profile (stdlib → third-party → local); absolute (`from wargame_rl.wargame...`)
+- Classes `PascalCase` · functions/vars `snake_case` · constants `UPPER_SNAKE_CASE` · private `_leading_underscore`
+- Ruff: 88 chars, 4-space indent, double quotes
+- Pydantic for structured data/config · `loguru` for logging · `numpy` typed arrays for perf
+
+## Naming & Design
+
+- Prefer general, future-proof names over narrow ones (e.g. `models` not `model_placements`, `ModelConfig` not `ModelPlacement`)
+- When adding per-entity configuration, make positional fields optional so attributes (stats, group, etc.) can be specified independently of placement
+- Avoid hardcoded magic numbers in factory methods — push defaults into Pydantic models with `Field(default=...)`
+- Scripted behaviours: name classes descriptively with a `Scripted` prefix (e.g. `ScriptedAdvanceToObjectivePolicy`, not `ScriptedPolicy`)
+- Use registry pattern with string identifiers for YAML-configurable subsystems (opponent policies, reward calculators/criteria)
+
+## Adding New Entity Types
+
+- Mirror existing entity patterns: reuse the same model class (`WargameModel`), same config schema (`ModelConfig`), same placement logic
+- Parameterize shared infrastructure (e.g. `ActionHandler(n_models=...)`) rather than duplicating it
+- Always default new config fields to the no-op value so existing YAML configs keep working (e.g. `number_of_opponent_models=0`)
+- Full checklist: config types → env state → observation types → observation builder → tensor pipeline → DQN networks → renderer → tests → backward compat tests
+- When adding config that changes step semantics or episode length, update docs (`docs/reward-phases.md`, `docs/tabletop-rules-reference.md`, `docs/opponent-policies.md`, `docs/goals-and-roadmap.md`) and any tests that assume steps-per-round or phase order
+- When adding new reward calculators or success criteria, register them and document in `docs/reward-phases.md` (tables and file layout)
+- When changing the environment, domain, reward, or rendering, follow [docs/ddd-envs.md](docs/ddd-envs.md): keep domain logic in `domain/`, use `BattleView` for read-only state, and preserve dependency direction (domain → types only; reward/renders → BattleView)
+
 ## Testing ("Good Enough" Testing)
 
 - Test the happy path and critical edge cases — not every possible permutation
@@ -135,18 +182,33 @@ wargame_rl/
 
 ## Package Management
 
-- Use `uv add` to add new packages
-- Always start from the Justfile: use `just <recipe>` for project operations; only use `uv run` when no suitable recipe exists
+- Use `uv add [--dev] <pkg>` to add new packages; run `just dev-sync` after pulling lock changes; never manually edit `uv.lock`
+- **Always start from the Justfile.** Before running any project operation (format, lint, test, train, validate, sync, simulate, etc.), check `Justfile` for an existing recipe and use `just <recipe>` — never invoke `uv run` (or other tool wrappers) directly when a recipe exists
+- If no recipe exists for what you need, prefer adding one to the Justfile over running ad-hoc `uv run` commands; only fall back to `uv run` when a one-off is clearly not worth a recipe
+- Discover recipes with `just` / `just --list` when unsure of the name or arguments
+
+## Training Runs
+
+- Default algorithm is **PPO**; do not default to DQN unless explicitly asked
+- Default network type is **transformer**; do not default to MLP unless explicitly asked
+- Start training: `just train <env_config.yaml>` · DQN: `just train <env_config.yaml> dqn` · DQN + network: `just train <env_config.yaml> dqn transformer`
+- **Multiple configs in parallel**: `just train-multi config1.yaml config2.yaml` runs one training per config concurrently (PPO + transformer); each run gets a unique `--run-suffix` and shared `--wandb-group` so they appear grouped in the Wandb UI
+- Env configs live in `examples/env_config/` — copy an existing one to create new scenarios
+- Training logs to Wandb automatically; checkpoints saved to `checkpoints/`. Reward phase index and phase advancement are logged (`reward_phase`, `phase_advanced_at_epoch`) so curriculum runs show phase transitions in the dashboard
+- Key CLI options: `--record-during-training`, `--max-epochs`, `--render-mode`, `--algorithm`, `--no-wandb`, `--run-suffix`, `--wandb-group`
+- Profile a run: `just profile <config.yaml> [model] [max_epochs]` generates `profile.html`
+- Simulate latest checkpoint: `just simulate-latest [network_type]` · Clean up: `just clean` removes `checkpoints/` and `wandb/`
 
 ## Git Workflow
 
 - Always verify the current branch before committing (especially after a PR merge)
 - Create feature branches for all changes; avoid committing directly to `main`
 - Branch naming: `feature/<topic>`, `fix/<topic>`, `refactor/<topic>`
-- Commit messages: imperative mood, concise summary
+- Commit messages: imperative mood, concise summary (e.g. "Add reward shaping for distance")
+- If pre-commit hooks reject a commit, fix the issues and make a new commit — no `--amend`, no `--no-verify`
 - After pushing a new feature branch, always create a PR using `gh pr create`
-- Run `just validate` before pushing
-- **Shipping:** always create a new branch from up-to-date `main` — never reuse an existing feature branch for a new PR
+- Run `just validate` (format + lint + test) before pushing; `just format && just lint` for quick iteration
+- **Shipping:** always create a new branch from up-to-date `main` — never reuse an existing feature branch for a new PR. Checkout `main`, pull latest, then branch. Never push directly on an in-progress branch from another workflow. The `/ship` skill (`.claude/skills/ship/`) automates this via `just ship`
 
 ## CUDA Environment
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,0 +1,28 @@
+# Testing
+
+Applies to everything under `tests/`. General testing philosophy lives in the root `CLAUDE.md`
+("Good Enough" Testing); this file covers the project-specific setup.
+
+## Setup
+
+- Pytest + shared fixtures in `conftest.py`; run via `just test`; coverage → `coverage.xml`
+- Fixtures: `env`, `experiences`, `replay_buffer`, `dqn_net` (parametrized MLP+Transformer), `dqn_mlp_net`, `dqn_transformer_net`
+
+## Rules
+
+- No `@lru_cache` on fixtures — use `scope="module"`/`scope="session"` instead
+- Use `RL_Network` (not `DQN_MLP`) when accepting parametrized `dqn_net`
+- Prefer integration tests; test through public APIs (add properties rather than accessing `_private` attrs)
+- Type-annotate fixtures and test functions
+- `wargame_rl/wargame/envs/interactive_demo.py` is NOT a test
+- When env default config changes stepping (e.g. `skip_phases`), tests that rely on per-phase or all-phase behaviour must set config explicitly (e.g. `skip_phases=[]` in a shared `_make_env` or in the test)
+
+## Test Files
+
+`test_env` (reset/step) · `test_clock_integration` (phases, skip_phases, rounds) · `test_fixed_placement` (config/placement) · `test_dqn` (networks/loss/training) · `test_agent` (actions/episodes) · `test_state` (obs/batch tensors) · `test_opponents` (opponent system) · `test_reward_phases` (reward) · `test_integration` (cross-cutting, backward compat)
+
+## New Features
+
+Cover: config validation · env integration · obs/info · tensor shapes · DQN forward · backward compat
+
+Run `just validate` before pushing.

--- a/wargame_rl/wargame/envs/CLAUDE.md
+++ b/wargame_rl/wargame/envs/CLAUDE.md
@@ -1,0 +1,52 @@
+# Gymnasium Env Patterns
+
+Applies to everything under `wargame_rl/wargame/envs/`.
+
+## Structure
+
+- `WargameEnv` extends `gymnasium.Env`; typed obs/action/info/config (all Pydantic)
+- Config: `WargameEnvConfig` (pydantic-yaml) from `examples/env_config/`
+- Actions: polar (angle, speed) pairs per model via `ActionHandler(n_models=...)`
+  - `ActionHandler.best_action_toward(dx, dy)` for scripted policies; never hardcode action counts — use `ActionHandler.n_actions`
+- `DistanceCache` pre-computes model-objective distances each step
+- Reward: `RewardPhaseManager` (phased reward only); termination in `env_components/termination.py`
+
+## Game timing and phases
+
+- `skip_phases`: list of battle phases to auto-advance (default: all non-movement). `max_turns = n_rounds × (5 - len(skip_phases))`; default is 1 step per round (movement only). Set `skip_phases: []` for full per-phase stepping (5 steps per round).
+- After the player's turn, the opponent's full turn is auto-executed before the next observation. Turn order: `turn_order` (player / opponent / random).
+
+## Placement (`ModelConfig`/`ObjectiveConfig` in YAML)
+
+- No key → full auto · Key without x/y → random + config attrs · Key with x/y → fixed
+- Properties: `has_fixed_model_positions` / `has_fixed_objective_positions` / `has_fixed_opponent_positions`
+
+## Opponents
+
+- Reuse `WargameModel`/`ModelConfig`; YAML keys: `number_of_opponent_models`, `opponent_models`, `turn_order`, `opponent_policy`
+- `TurnOrder`: `player`/`opponent`/`random`
+- Policies in `envs/opponent/`, registry: `RandomPolicy("random")`, `ScriptedAdvanceToObjectivePolicy("scripted_advance_to_objective")`
+- New policies: one class per behaviour, `Scripted` prefix, register as `"scripted_<name>"`; implement `select_action(opponent_models, env, action_mask=None)`
+- `number_of_opponent_models=0` (default) → no policy, env unchanged
+
+## Rendering
+
+- `"human"` (Pygame) / `"rgb_array"` (video); renderer injected via constructor
+- Player: blue/green circles · Opponents: red/warm triangles
+- Use a single FPS cap for human rendering; avoid phase-conditional throttle — it breaks when default stepping changes (e.g. skip_phases)
+
+## Adding Features
+
+1. Config → `WargameEnvConfig` in `types/`
+2. Logic → `env_components/`
+3. Obs → `env_observation.py`/`env_info.py` + obs builder
+4. Tensor → `model/dqn/observation.py`
+5. Networks → both `DQN_MLP` and `DQN_Transformer`
+6. Reward if signals change · Renderer if visual · Tests + backward compat
+
+## Design
+
+- Integer locations; pre-compute expensive ops at `__init__` (numpy vectorized)
+- Track rendering state (e.g. `previous_location`) in same change
+- New entities mirror existing patterns; always backward compatible
+- Follow [docs/ddd-envs.md](../../../docs/ddd-envs.md): keep domain logic in `domain/`, use `BattleView` for read-only state, and preserve dependency direction (domain → types only; reward/renders → BattleView)

--- a/wargame_rl/wargame/model/CLAUDE.md
+++ b/wargame_rl/wargame/model/CLAUDE.md
@@ -1,0 +1,62 @@
+# PyTorch / RL Model Patterns
+
+Applies to everything under `wargame_rl/wargame/model/`.
+
+## Networks
+
+Two network variants implementing `RL_Network` protocol (in `net.py`):
+- `TransformerNetwork` — NanoGPT-style self-attention (default, actively developed)
+- `MLPNetwork` — standard feed-forward (legacy, will be dropped)
+
+Both expose `policy_from_env(env)` and `from_checkpoint(env, path)` class methods.
+
+## DQN (`model/dqn/`)
+
+- `DQNLightning` — PyTorch Lightning module: training loop, epsilon-greedy exploration, target network sync, experience replay
+- `DQNConfig` / `TrainingConfig` — Pydantic config models
+- `ReplayBuffer` — experience replay with `Experience` named tuples
+- `RLDataset` — PyTorch `IterableDataset` wrapping the replay buffer
+- `Agent` — runs episodes with epsilon-greedy policy
+
+## PPO (`model/ppo/`)
+
+- `PPOLightning` — PyTorch Lightning module: actor-critic training, GAE, clipped surrogate objective
+- `PPOConfig` — Pydantic config (lr, gamma, GAE lambda, clip epsilon, etc.)
+- `PPO_Transformer` — actor-critic model with shared transformer backbone, separate policy and value heads
+- `PPOModel` — wraps policy net + value net
+- PPO only supports `TransformerNetwork` (no MLP variant)
+
+## Shared (`model/common/`)
+
+- `create_environment()` — factory for `WargameEnv` from config
+- `observation_to_tensor` / `observations_to_tensor_batch` — observation conversion
+- `RLDataset` — generic RL dataset
+- `TransformerConfig` — shared transformer hyperparameters
+- `Device` / `get_device()` — device management
+- Wandb integration in `wandb.py` — all logging goes through Lightning logger
+
+## Callbacks
+
+- `CheckpointCallback` — saves model checkpoints
+- `RecordEpisodeCallback` — records MP4 episodes during training
+- `EnvConfigCallback` — persists env YAML config alongside checkpoints
+
+## Observation Tensor Pipeline
+
+`observation.py`: `WargameEnvObservation` → 5 tensors: game state `(3,)`, objectives, player_models, opponent_models, action_mask `(n_models, n_actions)`. When changing tensor count or shapes, update `docs/opponent-policies.md` (Observation Impact table) and tests.
+
+To add a new entity:
+1. Add to `WargameEnvObservation` + obs builder
+2. Extend `_observation_to_numpy` tuple
+3. Update `observation_to_tensor` / `observations_to_tensor_batch`
+4. Update **both** networks' `forward()` — Transformer needs dedicated embedding + updated token ordering; player tokens must stay extractable for per-model action heads
+5. Fix unpacking in tests (`test_state.py`, `test_dqn.py`)
+
+## Conventions
+
+- Use `torch.Tensor` for all neural network operations
+- Observation tensors built by `observation.py` from `WargameEnvObservation`
+- Default algorithm is PPO; DQN is available but not the primary focus
+- Device management via `device.py` utility
+- Wandb integration in `wandb.py` — all logging goes through Lightning logger
+- When changing the observation tuple length, expect unpacking errors in tests (`test_state.py`, `test_dqn.py`) — fix them as part of the same change


### PR DESCRIPTION
Mirrors the `.cursor/rules` and `.cursor/skills` content into Claude Code's equivalent mechanisms, so both editors work from the same project guidance. No behaviour changes — documentation and agent config only.

## Mapping

| Cursor | Claude equivalent |
|---|---|
| `rules/*.mdc` with `alwaysApply: true` | merged into root `CLAUDE.md` |
| `rules/python-conventions.mdc` (`globs: **/*.py`) | **Python Conventions** section in root `CLAUDE.md` |
| `rules/gymnasium-env.mdc` (`globs: envs/**`) | `wargame_rl/wargame/envs/CLAUDE.md` |
| `rules/pytorch-dqn.mdc` (`globs: model/**`) | `wargame_rl/wargame/model/CLAUDE.md` |
| `rules/testing.mdc` (`globs: tests/**`) | `tests/CLAUDE.md` |
| `skills/ship/SKILL.md` | `.claude/skills/ship/SKILL.md` |

Claude Code has no glob-matching rule system, but it auto-loads a `CLAUDE.md` from a directory when reading files in that subtree — the closest behavioural match to Cursor's `globs`.

## Changes

- `CLAUDE.md` — new sections deduped against existing content: Development Tooling, Python Conventions, Naming & Design, Adding New Entity Types, Training Runs (incl. PPO + transformer defaults); added `just train-multi` / `just ship` to the command table, the pre-commit rule (no `--amend`/`--no-verify`), and a pointer to the directory-scoped files
- `wargame_rl/wargame/envs/CLAUDE.md` — env structure, phases/`skip_phases`, placement, opponents, rendering, feature-addition checklist
- `wargame_rl/wargame/model/CLAUDE.md` — networks, DQN/PPO layout, observation tensor pipeline
- `tests/CLAUDE.md` — fixtures, test file map, per-feature coverage checklist
- `.claude/skills/ship/SKILL.md` — the `ship` skill, plus a note on conventional-commit PR titles that CI enforces

`.cursor/` is left in place; the two sets will drift unless one is retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
