### PR TITLE
fix: correct stale observation tensor docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,9 +32,14 @@ wargame_rl/
 │   ├── plotting/                  # Training visualization
 │   └── wargame/
 │       ├── envs/                  # Gymnasium environment, reward, rendering
-│       │   ├── wargame.py         # WargameEnv
-│       │   ├── env_components/    # Actions, placement, termination, observation
+│       │   ├── wargame.py         # WargameEnv — facade, implements BattleView
+│       │   ├── domain/            # Battle aggregate, BattleView, clock, placement,
+│       │   │                      #   termination, LOS, shooting, terrain, turn execution
+│       │   ├── env_components/    # Adapters: actions, distance cache, observation builder
 │       │   ├── reward/            # Phase manager, calculators, criteria
+│       │   ├── mission/           # VP calculators + registry
+│       │   ├── opponent/          # Opponent policies + registry
+│       │   ├── state/             # Snapshots, event log, replay, narrator, analysis
 │       │   ├── types/             # Config, observations, actions, info
 │       │   └── renders/           # Pygame renderer
 │       ├── model/                 # RL algorithms
@@ -67,6 +72,9 @@ wargame_rl/
 | Ship (branch → commit → push → PR) | `just ship <branch> "<message>"` |
 | Simulate latest | `just simulate-latest` |
 | Test env (random) | `just test-env` |
+| Record a match event log | `just record <config.yaml>` |
+| Replay / narrate a log | `just replay <file>` · `just replay-summary <file>` |
+| Analyse a log | `just analyze <file>` · `just analyze-compare <files...>` |
 | Profile | `just profile <config.yaml> [model] [max_epochs]` |
 | Clean | `just clean` |
 
@@ -80,6 +88,11 @@ wargame_rl/
 - **VP reward and success** — `vp_gain` calculator, `player_vp_min` success criteria, optional terminal VP bonus; observation includes `player_vp_delta` for step-wise VP signal
 - **Deployment zones** — configurable spawn areas for player and opponent
 - **Group cohesion** — optional penalty for unit separation
+- **DDD layering** — `domain/` owns the rules (Battle aggregate, clock, placement, termination, LOS, shooting); `wargame.py` is a facade; reward/renders depend only on the `BattleView` protocol. See [docs/ddd-envs.md](docs/ddd-envs.md)
+
+### Game State I/O (`envs/state/`)
+
+Snapshot/event pipeline for recording and inspecting matches — `GameStateSnapshot`, event-log deltas, `StateExporter` (wired into `step()`), replay, narration, and `analyze_match` metrics. Driven by `replay_events.py` / `analyze_events.py` and the `record` · `replay` · `analyze` · `analyze-compare` recipes. See [docs/game-state-io.md](docs/game-state-io.md)
 
 ### RL Algorithms
 
@@ -122,7 +135,7 @@ Detailed patterns live next to the code they govern — read them when working i
 - Pass dependencies in; don't construct them inside classes
 - NEVER include unimportable resources
 - Public facing methods should have docstrings
-- Follow the package dependency flow (see [README § Flow of dependencies](README.md#flow-of-dependencies)); layers above must not depend on layers below.
+- Follow the package dependency flow (see [docs/ddd-envs.md § Dependency direction](docs/ddd-envs.md#dependency-direction)); layers above must not depend on layers below.
 - Follow KISS
 - Prefer complexity at startup, keep runtime simple
 - Prefer validation at initialisation / construction, keep runtime simple

--- a/docs/opponent-policies.md
+++ b/docs/opponent-policies.md
@@ -181,7 +181,7 @@ Scripted policies are prefixed with `Scripted` in the class name and `scripted_`
 
 ## Observation Impact
 
-When opponents are present, the player agent's observation includes opponent model positions as a separate list (`opponent_models`). This is converted to 5 tensors in the DQN observation pipeline:
+When opponents are present, the player agent's observation includes opponent model positions as a separate list (`opponent_models`). This is converted to 6 tensors in the observation pipeline:
 
 | Tensor index | Content | Shape |
 |--------------|---------|-------|
@@ -189,9 +189,10 @@ When opponents are present, the player agent's observation includes opponent mod
 | 1 | Objectives | `(n_objectives, 2)` |
 | 2 | Player models | `(n_player_models, features)` |
 | 3 | Opponent models | `(n_opponent_models, features)` |
-| 4 | Action mask | `(n_models, n_actions)` — bool, valid actions per model |
+| 4 | Terrain | `(n_terrain, 4)` — normalized footprint corners |
+| 5 | Action mask | `(n_models, n_actions)` — bool, valid actions per model |
 
-When there are no opponents, tensor 3 has shape `(0, features)` and the network handles it gracefully (empty sequence for the Transformer, zero-width concatenation for the MLP).
+When there are no opponents, tensor 3 has shape `(0, features)`; likewise tensor 4 is `(0, 4)` with no terrain. The networks handle both gracefully (empty sequence for the Transformer, zero-width concatenation for the MLP).
 
 ## File Layout
 

--- a/wargame_rl/wargame/model/CLAUDE.md
+++ b/wargame_rl/wargame/model/CLAUDE.md
@@ -43,7 +43,20 @@ Both expose `policy_from_env(env)` and `from_checkpoint(env, path)` class method
 
 ## Observation Tensor Pipeline
 
-`observation.py`: `WargameEnvObservation` → 5 tensors: game state `(3,)`, objectives, player_models, opponent_models, action_mask `(n_models, n_actions)`. When changing tensor count or shapes, update `docs/opponent-policies.md` (Observation Impact table) and tests.
+`model/common/observation.py`: `WargameEnvObservation` → **6 tensors**, in this order:
+
+| # | Tensor | Shape |
+|---|---|---|
+| 0 | game features | `(6,)` — placeholder, normalized_round, normalized_phase, player_vp, opponent_vp, player_vp_delta |
+| 1 | objectives | `(n_objectives, 2)`, normalized to `[-1, 1]` |
+| 2 | player models | `(n_models, feature_dim)` |
+| 3 | opponent models | `(n_opponent_models, feature_dim)` — 0 rows when no opponents |
+| 4 | terrain | `(n_terrain, 4)` normalized footprint corners — 0 rows when no terrain |
+| 5 | action mask | `(n_models, n_actions)`, bool |
+
+`feature_dim = base + n_opponent`, where base covers normalized location, distances to objectives, group_id one-hot, closest same-group distance, wound features (alive, wound_ratio, max_wounds_norm), and combat stats (attacks, bs, strength, ap, damage, toughness, save — each divided by its `NORM_*` constant). The trailing `n_opponent` columns are expected damage per target (player models) or zero-padding (opponent models).
+
+The docstring on `observation_to_tensor` is the source of truth — keep it, this table, and `docs/opponent-policies.md` (Observation Impact) in sync when tensor count or shapes change.
 
 To add a new entity:
 1. Add to `WargameEnvObservation` + obs builder


### PR DESCRIPTION
Documentation-only fixes for stale observation-pipeline descriptions surfaced while mapping the codebase. No code changes.

## The drift

The observation pipeline produces **6 tensors** with game features of shape `(6,)` (`model/common/observation.py:259`, docstring at `:286`). Two docs still described a pre-terrain, pre-VP layout:

| Doc | Said | Actual |
|---|---|---|
| `wargame_rl/wargame/model/CLAUDE.md` | 5 tensors, game state `(3,)`, no terrain | 6 tensors, game state `(6,)`, terrain at index 4 |
| `docs/opponent-policies.md` | 5 tensors, action mask at index 4 | 6 tensors, terrain at 4, action mask at 5 |

This matters because `model/CLAUDE.md` is the checklist agents follow when adding a new observed entity — a wrong tensor count sends them to the wrong place.

## Changes

- **`wargame_rl/wargame/model/CLAUDE.md`** — replaced the stale one-liner with a full tensor table mirroring the `observation_to_tensor` docstring, plus the `feature_dim` breakdown (location, objective distances, group one-hot, wound features, combat stats, per-target expected damage). Names that docstring as the source of truth.
- **`docs/opponent-policies.md`** — added the missing terrain row, corrected the action mask index 4 → 5, noted the empty-terrain case alongside the existing empty-opponent one.
- **`CLAUDE.md`** — the dependency-flow link pointed at `README.md#flow-of-dependencies`, a section that does not exist; repointed at [`docs/ddd-envs.md § Dependency direction`](docs/ddd-envs.md#dependency-direction), which actually documents it.
- **`CLAUDE.md`** — the project layout tree omitted `domain/`, `state/`, `mission/`, and `opponent/`. Added them, plus a Game State I/O section covering `envs/state/` (~2k LOC: snapshots, event deltas, replay, narration, `analyze_match`) and its `record` / `replay` / `analyze` Justfile recipes, none of which were documented.

## Verification

Every claim checked against source: `TERRAIN_FEATURE_DIM = 4` (`observation.py:27`), the six-element `game_features` array (`:240`), the return tuple (`:259`), and the `#dependency-direction` anchor (`docs/ddd-envs.md:101`). `just format` and `just lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
