### PR TITLE
fix: use gh api instead of gh pr edit for PR bodies

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -27,7 +27,18 @@ When the user invokes this skill, run the full ship workflow: **branch only from
    - After the PR is created, generate a short description from the changes in the branch (vs `main`).
    - Run `git log main..HEAD --oneline` and `git diff main --stat` (or `--name-only`) to see commits and changed files.
    - Compose a PR body that includes: (1) a short summary (one or two sentences) of what the PR does, and (2) a "Changes" section listing notable files or areas (e.g. "env: add VP to Battle and BattleView", "mission: new VP calculator and registry").
-   - Run `gh pr edit --body "<description>"` to set the PR description. Use a single-quoted or escaped multi-line string so the shell receives the body correctly.
+   - Write the body to a file, then set it via the REST API:
+     ```bash
+     cat > /tmp/pr-body.md <<'EOF'
+     <description>
+     EOF
+     PR=$(gh pr view --json number --jq .number)
+     REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+     gh api -X PATCH "repos/$REPO/pulls/$PR" -F body=@/tmp/pr-body.md --jq '.html_url'
+     ```
+   - **Do not use `gh pr edit --body`.** On this repo it fails with a deprecated Projects (classic) GraphQL error (`repository.pullRequest.projectCards`) and leaves the body unchanged — the command reports the error but the PR silently keeps the `--fill` body. The REST endpoint above is unaffected.
+   - Verify it applied: `gh api "repos/$REPO/pulls/$PR" --jq '.body | length'` should match the body you wrote, not the shorter commit-derived one.
+   - Using a heredoc file rather than an inline `--body` string also avoids shell-quoting damage to markdown tables, backticks, and emoji.
 
 4. **If something fails**
    - If pre-commit or commit fails, suggest running `just validate` first and fixing any issues, then try again.

--- a/.cursor/skills/ship/SKILL.md
+++ b/.cursor/skills/ship/SKILL.md
@@ -27,7 +27,17 @@ When the user invokes this skill, run the full ship workflow: **branch only from
    - After the PR is created, generate a short description from the changes in the branch (vs `main`).
    - Run `git log main..HEAD --oneline` and `git diff main --stat` (or `--name-only`) to see commits and changed files.
    - Compose a PR body that includes: (1) a short summary (one or two sentences) of what the PR does, and (2) a "Changes" section listing notable files or areas (e.g. "env: add VP to Battle and BattleView", "mission: new VP calculator and registry").
-   - Run `gh pr edit --body "<description>"` to set the PR description. Use a single-quoted or escaped multi-line string so the shell receives the body correctly.
+   - Write the body to a file, then set it via the REST API:
+     ```bash
+     cat > /tmp/pr-body.md <<'EOF'
+     <description>
+     EOF
+     PR=$(gh pr view --json number --jq .number)
+     REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+     gh api -X PATCH "repos/$REPO/pulls/$PR" -F body=@/tmp/pr-body.md --jq '.html_url'
+     ```
+   - **Do not use `gh pr edit --body`.** On this repo it fails with a deprecated Projects (classic) GraphQL error (`repository.pullRequest.projectCards`) and leaves the body unchanged — the command reports the error but the PR silently keeps the `--fill` body. The REST endpoint above is unaffected.
+   - Verify it applied: `gh api "repos/$REPO/pulls/$PR" --jq '.body | length'` should match the body you wrote, not the shorter commit-derived one.
 
 4. **If something fails**
    - If pre-commit or commit fails, suggest running `just validate` first and fixing any issues, then try again.


### PR DESCRIPTION
Fixes step 3 of the `ship` skill, which instructed the agent to run a command that silently drops the PR description on this repo.

## The bug

`gh pr edit --body` fails here with a deprecated Projects (classic) GraphQL error:

```
GraphQL: Projects (classic) is being deprecated... (repository.pullRequest.projectCards)
```

The failure is quiet in effect — `gh` prints the error, but the PR keeps whatever `gh pr create --fill` derived from the commit message. The composed description is lost with no obvious signal, so the skill appears to work while producing thin PR bodies. Hit on both PR #122 and #123.

## The fix

Step 3 now writes the body to a file and PATCHes it through the REST endpoint, which is unaffected by the GraphQL deprecation:

```bash
cat > /tmp/pr-body.md <<'BODY'
<description>
BODY
PR=$(gh pr view --json number --jq .number)
REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
gh api -X PATCH "repos/$REPO/pulls/$PR" -F body=@/tmp/pr-body.md --jq '.html_url'
```

Both lookups stay repo-agnostic — verified that `gh pr view --json number` and `gh repo view --json nameWithOwner` do not trip the same GraphQL path.

Also added:
- an explicit "do not use `gh pr edit --body`" note with the error signature, so the failure is recognisable if it recurs elsewhere
- a verification step (`gh api ... --jq '.body | length'`) to confirm the body actually applied rather than assuming it did
- a note that the heredoc-to-file form protects markdown tables, backticks, and emoji from shell-quoting damage

## Scope

Applied to `.cursor/skills/ship/SKILL.md` as well as `.claude/` — the two are mirrors and carry the identical bug. They will keep needing paired edits until one is retired.

## Verification

This PR's own description was set with the documented command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
