### PR TITLE
fix: correct replay reconstruction, phase attribution, and PPO checkpoint loading

### DIFF
--- a/docs/game-state-io.md
+++ b/docs/game-state-io.md
@@ -92,14 +92,17 @@ JsonMatchCodec.decode()
 
 A complete, serialisable Pydantic model of the game at one point in time. This is the "universal interchange format" — everything downstream operates on snapshots.
 
+> **`clock` vs `action_phase`.** The snapshot is taken after `step()` has advanced the clock, so `clock.battle_phase` is the phase that will execute *next*. The actions in the same snapshot were executed in `action_phase`. Always attribute `player_actions` / `player_action_descriptions` to `action_phase`.
+
 #### Schema
 
 ```python
 class GameStateSnapshot(BaseModel):
-    schema_version: str = "1.1"
+    schema_version: str = "1.2"
     step: int
     max_steps: int
     clock: ClockSnapshot
+    action_phase: str | None
     n_rounds: int
     board_width: int
     board_height: int
@@ -195,7 +198,7 @@ class RewardSnapshot(BaseModel):
 
 | Group | Fields | Purpose |
 |-------|--------|---------|
-| **Timing** | `step`, `max_steps`, `clock`, `n_rounds` | Where in the episode and game clock |
+| **Timing** | `step`, `max_steps`, `clock`, `action_phase`, `n_rounds` | Where in the episode and game clock |
 | **Board** | `board_width`, `board_height`, `deployment_zone`, `opponent_deployment_zone` | Static geometry |
 | **Units** | `player_models`, `opponent_models` | Full per-model state inc. weapons, wounds, distances |
 | **Objectives** | `objectives`, `objective_control` | Positions, radii, ownership |

--- a/tests/test_event_stream.py
+++ b/tests/test_event_stream.py
@@ -21,24 +21,6 @@ from wargame_rl.wargame.envs.types import WargameEnvAction, WargameEnvConfig
 from wargame_rl.wargame.envs.wargame import WargameEnv
 
 
-def _strip_objective_in_range(snap: GameStateSnapshot) -> GameStateSnapshot:
-    """Remove derived objective fields not tracked by delta encoding."""
-    result: GameStateSnapshot = snap.model_copy(
-        update={
-            "objectives": [
-                o.model_copy(
-                    update={
-                        "player_models_in_range": [],
-                        "opponent_models_in_range": [],
-                    }
-                )
-                for o in snap.objectives
-            ]
-        }
-    )
-    return result
-
-
 @pytest.fixture
 def env_with_exporter() -> tuple[WargameEnv, EventLogExporter]:
     """Env wired with an EventLogExporter for recording."""
@@ -238,9 +220,7 @@ class TestReplay:
         controller = ReplayController(exporter.log)
         for expected in snapshots_direct:
             reconstructed = controller.seek(expected.step)
-            assert _strip_objective_in_range(
-                reconstructed
-            ) == _strip_objective_in_range(expected)
+            assert reconstructed == expected
 
     def test_replay_iter_snapshots(self, recorded_log: EventLog) -> None:
         controller = ReplayController(recorded_log)
@@ -248,6 +228,38 @@ class TestReplay:
         assert len(all_snaps) == len(recorded_log)
         assert all_snaps[0].step == controller.first_step
         assert all_snaps[-1].step == controller.last_step
+
+    def test_iter_snapshots_matches_seek(self, recorded_log: EventLog) -> None:
+        """Regression: iter_snapshots() carried reset-time objective occupancy
+        for the whole episode because deltas ignored `objectives` and anchors
+        were never applied, so it disagreed with seek()."""
+        controller = ReplayController(recorded_log)
+        for snapshot in controller.iter_snapshots():
+            assert snapshot == controller.seek(snapshot.step)
+
+    def test_objective_occupancy_tracked_across_steps(
+        self,
+        env_with_exporter: tuple[WargameEnv, EventLogExporter],
+    ) -> None:
+        """Regression: objective occupancy must follow models as they move."""
+        env, exporter = env_with_exporter
+        env.reset(seed=7)
+        direct: list[GameStateSnapshot] = [env.to_snapshot()]
+        for _ in range(10):
+            action = WargameEnvAction(actions=env.action_space.sample())
+            _, _, terminated, truncated, _ = env.step(action)
+            direct.append(env.to_snapshot())
+            if terminated or truncated:
+                break
+
+        replayed = ReplayController(exporter.log).iter_snapshots()
+        for expected, actual in zip(direct, replayed):
+            assert [o.player_models_in_range for o in actual.objectives] == [
+                o.player_models_in_range for o in expected.objectives
+            ]
+            assert [o.opponent_models_in_range for o in actual.objectives] == [
+                o.opponent_models_in_range for o in expected.objectives
+            ]
 
     def test_empty_log_raises(self) -> None:
         with pytest.raises(ValueError, match="empty"):

--- a/tests/test_ppo.py
+++ b/tests/test_ppo.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 import torch
 from pytorch_lightning import Trainer
@@ -8,7 +10,7 @@ from wargame_rl.wargame.model.common.observation import (
     observation_to_tensor,
     observations_to_tensor_batch,
 )
-from wargame_rl.wargame.model.net import TransformerNetwork
+from wargame_rl.wargame.model.net import TransformerNetwork, convert_state_dict
 from wargame_rl.wargame.model.ppo.agent import Agent
 from wargame_rl.wargame.model.ppo.config import PPOConfig
 from wargame_rl.wargame.model.ppo.lightning import PPOLightning
@@ -375,3 +377,39 @@ def test_ppo_training_runs_without_error(
     )
 
     trainer.fit(model)
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint loading — convert_state_dict
+# ---------------------------------------------------------------------------
+
+
+def test_transformer_loads_from_ppo_lightning_checkpoint(
+    env: WargameEnv, ppo_net: PPO_Transformer, tmp_path: Path
+) -> None:
+    """Regression: PPO checkpoints key the policy under
+    'ppo_model.policy_network.', but convert_state_dict only stripped the DQN
+    'policy_net.' prefix, so every key was dropped and loading failed."""
+    # Arrange
+    module = PPOLightning(env=env, ppo_model=ppo_net, log=False)
+    checkpoint_path = tmp_path / "ppo.ckpt"
+    torch.save({"state_dict": module.state_dict()}, checkpoint_path)
+
+    # Act
+    loaded = TransformerNetwork.from_checkpoint(env, str(checkpoint_path))
+
+    # Assert
+    expected = ppo_net.policy_network.state_dict()
+    actual = loaded.state_dict()
+    assert set(actual) == set(expected)
+    for key, value in expected.items():
+        assert torch.equal(actual[key].cpu(), value.cpu())
+
+
+def test_convert_state_dict_raises_on_unknown_prefix() -> None:
+    # Arrange
+    state_dict = {"mystery_module.weight": torch.zeros(1)}
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="No policy network found"):
+        convert_state_dict(state_dict)

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -115,6 +115,28 @@ class TestSnapshotAfterStep:
         assert snap.step >= 1
         assert snap.player_actions is not None
 
+    def test_action_phase_is_the_phase_that_acted(
+        self, shooting_env: WargameEnv
+    ) -> None:
+        """Regression: `clock.battle_phase` is the *next* phase because the clock
+        advances before the snapshot is taken, so actions could not be attributed
+        to a phase. `action_phase` records the phase that actually executed."""
+        shooting_env.reset(seed=42)
+        n = len(shooting_env.wargame_models)
+
+        shooting_env.step(WargameEnvAction(actions=[STAY_ACTION] * n))
+        first = shooting_env.to_snapshot()
+        assert first.action_phase == BattlePhase.movement.value
+        assert first.clock.battle_phase != first.action_phase
+
+        shooting_env.step(WargameEnvAction(actions=[STAY_ACTION] * n))
+        second = shooting_env.to_snapshot()
+        assert second.action_phase == BattlePhase.shooting.value
+
+    def test_action_phase_is_none_after_reset(self, shooting_env: WargameEnv) -> None:
+        shooting_env.reset(seed=42)
+        assert shooting_env.to_snapshot().action_phase is None
+
     def test_opponent_actions_recorded(self, shooting_env: WargameEnv) -> None:
         """Opponent acts after player finishes all phases in a round."""
         shooting_env.reset(seed=42)
@@ -187,7 +209,7 @@ class TestSchemaVersion:
     def test_schema_version(self, shooting_env: WargameEnv) -> None:
         shooting_env.reset(seed=42)
         snap = shooting_env.to_snapshot()
-        assert snap.schema_version == "1.1"
+        assert snap.schema_version == "1.2"
 
 
 class TestEncoder:

--- a/tests/test_v9_milestone_validation.py
+++ b/tests/test_v9_milestone_validation.py
@@ -327,7 +327,7 @@ class TestRequirementSpotChecks:
         env = WargameEnv(config=small_env_config)
         env.reset(seed=1)
         snap = env.to_snapshot()
-        assert snap.schema_version == "1.1"
+        assert snap.schema_version == "1.2"
         schema = GameStateSnapshot.model_json_schema()
         assert "properties" in schema
 

--- a/wargame_rl/wargame/envs/state/events.py
+++ b/wargame_rl/wargame/envs/state/events.py
@@ -16,6 +16,7 @@ from wargame_rl.wargame.envs.state.snapshot import (
     CombatResultSnapshot,
     GameStateSnapshot,
     ModelSnapshot,
+    ObjectiveSnapshot,
     RewardSnapshot,
 )
 
@@ -43,6 +44,8 @@ class StateDelta(BaseModel):
 
     step: int
     clock: ClockSnapshot | None = None
+    action_phase: str | None = None
+    objectives: list[ObjectiveSnapshot] | None = None
     player_model_deltas: list[ModelDelta] = Field(default_factory=list)
     opponent_model_deltas: list[ModelDelta] = Field(default_factory=list)
     player_vp: int | None = None
@@ -94,6 +97,13 @@ def compute_delta(
 
     if current.clock != previous.clock:
         delta.clock = current.clock
+    if current.action_phase != previous.action_phase:
+        delta.action_phase = current.action_phase
+
+    # Objective occupancy changes as models move even though location/radius are
+    # static, so the whole list must be diffed — not just the objective markers.
+    if current.objectives != previous.objectives:
+        delta.objectives = current.objectives
 
     if current.player_vp != previous.player_vp:
         delta.player_vp = current.player_vp
@@ -162,6 +172,10 @@ def apply_delta(
 
     if delta.clock is not None:
         updates["clock"] = delta.clock
+    if delta.action_phase is not None:
+        updates["action_phase"] = delta.action_phase
+    if delta.objectives is not None:
+        updates["objectives"] = delta.objectives
     if delta.player_vp is not None:
         updates["player_vp"] = delta.player_vp
     if delta.opponent_vp is not None:

--- a/wargame_rl/wargame/envs/state/replay.py
+++ b/wargame_rl/wargame/envs/state/replay.py
@@ -84,7 +84,14 @@ class ReplayController:
 
         for event in self._log.events[1:]:
             assert isinstance(event, StepEvent)
-            current = apply_delta(current, event.delta)
+            # Prefer the anchor when present: it is authoritative and resyncs the
+            # walk, so a field missing from a delta cannot persist for the rest
+            # of the episode.
+            current = (
+                event.anchor
+                if event.anchor is not None
+                else apply_delta(current, event.delta)
+            )
             snapshots.append(current)
 
         return snapshots

--- a/wargame_rl/wargame/envs/state/snapshot.py
+++ b/wargame_rl/wargame/envs/state/snapshot.py
@@ -109,12 +109,19 @@ class RewardSnapshot(BaseModel):
 
 
 class GameStateSnapshot(BaseModel):
-    """Complete, serialisable snapshot of game state at one point in time."""
+    """Complete, serialisable snapshot of game state at one point in time.
 
-    schema_version: str = "1.1"
+    ``clock`` describes the state *after* the step completed, so its
+    ``battle_phase`` is the phase that will execute next. ``action_phase`` is the
+    phase the reported actions were executed in — use that, not ``clock``, when
+    attributing ``player_actions`` to a phase.
+    """
+
+    schema_version: str = "1.2"
     step: int
     max_steps: int
     clock: ClockSnapshot
+    action_phase: str | None = None
     n_rounds: int
     board_width: int
     board_height: int
@@ -437,6 +444,7 @@ def build_snapshot(
     n_speed_bins: int = 6,
     shooting_slice_start: int | None = None,
     shooting_slice_end: int | None = None,
+    action_phase: str | None = None,
 ) -> GameStateSnapshot:
     """Build a complete game-state snapshot from env internals."""
     player_configs = config.models
@@ -523,6 +531,7 @@ def build_snapshot(
         step=step,
         max_steps=max_steps,
         clock=clock,
+        action_phase=action_phase,
         n_rounds=n_rounds,
         board_width=config.board_width,
         board_height=config.board_height,

--- a/wargame_rl/wargame/envs/wargame.py
+++ b/wargame_rl/wargame/envs/wargame.py
@@ -144,6 +144,7 @@ class WargameEnv(gym.Env):
         # Last actions and termination flag (for snapshot / replay)
         self._last_player_action: WargameEnvAction | None = None
         self._last_opponent_action: WargameEnvAction | None = None
+        self._last_action_phase: BattlePhase | None = None
         self._last_terminated: bool = False
 
         # Last reward from step(); None until first step after reset
@@ -319,6 +320,7 @@ class WargameEnv(gym.Env):
         self._last_opponent_shooting_results = []
         self._last_player_action = None
         self._last_opponent_action = None
+        self._last_action_phase = None
         self._last_terminated = False
 
         self.current_turn = 0
@@ -412,6 +414,9 @@ class WargameEnv(gym.Env):
 
     def _apply_player_action(self, action: WargameEnvAction) -> None:
         phase = self._game_clock.state.phase or BattlePhase.movement
+        # Captured before the clock advances so snapshots can attribute the
+        # recorded actions to the phase that actually executed them.
+        self._last_action_phase = phase
         if phase == BattlePhase.shooting:
             self._last_player_shooting_results = self._resolve_shooting_action(
                 action,
@@ -619,6 +624,9 @@ class WargameEnv(gym.Env):
             n_speed_bins=self.config.n_speed_bins,
             shooting_slice_start=ss.start if ss else None,
             shooting_slice_end=ss.end if ss else None,
+            action_phase=(
+                self._last_action_phase.value if self._last_action_phase else None
+            ),
         )
 
     def load_state(
@@ -689,6 +697,9 @@ class WargameEnv(gym.Env):
         # Env counters
         self.current_turn = snapshot.step
         self._last_terminated = snapshot.is_terminated
+        self._last_action_phase = (
+            BattlePhase(snapshot.action_phase) if snapshot.action_phase else None
+        )
 
         # Reconstruct last actions
         if snapshot.player_actions is not None:

--- a/wargame_rl/wargame/model/net.py
+++ b/wargame_rl/wargame/model/net.py
@@ -652,15 +652,31 @@ class TransformerNetwork(RL_Network):
         )
 
 
+# Lightning wraps the policy network differently per algorithm; the first prefix
+# that matches any key wins. Order matters only in that each is unambiguous.
+POLICY_NET_PREFIXES = ("policy_net.", "ppo_model.policy_network.")
+
+
 def convert_state_dict(state_dict: dict) -> dict:
-    """Normalize state_dict keys (Lightning 'policy_net.', torch.compile '_orig_mod.')."""
-    new_state_dict = {}
-    prefix = "policy_net."
-    for key, value in state_dict.items():
-        if not key.startswith(prefix):
-            continue
-        new_key = key[len(prefix) :]
-        if new_key.startswith("_orig_mod."):
-            new_key = new_key[10:]
-        new_state_dict[new_key] = value
-    return new_state_dict
+    """Normalize state_dict keys (Lightning DQN/PPO wrappers, torch.compile).
+
+    Raises:
+        ValueError: If no known policy-network prefix matches any key.
+    """
+    for prefix in POLICY_NET_PREFIXES:
+        new_state_dict = {}
+        for key, value in state_dict.items():
+            if not key.startswith(prefix):
+                continue
+            new_key = key[len(prefix) :]
+            if new_key.startswith("_orig_mod."):
+                new_key = new_key[10:]
+            new_state_dict[new_key] = value
+        if new_state_dict:
+            return new_state_dict
+
+    raise ValueError(
+        "No policy network found in checkpoint: no key starts with any of "
+        f"{POLICY_NET_PREFIXES}. Got prefixes like: "
+        f"{sorted({k.split('.')[0] for k in state_dict})[:5]}"
+    )


### PR DESCRIPTION
Three bugs found while analysing recorded matches from a trained checkpoint.

## 1. Replayed objective occupancy was stale for the whole episode

`compute_delta` never diffed the `objectives` list, and `ReplayController.iter_snapshots()` walked deltas forward while ignoring the anchor snapshots `StepEvent` already carries. Objective occupancy changes as models move even though location/radius are static, so `player_models_in_range` / `opponent_models_in_range` were frozen at reset values.

Observed on a real log, same step:

```
iter_snapshots()[30] player_models_in_range: [[], [], []]          # wrong
seek(30)             player_models_in_range: [[], [0,1,2], [0,1,2]]  # correct
```

`objective_control` *is* tracked, which made this easy to miss: control said "player" while occupancy said nobody was there. Both `analyze_events.py` and `replay_events.py` consume `iter_snapshots()`.

Deltas now track `objectives`, and `iter_snapshots()` resyncs on anchors so a field missing from a delta can't persist for the rest of an episode.

**Test change worth review:** `_strip_objective_in_range` in `test_event_stream.py` existed only to hide this ("fields not tracked by delta encoding") and is removed, so `test_replay_deterministic_reconstruction` now asserts exact equality.

## 2. Actions could not be attributed to a phase

`step()` applies the action, advances the clock, *then* snapshots — so `clock.battle_phase` is the phase that will run next while `player_actions` describe the phase that just ran. A log reads as though models moved during the shooting phase.

Adds `action_phase`, captured before the advance. `clock` keeps its existing meaning (state after the step) since rewinding it would make the snapshot misreport the game clock. Schema version `1.1` → `1.2`; `load_state` restores it.

## 3. `simulate.py` could not load PPO checkpoints

`convert_state_dict` only stripped the DQN `policy_net.` prefix. PPO checkpoints key the policy under `ppo_model.policy_network.`, so every key was dropped and loading failed with a full missing-keys dump. PPO is the project default, so `just simulate-latest` was broken for the default algorithm.

Now tries each known prefix and raises a clear `ValueError` when none match, instead of silently producing an empty state dict.

## Testing

618 passed. New regression tests: `test_iter_snapshots_matches_seek`, `test_objective_occupancy_tracked_across_steps`, `test_action_phase_is_the_phase_that_acted`, `test_action_phase_is_none_after_reset`, `test_transformer_loads_from_ppo_lightning_checkpoint`, `test_convert_state_dict_raises_on_unknown_prefix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)