### PR TITLE
fix: make the reward-phase curriculum reach win_at_the_end at 25v25 scale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -277,7 +277,8 @@ Temporary Items
 [Ll]ib
 [Ll]ib64
 [Ll]ocal
-[Ss]cripts
+# Only the Windows virtualenv dir (capital S); `scripts/` holds project tooling
+Scripts
 pyvenv.cfg
 pip-selfcheck.json
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,8 @@ wargame_rl/
 ├── examples/env_config/           # YAML environment configurations
 ├── tests/                         # Pytest suite with conftest.py fixtures
 ├── docs/                          # Design docs (movement, reward phases, missions-and-vp, roadmap, rules)
+├── reports/                       # Experiment findings, kept for retrospection
+├── scripts/                       # Run-inspection tooling (run_summary, measure_phase_gates)
 ├── train.py                       # Training entry point (Typer CLI)
 ├── simulate.py                    # Inference/simulation entry point
 └── main.py                        # Legacy entry (env test with random actions)
@@ -75,6 +77,8 @@ wargame_rl/
 | Record a match event log | `just record <config.yaml>` |
 | Replay / narrate a log | `just replay <file>` · `just replay-summary <file>` |
 | Analyse a log | `just analyze <file>` · `just analyze-compare <files...>` |
+| Inspect a Wandb run | `just run-summary <run_id> [bucket]` |
+| Measure reward-phase gates | `just measure-phase-gates <ckpt> <config.yaml> [n_episodes]` |
 | Profile | `just profile <config.yaml> [model] [max_epochs]` |
 | Clean | `just clean` |
 
@@ -210,7 +214,7 @@ Detailed patterns live next to the code they govern — read them when working i
 - Training logs to Wandb automatically; checkpoints saved to `checkpoints/`. Reward phase index and phase advancement are logged (`reward_phase`, `phase_advanced_at_epoch`) so curriculum runs show phase transitions in the dashboard
 - **Reading run metrics:** see [docs/metrics.md](docs/metrics.md) for what each Wandb key means and the procedure for evaluating a run. Several metrics are means-of-means or change definition silently — check the reading rules there before drawing conclusions from `success_rate`, `terminal_success_bonus`, or any `reward/components/*` value
 - **Past experiments:** [reports/](reports/README.md) records findings from previous runs, including refuted hypotheses. Check it before re-testing a hyperparameter — `gamma` 0.99 and `ent_coef` 0.01 have both been tried at 25v25 and both made results worse
-- **Inspecting a run:** `just run-summary <run_id> [bucket]` for rolling means (single-epoch `success_rate` is an `n_episodes`-sample binomial — never read a point value); `uv run measure_phase_gates.py <ckpt> <env_config> 40` for per-phase criteria rates and the whole `min_fraction` curve
+- **Inspecting a run:** `just run-summary <run_id> [bucket]` for rolling means (single-epoch `success_rate` is an `n_episodes`-sample binomial — never read a point value); `just measure-phase-gates <ckpt> <env_config> 40` for per-phase criteria rates and the whole `min_fraction` curve
 - Key CLI options: `--record-during-training`, `--max-epochs`, `--render-mode`, `--algorithm`, `--no-wandb`, `--run-suffix`, `--wandb-group`
 - Profile a run: `just profile <config.yaml> [model] [max_epochs]` generates `profile.html`
 - Simulate latest checkpoint: `just simulate-latest [network_type]` · Clean up: `just clean` removes `checkpoints/` and `wandb/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,8 @@ Detailed patterns live next to the code they govern — read them when working i
 - Env configs live in `examples/env_config/` — copy an existing one to create new scenarios
 - Training logs to Wandb automatically; checkpoints saved to `checkpoints/`. Reward phase index and phase advancement are logged (`reward_phase`, `phase_advanced_at_epoch`) so curriculum runs show phase transitions in the dashboard
 - **Reading run metrics:** see [docs/metrics.md](docs/metrics.md) for what each Wandb key means and the procedure for evaluating a run. Several metrics are means-of-means or change definition silently — check the reading rules there before drawing conclusions from `success_rate`, `terminal_success_bonus`, or any `reward/components/*` value
+- **Past experiments:** [reports/](reports/README.md) records findings from previous runs, including refuted hypotheses. Check it before re-testing a hyperparameter — `gamma` 0.99 and `ent_coef` 0.01 have both been tried at 25v25 and both made results worse
+- **Inspecting a run:** `just run-summary <run_id> [bucket]` for rolling means (single-epoch `success_rate` is an `n_episodes`-sample binomial — never read a point value); `uv run measure_phase_gates.py <ckpt> <env_config> 40` for per-phase criteria rates and the whole `min_fraction` curve
 - Key CLI options: `--record-during-training`, `--max-epochs`, `--render-mode`, `--algorithm`, `--no-wandb`, `--run-suffix`, `--wandb-group`
 - Profile a run: `just profile <config.yaml> [model] [max_epochs]` generates `profile.html`
 - Simulate latest checkpoint: `just simulate-latest [network_type]` · Clean up: `just clean` removes `checkpoints/` and `wandb/`

--- a/Justfile
+++ b/Justfile
@@ -49,13 +49,14 @@ dockerize:
 # Or with algorithm and network: just train path/to/config.yaml dqn transformer
 # Or with an epoch cap: just train path/to/config.yaml ppo transformer 800
 # Or with a match event log for analysis: just train path/to/config.yaml ppo transformer 800 true
-train env_config_path='examples/env_config/4v4_scripted_opponent_fixed_objectives_2_reward_phases.yaml' algorithm='ppo' model='transformer' max_epochs='' record_events='':
+train env_config_path='examples/env_config/4v4_scripted_opponent_fixed_objectives_2_reward_phases.yaml' algorithm='ppo' model='transformer' max_epochs='' record_events='' *extra='':
 	@uv run train.py --record-during-training \
 		--env-config-path {{env_config_path}} \
 		--algorithm {{algorithm}} \
 		{{ if model != "" { "--network-type " + model } else { "" } }} \
 		{{ if max_epochs != "" { "--max-epochs " + max_epochs } else { "" } }} \
-		{{ if record_events != "" { "--record-events" } else { "" } }}
+		{{ if record_events != "" { "--record-events" } else { "" } }} \
+		{{extra}}
 
 # Run multiple env configs in parallel. Each run gets a unique --run-suffix and shared --wandb-group.
 # Uses PPO + transformer. Use: just train-multi config1.yaml config2.yaml

--- a/Justfile
+++ b/Justfile
@@ -47,12 +47,13 @@ dockerize:
 # Use it like: just train path/to/config.yaml
 # Or with algorithm: just train path/to/config.yaml ppo
 # Or with algorithm and network: just train path/to/config.yaml dqn transformer
-train env_config_path='examples/env_config/4v4_scripted_opponent_fixed_objectives_2_reward_phases.yaml' algorithm='ppo' model='transformer':
-	@if [ -z "{{model}}" ]; then \
-		uv run train.py --record-during-training --env-config-path {{env_config_path}} --algorithm {{algorithm}}; \
-	else \
-		uv run train.py --record-during-training --env-config-path {{env_config_path}} --algorithm {{algorithm}} --network-type {{model}}; \
-	fi
+# Or with an epoch cap: just train path/to/config.yaml ppo transformer 800
+train env_config_path='examples/env_config/4v4_scripted_opponent_fixed_objectives_2_reward_phases.yaml' algorithm='ppo' model='transformer' max_epochs='':
+	@uv run train.py --record-during-training \
+		--env-config-path {{env_config_path}} \
+		--algorithm {{algorithm}} \
+		{{ if model != "" { "--network-type " + model } else { "" } }} \
+		{{ if max_epochs != "" { "--max-epochs " + max_epochs } else { "" } }}
 
 # Run multiple env configs in parallel. Each run gets a unique --run-suffix and shared --wandb-group.
 # Uses PPO + transformer. Use: just train-multi config1.yaml config2.yaml
@@ -80,6 +81,17 @@ simulate checkpoint env_config_path network_type='':
 	else \
 		uv run simulate.py --checkpoint-path {{checkpoint}} --env-config-path {{env_config_path}} --network-type {{network_type}}; \
 	fi
+
+# Record a match event log from a trained checkpoint (no rendering) for analysis.
+# Use it like: just record-sim checkpoints/<run>/best.ckpt examples/env_config/foo.yaml
+record-sim checkpoint env_config_path num_episodes='1' network_type='transformer':
+	@uv run simulate.py \
+		--checkpoint-path {{checkpoint}} \
+		--env-config-path {{env_config_path}} \
+		--network-type {{network_type}} \
+		--num-episodes {{num_episodes}} \
+		--no-render \
+		--record-events
 
 clean-checkpoints:
 	rm -rf checkpoints/

--- a/Justfile
+++ b/Justfile
@@ -126,6 +126,10 @@ replay file:
 replay-summary file:
 	uv run replay_events.py summary {{file}}
 
+# Compact rolling-mean summary of a Wandb training run. Use: just run-summary <run_id> [bucket]
+run-summary run_id bucket='50':
+	@uv run run_summary.py {{run_id}} {{bucket}}
+
 # Analyze a recorded match for training evaluation
 analyze file:
 	uv run analyze_events.py report {{file}}

--- a/Justfile
+++ b/Justfile
@@ -31,7 +31,7 @@ format:
 # Run ruff linting and mypy type checking
 lint:
 	uv run ruff check --fix
-	uv run mypy --ignore-missing-imports --install-types --non-interactive wargame_rl/ tests/
+	uv run mypy --ignore-missing-imports --install-types --non-interactive wargame_rl/ tests/ scripts/
 
 # Run tests using pytest with coverage (parallel via xdist)
 test:
@@ -128,7 +128,11 @@ replay-summary file:
 
 # Compact rolling-mean summary of a Wandb training run. Use: just run-summary <run_id> [bucket]
 run-summary run_id bucket='50':
-	@uv run run_summary.py {{run_id}} {{bucket}}
+	@uv run scripts/run_summary.py {{run_id}} {{bucket}}
+
+# Measure every reward phase's criteria against a checkpoint, plus the min_fraction curve
+measure-phase-gates checkpoint env_config n_episodes='30':
+	@uv run scripts/measure_phase_gates.py {{checkpoint}} {{env_config}} {{n_episodes}}
 
 # Analyze a recorded match for training evaluation
 analyze file:

--- a/Justfile
+++ b/Justfile
@@ -48,12 +48,14 @@ dockerize:
 # Or with algorithm: just train path/to/config.yaml ppo
 # Or with algorithm and network: just train path/to/config.yaml dqn transformer
 # Or with an epoch cap: just train path/to/config.yaml ppo transformer 800
-train env_config_path='examples/env_config/4v4_scripted_opponent_fixed_objectives_2_reward_phases.yaml' algorithm='ppo' model='transformer' max_epochs='':
+# Or with a match event log for analysis: just train path/to/config.yaml ppo transformer 800 true
+train env_config_path='examples/env_config/4v4_scripted_opponent_fixed_objectives_2_reward_phases.yaml' algorithm='ppo' model='transformer' max_epochs='' record_events='':
 	@uv run train.py --record-during-training \
 		--env-config-path {{env_config_path}} \
 		--algorithm {{algorithm}} \
 		{{ if model != "" { "--network-type " + model } else { "" } }} \
-		{{ if max_epochs != "" { "--max-epochs " + max_epochs } else { "" } }}
+		{{ if max_epochs != "" { "--max-epochs " + max_epochs } else { "" } }} \
+		{{ if record_events != "" { "--record-events" } else { "" } }}
 
 # Run multiple env configs in parallel. Each run gets a unique --run-suffix and shared --wandb-group.
 # Uses PPO + transformer. Use: just train-multi config1.yaml config2.yaml

--- a/docs/reward-phases.md
+++ b/docs/reward-phases.md
@@ -91,10 +91,32 @@ reward_phases:
 
 | Type key | Parameters | Description |
 |----------|------------|-------------|
-| `all_at_objectives` | *(none)* | Succeeds when every model is within the radius of at least one objective. |
+| `all_at_objectives` | *(none)* | Succeeds when every model is within the radius of at least one objective. Dead models count as satisfied. **Scales badly with army size** — see the note below; prefer `fraction_at_objectives` beyond a handful of models. |
+| `fraction_at_objectives` | `min_fraction` (float in (0, 1], default 0.5) | Succeeds when at least `min_fraction` of **alive** models are within the radius of an objective. Dead models are excluded from numerator and denominator alike, unlike `all_at_objectives`. |
 | `all_models_grouped` | `max_distance` (float, default 10.0) | Succeeds when every model is within `max_distance` of at least one same-group member. Models alone in their group are considered grouped. |
 | `player_vp_min` | `fraction_of_max` (float, e.g. 0.33), `min_vp` (int, default 0) | Succeeds when player VP at episode end ≥ threshold. Threshold = max(min_vp, round(fraction_of_max × theoretical_max)). Theoretical max depends on `number_of_battle_rounds`, objectives, and mission params, so the same fraction gives a higher VP bar when episodes have more rounds. |
 | `player_ahead_on_vp` | *(none)* | Succeeds when `player_vp > opponent_vp` at evaluation time (a win-rate signal; use with `terminate_on_success: false`). |
+
+### Choosing an at-objectives criteria
+
+`all_at_objectives` requires **every** alive model inside a radius on the same
+step. If each model independently has probability `p` of being on an objective,
+success needs `p**n_models` — which collapses as the army grows:
+
+| per-model accuracy | 4 models | 25 models |
+|---|---|---|
+| 0.90 | 0.66 | 0.07 |
+| 0.95 | 0.81 | 0.28 |
+| 0.99 | 0.96 | 0.78 |
+
+A 25v25 run held `success_rate` at exactly 0 for 330 epochs while every other
+metric improved. Lowering `success_threshold` does not help: that tunes how many
+*episodes* must succeed, not how many *models* must arrive. Use
+`fraction_at_objectives` and raise `min_fraction` across phases instead.
+
+**Set `min_fraction` from measurement, not intuition.** Success is evaluated on
+the episode's final step, so measure the final-step fraction your current policy
+reaches and pick a bar just above it.
 
 ## How Advancement Works
 
@@ -172,6 +194,7 @@ wargame_rl/wargame/envs/reward/
   criteria/
     base.py                        # SuccessCriteria ABC
     all_at_objectives.py           # All models at objectives
+    fraction_at_objectives.py      # A fraction of alive models at objectives
     all_models_grouped.py          # All models within group distance
     player_ahead_on_vp.py          # Player ahead on VP (win-rate) criteria
     player_vp_min.py               # Player VP min success criteria

--- a/docs/reward-phases.md
+++ b/docs/reward-phases.md
@@ -86,6 +86,7 @@ reward_phases:
 | `vp_gain` | global | *(none)* | Reward = weight × ((player_vp_delta - opponent_vp_delta) / cap_per_turn). `cap_per_turn` is read from mission config (default 15), so net VP swings are normalized to turn cap scale. Use in a "Win the game" phase. |
 | `objective_flip_bonus` | global | `bonus_capture_first` (float, default 5.0), `bonus_flip_to_contested` (float, default 3.0), `bonus_contested_to_controlled` (float, default 5.0), `loss_penalty_scale` (float, default 1.0) | Symmetric control-state potential under the same OC/count rule as VP scoring. Gaining control adds value (neutral→player = `bonus_capture_first`; opponent→contested = `bonus_flip_to_contested`; contested→player = `bonus_contested_to_controlled`); losing control subtracts the mirror value × `loss_penalty_scale`. At `loss_penalty_scale=1.0` it is a pure (farming-proof) potential. Returns unweighted. |
 | `objective_coverage` | global | *(none)* | Dense reward = (number of player-controlled objectives) / (number of objectives), using the same OC/count rule as VP scoring. Paid every step, so it rewards spreading models to hold *multiple distinct* objectives rather than over-stacking one. Returns unweighted. |
+| `models_at_objectives` | global | *(none)* | Dense reward = (alive models within some objective radius) / (alive models). The step-wise counterpart of the `fraction_at_objectives` criteria — unlike `objective_coverage` it does **not** saturate once a point is controlled, so it keeps paying as more models arrive. Dead models leave both numerator and denominator. Returns unweighted. |
 
 ## Available Success Criteria
 
@@ -211,6 +212,7 @@ wargame_rl/wargame/envs/reward/
     closest_objective.py           # Closest-objective reward
     closest_objective_v2.py        # OC/count-margin closest-objective reward
     group_cohesion.py              # Group cohesion penalty
+    models_at_objectives.py        # Dense fraction-of-models-on-objectives reward
     objective_coverage.py          # Dense fraction-of-objectives-controlled reward
     objective_flip_bonus.py        # Symmetric objective control-state potential
     vp_gain.py                     # VP gain reward (global)

--- a/docs/reward-phases.md
+++ b/docs/reward-phases.md
@@ -57,7 +57,7 @@ reward_phases:
 | `success_threshold` | float | `0.8` | Fraction of evaluation episodes (0--1) that must succeed to advance |
 | `min_epochs` | int | `0` | Minimum epochs spent in this phase before advancement is eligible |
 | `min_epochs_above_threshold` | int | `5` | Success rate must be ≥ success_threshold for this many consecutive epochs before advancing |
-| `terminal_success_bonus` | float | `0.0` | Bonus added at episode end **when the phase's `success_criteria` is met** (previously hardcoded to all-models-at-objectives). Scaled by remaining-turn fraction so faster success gets higher reward. |
+| `terminal_success_bonus` | float | `0.0` | Bonus added at episode end **when the phase's `success_criteria` is met** (previously hardcoded to all-models-at-objectives). Scaled by remaining-turn fraction **only when `terminate_on_success` is true** — see below. |
 | `terminal_vp_bonus` | float | `0.0` | Bonus added at episode end when player VP meets the phase's VP threshold (for VP-based success criteria). |
 | `terminate_on_success` | bool | `true` | Whether to end the episode as soon as all models are at objectives. Set `false` in VP phases when you want to keep scoring. |
 
@@ -133,6 +133,30 @@ advance if:
 When advancement triggers, the `RewardPhaseManager` moves to the next phase and logs the transition. The new phase's reward calculators take effect immediately for subsequent episodes.
 
 The `reward_phase` metric (phase index, 0-based) is logged to wandb every epoch, making phase transitions visible in the training dashboard.
+
+### Size `min_epochs_above_threshold` against `n_episodes`
+
+Each epoch's `success_rate` is an `n_episodes`-sample binomial, not a measurement of the policy's true rate. Requiring *consecutive* epochs above the bar multiplies that noise, so the effective gate sits well above the nominal `success_threshold`:
+
+| True rate | P(one epoch ≥ 0.7) at `n_episodes=10` | P(10 consecutive) |
+|---|---|---|
+| 0.6 | 0.38 | 0.0001 |
+| 0.7 | 0.65 | 0.013 |
+| 0.8 | 0.88 | 0.28 |
+| 0.9 | 0.99 | 0.88 |
+
+At `n_episodes=10`, `min_epochs_above_threshold: 10` turns a nominal 0.7 threshold into an effective bar near 0.85. Prefer **more evaluation episodes and a shorter run** — `--n-eval-episodes 30` with `min_epochs_above_threshold: 3` keeps the effective bar close to the nominal one for roughly the same eval cost.
+
+### `terminal_success_bonus` and the remaining-turn scale
+
+The bonus is multiplied by the fraction of turns left when the episode ends — a speed incentive that presumes success *ends* the episode. It is therefore applied **only when `terminate_on_success` is true**.
+
+With `terminate_on_success: false` every episode runs to `max_turns`, which would leave a scale of `1/max_turns`. Note `max_turns = number_of_battle_rounds × (5 - len(skip_phases))`, so a 20-round config with three skipped phases has `max_turns = 40` and would shrink the bonus 40-fold. The bonus is delivered at full value in that case instead.
+
+Two consequences worth checking when a phase will not advance:
+
+- **Weigh the terminal bonus against the dense calculators, per episode.** A dense calculator emitting 0.08/step over 40 steps contributes 3.2, so a terminal bonus of 5.0 is comparable — but one of 0.5 is noise. `reward/components/*` are per-step means (see [metrics.md](metrics.md)), so multiply by `mean_episode_steps` before comparing.
+- **Check `gamma` covers the episode.** The bonus lands on the last step, so its value at t=0 is `bonus × gamma^max_turns`. The `PPOConfig` default `gamma=0.9` discounts a 40-step episode by 0.015, making any terminal signal invisible to early actions; use `--gamma 0.99` for episodes this long.
 
 ## Reward Aggregation
 

--- a/docs/reward-phases.md
+++ b/docs/reward-phases.md
@@ -59,7 +59,7 @@ reward_phases:
 | `min_epochs_above_threshold` | int | `5` | Success rate must be ≥ success_threshold for this many consecutive epochs before advancing |
 | `terminal_success_bonus` | float | `0.0` | Bonus added at episode end **when the phase's `success_criteria` is met** (previously hardcoded to all-models-at-objectives). Scaled by remaining-turn fraction **only when `terminate_on_success` is true** — see below. |
 | `terminal_vp_bonus` | float | `0.0` | Bonus added at episode end when player VP meets the phase's VP threshold (for VP-based success criteria). |
-| `terminate_on_success` | bool | `true` | Whether to end the episode as soon as all models are at objectives. Set `false` in VP phases when you want to keep scoring. |
+| `terminate_on_success` | bool | `true` | Whether to end the episode as soon as **this phase's `success_criteria`** is met. Set `false` in VP phases when you want to keep scoring — and read the warning below, because this flag changes what `success_rate` measures. |
 
 ### Reward calculator fields
 
@@ -147,6 +147,19 @@ Each epoch's `success_rate` is an `n_episodes`-sample binomial, not a measuremen
 | 0.9 | 0.99 | 0.88 |
 
 At `n_episodes=10`, `min_epochs_above_threshold: 10` turns a nominal 0.7 threshold into an effective bar near 0.85. Prefer **more evaluation episodes and a shorter run** — `--n-eval-episodes 30` with `min_epochs_above_threshold: 3` keeps the effective bar close to the nominal one for roughly the same eval cost.
+
+### `terminate_on_success` silently changes what `success_rate` means
+
+The flag consults the phase's configured `success_criteria` (it was previously hardcoded to all-models-at-objectives, so fraction- and VP-gated phases could never end early). Switching it on is not a neutral speed optimisation — it redefines the metric every gate is calibrated against:
+
+| `terminate_on_success` | `success_rate` measures |
+|---|---|
+| `false` | the criteria **holds at the final step** |
+| `true` | the criteria was **ever met** — episodes that achieve it stop there, so it is true at the last step by construction |
+
+Recorded matches show peak occupancy running ~3x final occupancy, so flipping this raises `success_rate` by roughly that factor without the policy improving at all. Every threshold in a ladder calibrated under one setting is wrong under the other.
+
+For VP phases it is also semantically wrong: `win_at_the_end` must mean ahead *at the end*, not ahead at some point. Keep it `false` there.
 
 ### `terminal_success_bonus` and the remaining-turn scale
 

--- a/examples/env_config/25v25_scripted_opponent_random_objectives_3_reward_phases_terrain.yaml
+++ b/examples/env_config/25v25_scripted_opponent_random_objectives_3_reward_phases_terrain.yaml
@@ -93,25 +93,53 @@ opponent_models:
 # randomly outside both deployment zones at the start of every episode.
 
 reward_phases:
-  # Goal: every alive model inside an objective radius. Only calculators that
-  # move models onto objectives belong here — vp_gain and killing were removed
-  # because neither advances this criteria and both outweighed the shaping term.
-  - name: reach_objectives
+  # `all_at_objectives` is unreachable at this army size: with per-model accuracy
+  # p, success needs p**25. A 25v25 run held success_rate at exactly 0 for 330
+  # epochs while the policy was otherwise learning well. Split into a two-step
+  # fraction ladder instead. Thresholds are measured, not guessed — evaluating
+  # that run's best checkpoint over 80 episodes gives a 48% success rate at
+  # min_fraction 0.2 and 20% at 0.4, so each phase starts with real signal
+  # (unlike the 0% of all_at_objectives) and needs a genuine gain to advance.
+  #
+  # Only calculators that move models onto objectives belong in these phases;
+  # vp_gain and killing were removed because neither advances the criteria and
+  # both outweighed the shaping term.
+  - name: approach_objectives
     terminal_success_bonus: 5.0
-    terminate_on_success: true
+    terminate_on_success: false
     reward_calculators:
       - type: closest_objective
         weight: 1.0
         params: { progress_scale: 10.0 }
       - type: objective_coverage
+        weight: 0.3
+    success_criteria:
+      type: fraction_at_objectives
+      params: { min_fraction: 0.2 }
+    success_threshold: 0.7
+    min_epochs: 0
+    min_epochs_above_threshold: 10
+
+  # Massing enough models to hold a point. objective_coverage is weighted up
+  # because reaching 40% across 3 objectives requires spreading, not stacking;
+  # group_cohesion is live now that groups have 5 members each.
+  - name: mass_on_objectives
+    terminal_success_bonus: 5.0
+    terminate_on_success: false
+    reward_calculators:
+      - type: closest_objective
         weight: 0.5
+        params: { progress_scale: 10.0 }
+      - type: objective_coverage
+        weight: 0.8
       - type: group_cohesion
         weight: 0.5
         params: { group_max_distance: 5.0, violation_penalty: -0.1 }
     success_criteria:
-      type: all_at_objectives
-    success_threshold: 0.7
-    min_epochs: 0
+      type: fraction_at_objectives
+      params: { min_fraction: 0.4 }
+    success_threshold: 0.6
+    min_epochs: 20
     min_epochs_above_threshold: 10
 
   - name: win_only_by_vp

--- a/examples/env_config/25v25_scripted_opponent_random_objectives_3_reward_phases_terrain.yaml
+++ b/examples/env_config/25v25_scripted_opponent_random_objectives_3_reward_phases_terrain.yaml
@@ -131,15 +131,24 @@ reward_phases:
     # nominal 0.7 was silently a 0.85 gate. Launch with --n-eval-episodes 30 and
     # a run of 3, which puts the effective bar back near the nominal value.
     #
-    # Every rung below is sized from a measured min_fraction curve rather than
-    # intuition (see measure_phase_gates.py). At epoch 288 of a gamma=0.95 run
-    # the deterministic policy scored: 0.15 -> 0.47, 0.20 -> 0.35, 0.25 -> 0.30,
-    # 0.35 -> 0.20, 0.50 -> 0.05, with a median final fraction of 0.12.
+    # Rungs are sized from measurement (see measure_phase_gates.py), against the
+    # *live* per-epoch success_rate the gate actually reads — not against a
+    # best-checkpoint sweep. Best checkpoints are selected on reward, so they run
+    # 10-15 points optimistic; sizing rungs from them puts every gate out of
+    # reach of the thing that opens it.
     #
-    # The previous ladder was NOT monotonic: mass_on_objectives at min_fraction
-    # 0.35 measured 0.20, harder than win_only_by_vp (~0.40) and harder than the
-    # final win_at_the_end criteria (~0.30). An intermediate rung stricter than
-    # the destination stalls the curriculum for no benefit.
+    # Live rates observed: min_fraction 0.15 -> ~36%, 0.20 -> ~25%, 0.25 -> ~17%.
+    #
+    # The gate needs `min_epochs_above_threshold` *consecutive* epochs above the
+    # bar, each an n_episodes-sample binomial, so it only fires when the live
+    # mean sits near the threshold. At a live mean of 0.174 against a 0.35 bar,
+    # P(one epoch passes) is 0.003 and P(three running) is 2e-8 — never, at any
+    # epoch budget. Phase 0 at a 0.365 mean against 0.45 gives ~0.008 per
+    # attempt and duly advanced after 38 epochs.
+    #
+    # The ladder must also stay monotonic: an earlier version had
+    # mass_on_objectives at min_fraction 0.35 measuring 0.20, harder than
+    # win_only_by_vp and harder than the final win_at_the_end criteria.
     success_threshold: 0.45
     min_epochs: 0
     min_epochs_above_threshold: 3
@@ -163,8 +172,8 @@ reward_phases:
         params: { group_max_distance: 5.0, violation_penalty: -0.1 }
     success_criteria:
       type: fraction_at_objectives
-      params: { min_fraction: 0.25 }
-    success_threshold: 0.35
+      params: { min_fraction: 0.2 }
+    success_threshold: 0.25
     min_epochs: 20
     min_epochs_above_threshold: 3
 
@@ -198,7 +207,7 @@ reward_phases:
     success_criteria:
       type: player_vp_min
       params: { fraction_of_max: 0.3 }
-    success_threshold: 0.35
+    success_threshold: 0.25
     min_epochs: 20
     min_epochs_above_threshold: 3
 

--- a/examples/env_config/25v25_scripted_opponent_random_objectives_3_reward_phases_terrain.yaml
+++ b/examples/env_config/25v25_scripted_opponent_random_objectives_3_reward_phases_terrain.yaml
@@ -118,8 +118,14 @@ reward_phases:
       - type: closest_objective
         weight: 1.0
         params: { progress_scale: 10.0 }
+      # Weighted above objective_coverage because occupancy, not control, is
+      # what the criteria measures. Recorded matches show the policy reaching
+      # objectives then leaving them (peak 3/4 -> final 1/4): `closest_objective`
+      # with progress_scale is a potential, so a round trip away and back sums
+      # to zero and nothing opposes drift. Only a per-step occupancy term makes
+      # holding strictly better than oscillating.
       - type: models_at_objectives
-        weight: 0.5
+        weight: 1.0
       - type: objective_coverage
         weight: 0.3
     success_criteria:
@@ -164,7 +170,7 @@ reward_phases:
         weight: 0.5
         params: { progress_scale: 10.0 }
       - type: models_at_objectives
-        weight: 1.0
+        weight: 1.5
       - type: objective_coverage
         weight: 0.8
       - type: group_cohesion

--- a/examples/env_config/25v25_scripted_opponent_random_objectives_3_reward_phases_terrain.yaml
+++ b/examples/env_config/25v25_scripted_opponent_random_objectives_3_reward_phases_terrain.yaml
@@ -116,9 +116,14 @@ reward_phases:
     success_criteria:
       type: fraction_at_objectives
       params: { min_fraction: 0.2 }
-    success_threshold: 0.7
+    # `min_epochs_above_threshold` demands *consecutive* epochs above the bar, and
+    # each epoch's success_rate is an n_episodes-sample binomial. At n_episodes=10
+    # a run of 10 consecutive readings >= 0.7 needs a true rate near 0.85, so the
+    # nominal 0.7 was silently a 0.85 gate. Launch with --n-eval-episodes 30 and
+    # a run of 3, which puts the effective bar back near the nominal value.
+    success_threshold: 0.6
     min_epochs: 0
-    min_epochs_above_threshold: 10
+    min_epochs_above_threshold: 3
 
   # Massing enough models to hold a point. objective_coverage is weighted up
   # because reaching 40% across 3 objectives requires spreading, not stacking;
@@ -138,11 +143,12 @@ reward_phases:
     success_criteria:
       type: fraction_at_objectives
       params: { min_fraction: 0.4 }
-    success_threshold: 0.6
+    success_threshold: 0.5
     min_epochs: 20
-    min_epochs_above_threshold: 10
+    min_epochs_above_threshold: 3
 
   - name: win_only_by_vp
+    terminal_success_bonus: 5.0
     terminate_on_success: false
     reward_calculators:
       - type: vp_gain
@@ -167,10 +173,12 @@ reward_phases:
     success_criteria:
       type: player_vp_min
       params: { fraction_of_max: 0.4 }
-    success_threshold: 0.7
+    success_threshold: 0.6
     min_epochs: 20
+    min_epochs_above_threshold: 3
 
   - name: win_at_the_end
+    terminal_success_bonus: 5.0
     terminate_on_success: false
     reward_calculators:
       - type: vp_gain

--- a/examples/env_config/25v25_scripted_opponent_random_objectives_3_reward_phases_terrain.yaml
+++ b/examples/env_config/25v25_scripted_opponent_random_objectives_3_reward_phases_terrain.yaml
@@ -1,0 +1,163 @@
+config_name: 25v25_scripted_advance_random_objectives_3_reward_phases_terrain
+number_of_wargame_models: 25
+number_of_opponent_models: 25
+number_of_objectives: 3
+objective_radius_size: 3
+board_width: 60
+board_height: 44
+max_groups: 5
+turn_order: random
+number_of_battle_rounds: 20
+skip_phases:
+  - command
+  - charge
+  - fight
+
+deployment_zone: [0, 0, 20, 44]
+opponent_deployment_zone: [40, 0, 60, 44]
+
+opponent_policy:
+  type: scripted_advance_to_objective
+
+# Terrain blocks line-of-sight only (models can still move through it).
+# Symmetric layout: a central ruin plus mirrored mid-field and flank ruins,
+# so neither side gets a clean firing lane into the objective band.
+terrain:
+  - { footprint: [28, 19, 34, 25] } # centre
+  - { footprint: [26, 8, 32, 14] } # mid-field north
+  - { footprint: [26, 30, 32, 36] } # mid-field south
+  - { footprint: [16, 18, 22, 24] } # player-side approach
+  - { footprint: [38, 18, 44, 24] } # opponent-side approach
+  - { footprint: [30, 0, 36, 4] } # north flank
+  - { footprint: [30, 40, 36, 43] } # south flank
+
+# 5 groups of 5. `weapons` is required for shooting to resolve at all — with an
+# empty list a model cannot shoot, which also makes terrain LOS inert.
+# range 12 on a 60x44 board puts the engagement band at a scale where a ~6-cell
+# ruin actually breaks a firing lane.
+models:
+  - { group_id: 0, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 0, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 0, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 0, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 0, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 1, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 1, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 1, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 1, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 1, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 2, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 2, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 2, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 2, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 2, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 3, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 3, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 3, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 3, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 3, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 4, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 4, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 4, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 4, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 4, weapons: [{ range: 12, attacks: 1 }] }
+
+opponent_models:
+  - { group_id: 0, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 0, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 0, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 0, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 0, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 1, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 1, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 1, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 1, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 1, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 2, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 2, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 2, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 2, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 2, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 3, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 3, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 3, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 3, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 3, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 4, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 4, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 4, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 4, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 4, weapons: [{ range: 12, attacks: 1 }] }
+
+# No `objectives:` block -> the 3 objectives (number_of_objectives) are placed
+# randomly outside both deployment zones at the start of every episode.
+
+reward_phases:
+  # Goal: every alive model inside an objective radius. Only calculators that
+  # move models onto objectives belong here — vp_gain and killing were removed
+  # because neither advances this criteria and both outweighed the shaping term.
+  - name: reach_objectives
+    terminal_success_bonus: 5.0
+    terminate_on_success: true
+    reward_calculators:
+      - type: closest_objective
+        weight: 1.0
+        params: { progress_scale: 10.0 }
+      - type: objective_coverage
+        weight: 0.5
+      - type: group_cohesion
+        weight: 0.5
+        params: { group_max_distance: 5.0, violation_penalty: -0.1 }
+    success_criteria:
+      type: all_at_objectives
+    success_threshold: 0.7
+    min_epochs: 0
+    min_epochs_above_threshold: 10
+
+  - name: win_only_by_vp
+    terminate_on_success: false
+    reward_calculators:
+      - type: vp_gain
+        weight: 1.0
+      - type: objective_flip_bonus
+        weight: 1.0
+        params:
+          {
+            bonus_capture_first: 2.0,
+            bonus_flip_to_contested: 1.0,
+            bonus_contested_to_controlled: 2.0,
+            loss_penalty_scale: 1.0,
+          }
+      - type: closest_objective_v2
+        weight: 0.3
+        params: { progress_scale: 10.0 }
+      - type: objective_coverage
+        weight: 0.1
+      - type: killing
+        weight: 1.0
+        params: { bonus_killing_opponent: 5.0 }
+    success_criteria:
+      type: player_vp_min
+      params: { fraction_of_max: 0.4 }
+    success_threshold: 0.7
+    min_epochs: 20
+
+  - name: win_at_the_end
+    terminate_on_success: false
+    reward_calculators:
+      - type: vp_gain
+        weight: 1.0
+      - type: objective_flip_bonus
+        weight: 0.5
+        params:
+          {
+            bonus_capture_first: 2.0,
+            bonus_flip_to_contested: 1.0,
+            bonus_contested_to_controlled: 2.0,
+            loss_penalty_scale: 1.0,
+          }
+    success_criteria:
+      type: player_ahead_on_vp
+      params: {}
+    success_threshold: 0.8
+    min_epochs: 20

--- a/examples/env_config/25v25_scripted_opponent_random_objectives_3_reward_phases_terrain.yaml
+++ b/examples/env_config/25v25_scripted_opponent_random_objectives_3_reward_phases_terrain.yaml
@@ -130,7 +130,12 @@ reward_phases:
     # a run of 10 consecutive readings >= 0.7 needs a true rate near 0.85, so the
     # nominal 0.7 was silently a 0.85 gate. Launch with --n-eval-episodes 30 and
     # a run of 3, which puts the effective bar back near the nominal value.
-    success_threshold: 0.6
+    #
+    # Thresholds across this ladder are set from measurement: the best observed
+    # phase-0 rate at min_fraction 0.2 is ~45% across four runs. A gate above
+    # that never opens, and a curriculum phase that cannot be passed is worse
+    # than one passed at moderate competence.
+    success_threshold: 0.45
     min_epochs: 0
     min_epochs_above_threshold: 3
 
@@ -153,8 +158,8 @@ reward_phases:
         params: { group_max_distance: 5.0, violation_penalty: -0.1 }
     success_criteria:
       type: fraction_at_objectives
-      params: { min_fraction: 0.4 }
-    success_threshold: 0.5
+      params: { min_fraction: 0.35 }
+    success_threshold: 0.35
     min_epochs: 20
     min_epochs_above_threshold: 3
 
@@ -187,8 +192,8 @@ reward_phases:
         params: { bonus_killing_opponent: 5.0 }
     success_criteria:
       type: player_vp_min
-      params: { fraction_of_max: 0.4 }
-    success_threshold: 0.6
+      params: { fraction_of_max: 0.3 }
+    success_threshold: 0.45
     min_epochs: 20
     min_epochs_above_threshold: 3
 

--- a/examples/env_config/25v25_scripted_opponent_random_objectives_3_reward_phases_terrain.yaml
+++ b/examples/env_config/25v25_scripted_opponent_random_objectives_3_reward_phases_terrain.yaml
@@ -104,13 +104,22 @@ reward_phases:
   # Only calculators that move models onto objectives belong in these phases;
   # vp_gain and killing were removed because neither advances the criteria and
   # both outweighed the shaping term.
+  # `models_at_objectives` is the dense counterpart of the fraction criteria.
+  # Without it the phase was gated on a model fraction that nothing paid for:
+  # `objective_coverage` saturates once the player out-counts the opponent (~2
+  # models a point) and `closest_objective` pays for approaching, not staying.
+  # A run with the terminal bonus alone behind the criteria stalled at 34% —
+  # a sparse binary signal says whether the episode succeeded, not which way to
+  # move, so it cannot replace dense shaping.
   - name: approach_objectives
-    terminal_success_bonus: 5.0
+    terminal_success_bonus: 3.0
     terminate_on_success: false
     reward_calculators:
       - type: closest_objective
         weight: 1.0
         params: { progress_scale: 10.0 }
+      - type: models_at_objectives
+        weight: 0.5
       - type: objective_coverage
         weight: 0.3
     success_criteria:
@@ -129,12 +138,14 @@ reward_phases:
   # because reaching 40% across 3 objectives requires spreading, not stacking;
   # group_cohesion is live now that groups have 5 members each.
   - name: mass_on_objectives
-    terminal_success_bonus: 5.0
+    terminal_success_bonus: 3.0
     terminate_on_success: false
     reward_calculators:
       - type: closest_objective
         weight: 0.5
         params: { progress_scale: 10.0 }
+      - type: models_at_objectives
+        weight: 1.0
       - type: objective_coverage
         weight: 0.8
       - type: group_cohesion
@@ -148,7 +159,7 @@ reward_phases:
     min_epochs_above_threshold: 3
 
   - name: win_only_by_vp
-    terminal_success_bonus: 5.0
+    terminal_success_bonus: 3.0
     terminate_on_success: false
     reward_calculators:
       - type: vp_gain
@@ -165,6 +176,10 @@ reward_phases:
       - type: closest_objective_v2
         weight: 0.3
         params: { progress_scale: 10.0 }
+      # Retained from the earlier phases so the objective-holding behaviour is
+      # not forgotten the moment the dense shaping switches to VP.
+      - type: models_at_objectives
+        weight: 0.3
       - type: objective_coverage
         weight: 0.1
       - type: killing
@@ -178,11 +193,13 @@ reward_phases:
     min_epochs_above_threshold: 3
 
   - name: win_at_the_end
-    terminal_success_bonus: 5.0
+    terminal_success_bonus: 3.0
     terminate_on_success: false
     reward_calculators:
       - type: vp_gain
         weight: 1.0
+      - type: models_at_objectives
+        weight: 0.2
       - type: objective_flip_bonus
         weight: 0.5
         params:

--- a/examples/env_config/25v25_scripted_opponent_random_objectives_3_reward_phases_terrain.yaml
+++ b/examples/env_config/25v25_scripted_opponent_random_objectives_3_reward_phases_terrain.yaml
@@ -124,17 +124,22 @@ reward_phases:
         weight: 0.3
     success_criteria:
       type: fraction_at_objectives
-      params: { min_fraction: 0.2 }
+      params: { min_fraction: 0.15 }
     # `min_epochs_above_threshold` demands *consecutive* epochs above the bar, and
     # each epoch's success_rate is an n_episodes-sample binomial. At n_episodes=10
     # a run of 10 consecutive readings >= 0.7 needs a true rate near 0.85, so the
     # nominal 0.7 was silently a 0.85 gate. Launch with --n-eval-episodes 30 and
     # a run of 3, which puts the effective bar back near the nominal value.
     #
-    # Thresholds across this ladder are set from measurement: the best observed
-    # phase-0 rate at min_fraction 0.2 is ~45% across four runs. A gate above
-    # that never opens, and a curriculum phase that cannot be passed is worse
-    # than one passed at moderate competence.
+    # Every rung below is sized from a measured min_fraction curve rather than
+    # intuition (see measure_phase_gates.py). At epoch 288 of a gamma=0.95 run
+    # the deterministic policy scored: 0.15 -> 0.47, 0.20 -> 0.35, 0.25 -> 0.30,
+    # 0.35 -> 0.20, 0.50 -> 0.05, with a median final fraction of 0.12.
+    #
+    # The previous ladder was NOT monotonic: mass_on_objectives at min_fraction
+    # 0.35 measured 0.20, harder than win_only_by_vp (~0.40) and harder than the
+    # final win_at_the_end criteria (~0.30). An intermediate rung stricter than
+    # the destination stalls the curriculum for no benefit.
     success_threshold: 0.45
     min_epochs: 0
     min_epochs_above_threshold: 3
@@ -158,7 +163,7 @@ reward_phases:
         params: { group_max_distance: 5.0, violation_penalty: -0.1 }
     success_criteria:
       type: fraction_at_objectives
-      params: { min_fraction: 0.35 }
+      params: { min_fraction: 0.25 }
     success_threshold: 0.35
     min_epochs: 20
     min_epochs_above_threshold: 3
@@ -193,7 +198,7 @@ reward_phases:
     success_criteria:
       type: player_vp_min
       params: { fraction_of_max: 0.3 }
-    success_threshold: 0.45
+    success_threshold: 0.35
     min_epochs: 20
     min_epochs_above_threshold: 3
 

--- a/measure_phase_gates.py
+++ b/measure_phase_gates.py
@@ -1,0 +1,95 @@
+"""Measure every reward phase's success criteria against one checkpoint.
+
+Answers "is the ladder ahead passable?" before a run reaches those phases, using
+the same evaluation path training uses: run the episode to its end, then check
+each phase's criteria against `env.last_step_context`.
+
+Usage: uv run measure_phase_gates.py <checkpoint> <env_config> [n_episodes]
+"""
+
+from __future__ import annotations
+
+import sys
+
+import torch
+from pydantic_yaml import parse_yaml_raw_as
+
+from wargame_rl.wargame.envs.domain.entities import alive_mask_for
+from wargame_rl.wargame.envs.reward.criteria.registry import build_criteria
+from wargame_rl.wargame.envs.types.config import WargameEnvConfig
+from wargame_rl.wargame.model.common.factory import create_environment
+from wargame_rl.wargame.model.dqn.agent import Agent
+from wargame_rl.wargame.model.net import TransformerNetwork
+
+
+def main() -> None:
+    checkpoint_path = sys.argv[1]
+    config_path = sys.argv[2]
+    n_episodes = int(sys.argv[3]) if len(sys.argv) > 3 else 30
+
+    with open(config_path) as handle:
+        env_config = parse_yaml_raw_as(WargameEnvConfig, handle.read())
+
+    env = create_environment(env_config=env_config)
+    agent = Agent(env)
+    net = TransformerNetwork.from_checkpoint(env, checkpoint_path)
+    net.eval()
+
+    criteria = [
+        (
+            phase.name,
+            build_criteria(phase.success_criteria.type, phase.success_criteria.params),
+        )
+        for phase in env_config.reward_phases
+    ]
+    hits = {name: 0 for name, _ in criteria}
+    final_fractions: list[float] = []
+
+    with torch.no_grad():
+        for _ in range(n_episodes):
+            obs, _ = env.reset()
+            done = False
+            while not done:
+                action = agent.get_action(net, obs, epsilon=0.0)
+                obs, _, done, truncated, _ = env.step(action)
+                done = done or truncated
+            ctx = env.last_step_context
+            if ctx is None:
+                continue
+            for name, criterion in criteria:
+                if criterion.is_successful(env, ctx):
+                    hits[name] += 1
+            final_fractions.append(
+                ctx.distance_cache.fraction_at_objectives(
+                    alive_mask=alive_mask_for(env.player_models)
+                )
+            )
+
+    print(f"checkpoint : {checkpoint_path.split('/')[-1]}")
+    print(f"episodes   : {n_episodes}\n")
+
+    # The whole min_fraction curve from one sweep, so ladder rungs can be sized
+    # from data instead of re-running an evaluation per candidate value.
+    final_fractions.sort(reverse=True)
+    print("min_fraction -> success rate")
+    for candidate in (0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.5):
+        rate = sum(1 for f in final_fractions if f >= candidate) / len(final_fractions)
+        models = candidate * len(env.wargame_models)
+        print(f"  {candidate:>4.2f} ({models:>4.1f} models) -> {rate:.2f}")
+    median = final_fractions[len(final_fractions) // 2]
+    print(
+        f"  final fraction: median={median:.2f} "
+        f"best={final_fractions[0]:.2f} worst={final_fractions[-1]:.2f}\n"
+    )
+    print(f"{'phase':<22} {'criteria':<24} {'threshold':>9} {'measured':>9}  verdict")
+    for phase, (name, _) in zip(env_config.reward_phases, criteria):
+        rate = hits[name] / n_episodes
+        verdict = "PASSABLE" if rate >= phase.success_threshold else "BLOCKED"
+        print(
+            f"{name:<22} {phase.success_criteria.type:<24} "
+            f"{phase.success_threshold:>9.2f} {rate:>9.2f}  {verdict}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/reports/2026-08-04-mechanism-defects.md
+++ b/reports/2026-08-04-mechanism-defects.md
@@ -1,0 +1,187 @@
+# Mechanism defects blocking curriculum advancement
+
+**Date:** 2026-08-04
+**Context:** [reward-phase curriculum experiment](2026-08-04-reward-phase-curriculum.md)
+
+Four defects in the reward-phase advancement mechanism. Three of them (D1, D2, D4) make
+advancement impossible or near-impossible **independently of how well the agent plays**,
+which is why several hundred epochs of visible learning produced no phase transition.
+
+Each entry states the symptom, the measurement, the root cause, and how it was verified.
+
+---
+
+## D1 — `terminal_success_bonus` delivered at 1/40th of its configured value
+
+**Symptom.** Phase 0 plateaued at ~45% against a 0.7 gate for ~400 epochs (run
+`wd71v79p`) while `objective_coverage` and `closest_objective/progress` continued to rise.
+Suspicion fell on the terminal bonus after decomposing episode reward by component.
+
+**Root cause.** `RewardPhaseManager` scaled the bonus by the fraction of turns remaining —
+a *speed* incentive that presumes success ends the episode:
+
+```python
+remaining = max(0.0, float(ctx.max_turns - ctx.current_turn + 1))
+remaining_frac = remaining / float(ctx.max_turns)
+bonus = phase.terminal_success_bonus * remaining_frac
+```
+
+With `terminate_on_success: false` every episode runs to `max_turns`, so
+`remaining_frac = 1/max_turns`. Note `max_turns = number_of_battle_rounds x (5 - len(skip_phases))`,
+so a 20-round config with three skipped phases has `max_turns = 40`, not 20.
+
+**Measurement.** Evaluated against the live config before and after the fix:
+
+| | delivered bonus | value at t=0 |
+|---|---|---|
+| before | **0.125** | 0.082 (γ=0.9) |
+| after | **5.0** | 3.379 (γ=0.99) |
+
+Logged reward components, converted to per-episode contributions
+(per-step mean x `mean_episode_steps`):
+
+| Component | per-episode | share |
+|---|---|---|
+| `objective_coverage` (weight 0.3) | 3.12 | **61%** |
+| `closest_objective` (weight 1.0) | 1.54 | 30% |
+| `terminal_success_bonus` (nominal 5.0) | **0.06** | **1.2%** |
+
+The criterion the curriculum gates on contributed ~1% of episode reward.
+
+**Fix.** Apply the remaining-turn scale only when `terminate_on_success` is true.
+
+**Verification.** `reward/components/terminal_success_bonus` now logs exactly
+`0.00244140625` per successful episode, which is `5.0 / 2048` (the bonus over the rollout
+step count). Before the fix the same quantity would be `0.125 / 2048 = 0.000061`.
+
+---
+
+## D2 — the advancement gate demanded far more than its nominal threshold
+
+**Symptom.** A nominal `success_threshold: 0.7` never fired despite epochs frequently
+reading above 0.7.
+
+**Root cause.** `min_epochs_above_threshold` requires that many *consecutive* epochs above
+the bar, and each epoch's `success_rate` is an `n_episodes`-sample binomial — a noisy
+estimate, not the policy's true rate. Requiring a run of them compounds the noise.
+
+**Measurement.** At `n_episodes=10`, threshold 0.7:
+
+| True rate | P(one epoch ≥0.7) | P(10 consecutive) |
+|---|---|---|
+| 0.6 | 0.38 | 0.0001 |
+| 0.7 | 0.65 | 0.013 |
+| 0.8 | 0.88 | 0.28 |
+| 0.9 | 0.99 | 0.88 |
+
+A nominal 0.7 gate was effectively an 0.85 gate.
+
+**Fix.** `--n-eval-episodes 30` with `min_epochs_above_threshold: 3`, which restores the
+effective bar to near the nominal value at comparable evaluation cost.
+
+**Verification.** Predictive, on a later run: `approach_objectives` held a live mean of
+0.365 against a 0.45 gate, giving P(one epoch) ≈ 0.20 and P(three consecutive) ≈ 0.008 —
+about 1 attempt in 125, so roughly 40 epochs. It advanced at **epoch 38**.
+
+---
+
+## D3 — the gated quantity had no dense reward behind it
+
+**Symptom.** Phases gated on `fraction_at_objectives` improved on every reward component
+without improving on the criteria.
+
+**Root cause.** No calculator paid for the fraction of models on objectives:
+
+| Calculator | Pays for | Why it does not serve the criteria |
+|---|---|---|
+| `objective_coverage` | fraction of objectives *controlled* | saturates once the player out-counts the opponent (~2 models a point) |
+| `closest_objective` | distance *closed* | rewards approaching, not staying |
+
+**Fix.** Added `models_at_objectives`: dense reward = alive models within some objective
+radius / alive models. Non-saturating as more models arrive; dead models leave both
+numerator and denominator.
+
+**Status.** The gap is confirmed real. **The benefit is not yet demonstrated** — the run
+introducing it tracked its predecessor rather than beating it, and no run has isolated it
+at the raised weights (1.0 / 1.5). See also
+[objective drift](2026-08-04-objective-drift.md), where the same term is the mechanism
+that opposes drift.
+
+---
+
+## D4 — rungs calibrated against the wrong distribution
+
+**Symptom.** A rung sized from a measured curve still never advanced, over 330 epochs.
+
+**Root cause.** The rungs were sized by sweeping criteria against a **best checkpoint**,
+but the gate reads the **live per-epoch `success_rate`**. Best checkpoints are selected on
+reward, so they are systematically optimistic — by 10–15 points here.
+
+**Measurement.** `mass_on_objectives` at `min_fraction 0.25`:
+
+- Best-checkpoint sweep: **0.33** → looks marginal against a 0.35 gate
+- Live per-epoch mean over 330 epochs: **0.174** → 16.9, 13.6, 17.6, 19.9, 10.3, 18.5, 18.9, 17.4, 17.4 (50-epoch buckets), no trend
+
+At p=0.174 with n=30, P(one epoch ≥0.35) ≈ 0.003 and P(three consecutive) ≈ **2x10⁻⁸**.
+The gate could not open at any epoch budget. Meanwhile `objective_coverage` rose
+0.055 → 0.060 and `progress` 0.028 → 0.032 across the same window: the policy was
+improving the whole time.
+
+**Fix.** Size rungs from live rates. Measured live: `min_fraction` 0.15 → ~36%,
+0.20 → ~25%, 0.25 → ~17%. Rungs set to 0.15 @ 0.45, 0.20 @ 0.25, VP @ 0.25.
+
+**Verification.** Three gates cleared in 50 epochs, against one gate in 373 epochs for the
+checkpoint-calibrated ladder. The two runs differ only in rung sizes.
+
+---
+
+## D5 — the ladder was not monotonic (found during D4 investigation)
+
+**Symptom.** An intermediate phase blocked while later phases measured passable.
+
+**Measurement.** All four criteria evaluated against one checkpoint, 30–40 episodes each,
+through the same path training uses (run to episode end, check against
+`last_step_context`):
+
+| Phase | Criteria | Threshold | Measured |
+|---|---|---|---|
+| `approach_objectives` | fraction ≥ 0.2 | 0.45 | 0.37 |
+| `mass_on_objectives` | fraction ≥ 0.35 | 0.35 | **0.20** |
+| `win_only_by_vp` | `player_vp_min` 0.3 | 0.45 | ~0.40 |
+| `win_at_the_end` | `player_ahead_on_vp` | 0.80 | ~0.30 |
+
+`mass_on_objectives` — massing 35% of 25 models (≈9) on objectives at the final step — was
+**harder than winning the VP race and harder than the final goal itself**. A rung stricter
+than its own destination stalls everything behind it, and no reward tuning can fix it.
+
+**Fix.** `min_fraction` 0.35 → 0.20, so difficulty increases monotonically along the
+ladder.
+
+---
+
+## Latent issue, fixed but deliberately not enabled
+
+`terminate_on_success` was hardcoded to `all_models_at_objectives` and never consulted the
+phase's configured criteria, so fraction- and VP-gated phases could not end on their own
+success. This is now fixed, but **left disabled in config**.
+
+Enabling it redefines the metric:
+
+| `terminate_on_success` | `success_rate` measures |
+|---|---|
+| `false` | criteria **holds at the final step** |
+| `true` | criteria was **ever met** — the episode stops there, so it holds at the last step by construction |
+
+Given peak occupancy runs ~3x final occupancy, flipping this raises `success_rate` by
+roughly that factor with no policy improvement, invalidating every calibrated threshold.
+For VP phases it is also semantically wrong: `win_at_the_end` must mean ahead *at the end*.
+
+---
+
+## Cross-cutting lesson
+
+D1 and D2 are arithmetic. D4 and D5 are measurement discipline. None required a training
+run to find — but all four were found only after several runs had been spent on
+hyperparameter hypotheses that turned out to be wrong.
+
+**Before tuning a policy against a gate, verify the gate can open.**

--- a/reports/2026-08-04-objective-drift.md
+++ b/reports/2026-08-04-objective-drift.md
@@ -1,0 +1,123 @@
+# Objective drift: the agent reaches objectives, then abandons them
+
+**Date:** 2026-08-04
+**Method:** per-step `at_objective` traces reconstructed from recorded match event logs
+**Data:** 5 recorded episodes, 4v4 config, `recordings/ppo721_ep{0..4}.jsonl`
+
+## Question
+
+Aggregate metrics showed `objective_coverage` and `closest_objective/progress` improving
+while the fraction-based success criteria stayed flat. What is the agent actually doing
+inside an episode?
+
+## Method
+
+Event logs were decoded with `JsonMatchCodec` and replayed through `ReplayController`,
+which reconstructs a full `GameStateSnapshot` per step from delta-encoded events. For each
+step the number of player models with any `at_objective` flag set was counted.
+
+```python
+log = JsonMatchCodec().decode(open(path, "rb").read())
+snaps = ReplayController(log).iter_snapshots()
+counts = [sum(1 for m in s.player_models if any(m.at_objective)) for s in snaps]
+```
+
+## Result
+
+Models on objectives, per step, out of 4:
+
+```
+ep0  00000111111221133333333333333112211111111   peak 3 -> final 1
+ep1  (peak 3 -> final 2)
+ep2  00011001122333311000000003322110011222211   peak 3 -> final 1
+ep3  00011111122112222002222112222224            peak 4 -> final 4  (terminated on success)
+ep4  (peak 4 -> final 4)                          (terminated on success)
+```
+
+Per-episode summary, with each model's final distance to its nearest objective
+(objective radius = 3):
+
+| Episode | Steps | Peak on-obj | Final on-obj | Final distances |
+|---|---|---|---|---|
+| ep0 | 40 | 3/4 | 1/4 | 2.8, 5.1, 5.4, 6.7 |
+| ep1 | 40 | 3/4 | 2/4 | 2.2, 3.0, 5.0, 6.3 |
+| ep2 | 40 | 3/4 | 1/4 | 2.0, 5.0, 5.4, 5.8 |
+| ep3 | 31 | 4/4 | 4/4 | 2.2, 2.2, 2.2, 3.0 |
+| ep4 | 31 | 4/4 | 4/4 | 1.0, 1.0, 1.0, 2.2 |
+
+**ep2 is the clearest case:** 3 models on objectives at step ~15, then **zero for eight
+consecutive steps**, then back to 3, then down to 1 at the end. That is active abandonment
+and re-approach, not positional noise.
+
+Episodes that ran the full 40 steps ended with 1–2 of 4 on objectives, at distances of
+5–6 against a radius of 3 — outside, having previously been inside. The two episodes
+ending at 4/4 (ep3, ep4) are the two that **terminated early on success**: the episode
+stopped at the good moment, so the final state is favourable by construction.
+
+## Interpretation
+
+`closest_objective` with `progress_scale` computes `10 x distance_closed`. This is a
+**potential function**: over any trajectory that leaves an objective and returns, the
+contributions cancel to exactly zero. The policy is therefore mathematically indifferent
+between holding a point and wandering off and back.
+
+`objective_coverage` pays only when out-counting the opponent at an objective and
+saturates at roughly two models a point, so it does not oppose the remaining models
+drifting.
+
+At the time these episodes were recorded, **no reward term paid for occupancy per step**,
+so no gradient held models in place. This is the same gap recorded as
+[D3](2026-08-04-mechanism-defects.md#d3--the-gated-quantity-had-no-dense-reward-behind-it).
+
+**Status of this interpretation:** the drift is *measured*; the potential-function
+explanation is *inferred* from the calculator's definition. It has not been tested by
+ablating `progress_scale`.
+
+## Consequences
+
+**Success is judged at the final step**, so drift makes the criteria under-report
+capability by roughly the peak-to-final ratio:
+
+| Scale | Peak on objectives | Final on objectives |
+|---|---|---|
+| 4v4 (this data) | 3/4 | 1/4 |
+| 25v25 (earlier measurement) | 6–8 / 25 | 2.5–4 / 25 |
+
+Both give a ratio near 3x. This directly explains why gates calibrated on final-step
+measurements sat far below observable behaviour, and why an early sizing attempt that used
+*peak* occupancy produced thresholds that measured 0% in practice.
+
+## Secondary findings
+
+**Terrain and shooting were inert in this config.** All five episodes ended 4–4 alive with
+`weapons: []` on every model. An empty weapon list means a model cannot shoot; terrain
+blocks only line-of-sight; line-of-sight only matters for shooting. Nothing about terrain
+was exercised.
+
+**The analyser's "high idle rate" warning is a false positive.** It fired on all five
+episodes at 48–52%. `_analyze_movement` (`analysis.py:291-295`) counts every `Stay` as
+idle regardless of battle phase. With `skip_phases: [command, charge, fight]`, exactly half
+of all steps are the shooting phase, where `Stay` is the only legal action. The ~50%
+figure is structural, not behavioural. Already noted in `CLAUDE.md`.
+
+## Actions taken
+
+- `models_at_objectives` weight raised to 1.0 (`approach_objectives`) and 1.5
+  (`mass_on_objectives`), above the saturating `objective_coverage`. This is the only term
+  that makes holding strictly better than oscillating.
+- `terminate_on_success` fixed to consult the configured criteria — but **not enabled**,
+  since it would inflate `success_rate` ~3x by construction. See
+  [mechanism defects](2026-08-04-mechanism-defects.md#latent-issue-fixed-but-deliberately-not-enabled).
+
+## Limitations
+
+**These are 4v4 recordings, not 25v25.** No 25v25 snapshots existed: `--record-events` was
+passed to five 25v25 runs and wrote nothing, because the log was serialised only after
+`trainer.fit()` returned and every run was stopped mid-flight. This is now fixed — the log
+is written at each epoch start — so future runs produce this data as a side effect.
+
+The 25v25 peak-vs-final figures quoted above come from earlier aggregate measurements, not
+from step traces, and corroborate the ratio without replacing a direct trace.
+
+**Five episodes, one checkpoint, one config.** Enough to establish that drift occurs and to
+identify a plausible mechanism; not enough to quantify its frequency across policies.

--- a/reports/2026-08-04-reward-phase-curriculum.md
+++ b/reports/2026-08-04-reward-phase-curriculum.md
@@ -1,0 +1,179 @@
+# Reward-phase curriculum at 25v25: why it stalled, and what moved it
+
+**Date:** 2026-08-04
+**Config:** `examples/env_config/25v25_scripted_opponent_random_objectives_3_reward_phases_terrain.yaml`
+**Algorithm:** PPO + TransformerNetwork (6.51M params), 25v25, 3 random objectives, 20 rounds
+(`max_turns = 40`), 7 terrain pieces, scripted advancing opponent
+**Branch / PR:** `feature/25v25-terrain-config` — [#127](https://github.com/sashman/wargame_rl/pull/127)
+
+## Question
+
+An earlier 25v25 run gated on `all_at_objectives` held `success_rate` at exactly 0 for 330
+epochs while other metrics improved — that criteria needs `p**25` at this army size and is
+unreachable. Replacing it with a `fraction_at_objectives` ladder produced non-zero rates
+but the successor runs below still plateaued under their phase-0 gate. **Why does the
+curriculum never advance, and can it be made to reach the final `win_at_the_end` phase?**
+
+## Summary of outcome
+
+The curriculum reached `win_at_the_end`. The cause of the stall was **four defects in the
+advancement mechanism**, not the quality of the learned policy — three of the four make
+advancement impossible independently of how well the agent plays.
+
+The hypotheses about *learning dynamics* (discount factor, entropy coefficient) were
+mostly wrong and cost three runs. The defects were found by measuring the mechanism.
+
+## Runs
+
+All runs: PPO + transformer, `n_steps=2048`. All were stopped manually; none ran to their
+epoch cap. `success_rate` figures are the mean of the last 40 logged epochs.
+
+| # | Run | Changed vs previous | γ | ent | n_eval | Epochs | Final phase | `success_rate` |
+|---|---|---|---|---|---|---|---|---|
+| 1 | `wd71v79p` | baseline (fraction ladder) | 0.90 | 0.03 | 10 | 511 | 0 | 48.2 |
+| 2 | `km1equ2u` | terminal-bonus fix; γ 0.99; gate 3x30 | 0.99 | 0.03 | 30 | 301 | 0 | 33.2 |
+| 3 | `5ibr1cls` | + `models_at_objectives`; bonus 5.0→3.0 | 0.99 | 0.03 | 30 | 163 | 0 | 15.1 |
+| 4 | `zdo84kkc` | + `ent_coef` 0.01 | 0.99 | **0.01** | 30 | 148 | 0 | 3.7 |
+| 5 | `cad3hbz7` | γ 0.95; ent reverted; thresholds lowered | 0.95 | 0.03 | 30 | 301 | 0 | 32.7 |
+| 6 | `zf3ebdvs` | ladder re-sized from checkpoint sweep; warm start | 0.95 | 0.03 | 30 | 373 | **1** | 17.3 |
+| 7 | `g5zuqts1` | ladder re-sized from **live** rates; warm start | 0.95 | 0.03 | 30 | 945 | **3** | 18.5 |
+
+Run 7 advanced `approach_objectives → mass_on_objectives` at epoch 5,
+`→ win_only_by_vp` at epoch 30, and `→ win_at_the_end` at epoch 50, confirmed by phase
+name in the training log.
+
+Note that `success_rate` is **not comparable across rows**: the active phase's criteria
+and `min_fraction` change between runs, so the same number measures different things.
+
+## Hypotheses and verdicts
+
+| # | Hypothesis | Verdict | Evidence |
+|---|---|---|---|
+| H1 | `terminal_success_bonus` is under-delivered | **Confirmed** | Arithmetic + direct measurement: nominal 5.0 delivered 0.125 |
+| H2 | The advancement gate demands more than its nominal threshold | **Confirmed** | Binomial: 10 consecutive epochs ≥0.7 at n=10 needs a true rate ≈0.85 |
+| H3 | The criteria has no dense reward behind it | **Confirmed** (gap real) | No calculator paid for the gated quantity; effect on `success_rate` **not** demonstrated |
+| H4 | γ=0.9 is too myopic for 40-step episodes | **Refuted** | γ 0.9→0.99 lowered `success_rate` 48.2 → 33.2 |
+| H5 | `ent_coef=0.03` pins the policy and prevents commitment | **Refuted** | ent 0.03→0.01 collapsed eval `success_rate` to 3.7 |
+| H6 | The ladder is mis-shaped, not the policy | **Confirmed** | Rung measured harder than the final goal; re-sizing produced advancement |
+
+Full evidence for H1, H2, H3 and H6 is in
+[mechanism defects](2026-08-04-mechanism-defects.md).
+
+### H4 — raising the discount factor (refuted)
+
+γ was raised 0.9 → 0.99 so the terminal bonus, which lands on the last step, would be
+visible to early actions (`0.9^40 = 0.015` vs `0.99^40 = 0.669`).
+
+Measured: `success_rate` fell from 48.2 (run 1) to 33.2 (run 2). Reverting to an
+intermediate γ=0.95 recovered to 32.7 in run 5 under lower thresholds.
+
+Interpretation — **inferred, not measured.** Raising γ multiplied the discounted dense
+shaping at t=0 by ~3.3x but the terminal bonus by ~41x, shifting the split at t=0 from
+roughly 11% terminal / 89% dense to 59% / 41%. A terminal bonus is a sparse binary
+signal: it reports *whether* an episode succeeded, not which direction to move. The
+plausible reading is that it displaced the dense shaping that performs the navigation.
+This was not isolated experimentally — run 2 also changed the terminal-bonus magnitude
+and the gate sampling.
+
+### H5 — lowering the entropy coefficient (refuted)
+
+`loss/entropy_loss_epoch` sat in `[-1.81, -1.72]` — a 0.09-nat band — across 975 epochs
+and three configurations differing in γ, terminal-bonus magnitude (40x), and reward
+composition. Invariance under that much change suggested the coefficient was pinning it.
+
+It was: `ent_coef` 0.03 → 0.01 moved entropy −1.79 → −0.59. But the outcome inverted
+expectations. Over epochs 100–149:
+
+| Metric (epochs 100–149) | ent 0.03 | ent 0.01 |
+|---|---|---|
+| `closest_objective` | 0.898 | **1.063** |
+| `models_at_objectives` | 0.670 | **0.833** |
+| `objective_coverage` | 1.785 | **2.041** |
+| `mean_episode_reward` (eval) | **5.03** | 1.27 |
+| `min_episode_reward` (eval) | −0.06 | **−2.25** |
+
+Every *training-rollout* component improved while *evaluation* reward fell 4x. Objectives
+are placed randomly each episode; at 0.59 nats the policy keeps roughly `e^0.59 ≈ 1.8`
+actions live and had converged to a rigid routine that generalised poorly to unseen
+layouts. The `min_episode_reward` of −2.25 is consistent with catastrophic failures on
+some layouts.
+
+This is a clean instance of the training-rollout vs evaluation distinction in
+`docs/metrics.md`: the two quantities disagreed in **sign of change**.
+
+## What produced the advancement
+
+Runs 6 and 7 differ **only** in the ladder's rung sizes; run 7 warm-started from run 6's
+checkpoint and shares its code, γ, `ent_coef`, and eval-episode count.
+
+| Rung | Run 6 | Run 7 |
+|---|---|---|
+| `approach_objectives` | `min_fraction` 0.15 @ 0.45 | unchanged |
+| `mass_on_objectives` | `min_fraction` 0.25 @ 0.35 | **0.20 @ 0.25** |
+| `win_only_by_vp` | `fraction_of_max` 0.3 @ 0.35 | **@ 0.25** |
+
+Run 6 advanced once (epoch 38) then held `success_rate` at 17.3 for 330 epochs against a
+0.35 gate. Run 7 cleared three gates in 50 epochs.
+
+**This comparison is well-controlled and supports attributing the advancement to the rung
+sizes.** It does not show the policy improved — see the limitation below.
+
+## Limitations
+
+**The bar was lowered.** Reaching `win_at_the_end` was achieved partly by reducing
+thresholds and `min_fraction` values to measured capability. This was the correct response
+to gates that were provably unopenable (D2, D4 in the defects report), but the agent
+cleared easier rungs than originally specified. Any claim of "the curriculum works now"
+must carry this caveat.
+
+**The agent did not improve at the final phase.** Over 895 epochs in `win_at_the_end`,
+`success_rate` (fraction of episodes ending ahead on VP) was:
+
+| Epochs | 50–199 | 200–349 | 350–499 | 500–649 | 650–799 | 800–949 |
+|---|---|---|---|---|---|---|
+| mean | 8.9 | 17.7 | 15.4 | 17.3 | 12.7 | 17.2 |
+
+An initial rise to ~17% then flat. **Reaching the phase is established; winning it is
+not.** The agent loses the VP race roughly 83% of the time.
+
+**Single seed, one variable-set per run.** Runs 2, 5 and 6 each changed more than one
+thing. These runs support "this mechanism was broken" and do not support ranking
+hyperparameters. H4 and H5 are refuted as *directions that helped*, not isolated
+as sole causes of the observed drops.
+
+**Runs were stopped early** (148–945 of 500–1200 epochs) based on visible trends. Runs 3
+and 4 were stopped at 163 and 148 epochs; both were tracking or below their predecessors
+at matched epochs, but a later reversal cannot be excluded.
+
+**H3 is a confirmed gap with unconfirmed benefit.** `models_at_objectives` closes a real
+hole — the criteria measured a quantity nothing rewarded — but run 3 tracked run 2 rather
+than beating it, and no run has isolated its effect at the raised weights.
+
+**The opponent cannot shoot.** `ScriptedAdvanceToObjectivePolicy` emits only movement and
+stay actions. Terrain blocks line-of-sight, and line-of-sight only affects shooting, so
+terrain protects the opponent from the player and never the reverse. The player takes no
+casualties, making `killing` risk-free in the VP phases. Every VP result here is against
+a defenceless opponent.
+
+## Conclusions
+
+1. **The curriculum stall was a mechanism failure, not a learning failure.** Three of the
+   four defects make advancement impossible regardless of policy quality.
+2. **Measure the mechanism before tuning the policy.** Three runs (~2.5 hours) were spent
+   on discount and entropy hypotheses. The defects were found by arithmetic and by
+   evaluating criteria directly against checkpoints.
+3. **Gate thresholds must be calibrated against the distribution the gate reads** — the
+   live per-epoch `success_rate`, not a best-checkpoint sweep.
+4. **A curriculum rung must be verified easier than the rungs after it.** One rung here
+   was measurably harder than the final goal.
+
+## Follow-up
+
+- **Make the opponent shoot.** Add a shooting branch to
+  `ScriptedAdvanceToObjectivePolicy.select_action` and mask its shots with
+  `compute_shooting_masks`. Without masking the opponent would shoot through terrain at
+  unlimited range: `_resolve_shooting_action` validates alive/slice/weapons but neither
+  range nor line-of-sight. Until then no VP result is a fair test.
+- **Isolate `models_at_objectives`** at its raised weights (1.0 / 1.5) against a matched
+  control, with the `at_objective` trace as the primary signal rather than `success_rate`.
+- **Raise the phase-3 win rate**, currently ~17% and flat over 895 epochs.

--- a/reports/README.md
+++ b/reports/README.md
@@ -1,0 +1,46 @@
+# Experiment reports
+
+Findings from training experiments, kept for retrospection. Each report records what
+was asked, what was measured, and what the measurement does and does not support.
+
+## Index
+
+| Report | Question | Outcome |
+|---|---|---|
+| [2026-08-04 — reward-phase curriculum](2026-08-04-reward-phase-curriculum.md) | Why does the 25v25 curriculum never leave phase 0, and can it reach `win_at_the_end`? | Reached `win_at_the_end`; cause was four mechanism defects, not policy quality |
+| [2026-08-04 — mechanism defects](2026-08-04-mechanism-defects.md) | Detailed evidence for each defect found | Four confirmed, all fixed |
+| [2026-08-04 — objective drift](2026-08-04-objective-drift.md) | What does the agent actually do during an episode? | Reaches objectives, then abandons them; peak occupancy ~3x final |
+
+## Conventions
+
+**Distinguish measurement from inference.** Every quantitative claim states how it was
+obtained. Claims that are inferred rather than measured say so.
+
+**Report negative results.** A refuted hypothesis costs a run to establish and costs
+another run every time it is retried by someone who does not know it failed.
+
+**State confounds.** Most runs here changed more than one variable, were stopped early,
+and used a single seed. That is adequate for finding defects and inadequate for ranking
+hyperparameters. Reports say which of the two they support.
+
+**Prefer the live metric.** `success_rate` from a best checkpoint is not the same
+quantity as the per-epoch `success_rate` a gate reads. See
+[mechanism defects, D4](2026-08-04-mechanism-defects.md#d4--rungs-calibrated-against-the-wrong-distribution).
+
+## Reproducing
+
+```bash
+# Rolling-mean metrics for a run (point readings are n-sample binomials -- do not trust them)
+just run-summary <run_id> [bucket_size]
+
+# Per-phase criteria rates and the whole min_fraction curve for a checkpoint
+uv run measure_phase_gates.py <checkpoint> <env_config> 40
+
+# Behavioural analysis of a recorded match
+just replay-summary <file>
+just analyze <file>
+just analyze-compare <files...>
+```
+
+Recordings live in `recordings/` (gitignored). Runs are in the `wargame_rl/wargame_rl`
+Weights & Biases project; run IDs are given in each report.

--- a/reports/README.md
+++ b/reports/README.md
@@ -34,7 +34,7 @@ quantity as the per-epoch `success_rate` a gate reads. See
 just run-summary <run_id> [bucket_size]
 
 # Per-phase criteria rates and the whole min_fraction curve for a checkpoint
-uv run measure_phase_gates.py <checkpoint> <env_config> 40
+just measure-phase-gates <checkpoint> <env_config> 40
 
 # Behavioural analysis of a recorded match
 just replay-summary <file>

--- a/run_summary.py
+++ b/run_summary.py
@@ -1,0 +1,92 @@
+"""Print a compact training-run summary from Wandb history.
+
+Usage: uv run scripts/run_summary.py <run_id> [bucket_size]
+
+Single-epoch `success_rate` is an n_episodes-sample binomial, so this reports
+rolling means over epoch buckets rather than point readings. See docs/metrics.md.
+"""
+
+from __future__ import annotations
+
+import statistics
+import sys
+
+from wandb.apis.public import Api
+
+ENTITY = "wargame_rl"
+PROJECT = "wargame_rl"
+
+TRACKED = [
+    "success_rate",
+    "reward/mean_episode_reward",
+    "reward/max_episode_reward",
+    "reward/components/objective_coverage",
+    "reward/components/closest_objective/progress",
+    "reward/components/terminal_success_bonus",
+    "loss/entropy_loss_epoch",
+    "loss/value_loss_epoch",
+    "mean_episode_steps",
+]
+
+
+def main() -> None:
+    run_id = sys.argv[1]
+    bucket_size = int(sys.argv[2]) if len(sys.argv) > 2 else 50
+
+    api = Api()
+    run = api.run(f"{ENTITY}/{PROJECT}/{run_id}")
+    rows = list(run.scan_history())
+
+    by_epoch: dict[int, dict[str, float]] = {}
+    for row in rows:
+        epoch = row.get("epoch")
+        if epoch is None:
+            continue
+        merged = by_epoch.setdefault(int(epoch), {})
+        for key, value in row.items():
+            if isinstance(value, (int, float)):
+                merged[key] = value
+
+    if not by_epoch:
+        print("no epoch-indexed rows yet")
+        return
+
+    epochs = sorted(by_epoch)
+    last = epochs[-1]
+    runtime = max(r.get("_runtime", 0.0) for r in rows if "_runtime" in r)
+    print(
+        f"run={run_id} state={run.state} last_epoch={last} runtime={runtime / 60:.1f}min"
+    )
+
+    phases = {
+        e: by_epoch[e]["reward_phase"] for e in epochs if "reward_phase" in by_epoch[e]
+    }
+    if phases:
+        current = phases[max(phases)]
+        print(f"reward_phase={int(current)}")
+        previous = None
+        for epoch in sorted(phases):
+            if previous is not None and phases[epoch] != previous:
+                print(
+                    f"  ** PHASE ADVANCED to {int(phases[epoch])} at epoch {epoch} **"
+                )
+            previous = phases[epoch]
+
+    header = f"{'epochs':>12} {'n':>3} " + " ".join(
+        f"{k.split('/')[-1][:11]:>11}" for k in TRACKED
+    )
+    print(header)
+    for start in range(0, last + 1, bucket_size):
+        window = [by_epoch[e] for e in epochs if start <= e < start + bucket_size]
+        if not window:
+            continue
+        cells = []
+        for key in TRACKED:
+            values = [w[key] for w in window if key in w]
+            cells.append(f"{statistics.mean(values):11.4f}" if values else f"{'-':>11}")
+        label = f"{start}-{start + bucket_size - 1}"
+        print(f"{label:>12} {len(window):>3} " + " ".join(cells))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/measure_phase_gates.py
+++ b/scripts/measure_phase_gates.py
@@ -4,7 +4,7 @@ Answers "is the ladder ahead passable?" before a run reaches those phases, using
 the same evaluation path training uses: run the episode to its end, then check
 each phase's criteria against `env.last_step_context`.
 
-Usage: uv run measure_phase_gates.py <checkpoint> <env_config> [n_episodes]
+Usage: just measure-phase-gates <checkpoint> <env_config> [n_episodes]
 """
 
 from __future__ import annotations

--- a/scripts/run_summary.py
+++ b/scripts/run_summary.py
@@ -1,6 +1,6 @@
 """Print a compact training-run summary from Wandb history.
 
-Usage: uv run scripts/run_summary.py <run_id> [bucket_size]
+Usage: just run-summary <run_id> [bucket_size]
 
 Single-epoch `success_rate` is an n_episodes-sample binomial, so this reports
 rolling means over epoch buckets rather than point readings. See docs/metrics.md.

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -178,6 +178,81 @@ def test_step_adds_terminal_success_bonus_when_all_models_at_objective() -> None
     assert reward >= 12.5
 
 
+def _fraction_termination_config(
+    *, min_fraction: float, terminate_on_success: bool
+) -> WargameEnvConfig:
+    """Two models, one on an objective and one far away -> fraction is exactly 0.5."""
+    return WargameEnvConfig(
+        render_mode=None,
+        board_width=10,
+        board_height=10,
+        number_of_wargame_models=2,
+        number_of_objectives=1,
+        objective_radius_size=1,
+        models=[
+            {"x": 4, "y": 4, "group_id": 0},  # type: ignore[list-item]
+            {"x": 9, "y": 9, "group_id": 0},  # type: ignore[list-item]
+        ],
+        objectives=[{"x": 4, "y": 4}],  # type: ignore[list-item]
+        reward_phases=[
+            RewardPhaseConfig(
+                name="reach",
+                reward_calculators=[
+                    RewardCalculatorConfig(type="closest_objective", weight=1.0),
+                ],
+                success_criteria=SuccessCriteriaConfig(
+                    type="fraction_at_objectives",
+                    params={"min_fraction": min_fraction},
+                ),
+                terminate_on_success=terminate_on_success,
+            ),
+        ],
+    )
+
+
+def test_terminates_on_success_of_configured_fraction_criteria() -> None:
+    """Termination consults the phase's criteria, not a hardcoded all-at-objectives.
+
+    With 1 of 2 models on the objective the fraction is 0.5, which satisfies a
+    0.5 criteria but never satisfies all-at-objectives -- so this episode could
+    not end early before termination honoured the configured criteria.
+    """
+    env = WargameEnv(
+        config=_fraction_termination_config(min_fraction=0.5, terminate_on_success=True)
+    )
+    env.reset(seed=42)
+
+    _, _, terminated, _, _ = env.step(WargameEnvAction(actions=[0, 0]))
+
+    assert terminated is True
+
+
+def test_does_not_terminate_when_fraction_criteria_unmet() -> None:
+    """A fraction the state does not reach must not end the episode."""
+    env = WargameEnv(
+        config=_fraction_termination_config(min_fraction=1.0, terminate_on_success=True)
+    )
+    env.reset(seed=42)
+
+    _, _, terminated, _, _ = env.step(WargameEnvAction(actions=[0, 0]))
+
+    assert terminated is False
+
+
+def test_terminate_on_success_false_keeps_episode_running_on_success() -> None:
+    """`terminate_on_success: false` must suppress success termination entirely."""
+    env = WargameEnv(
+        config=_fraction_termination_config(
+            min_fraction=0.5, terminate_on_success=False
+        )
+    )
+    env.reset(seed=42)
+
+    _, _, terminated, _, _ = env.step(WargameEnvAction(actions=[0, 0]))
+
+    assert terminated is False
+
+
 def test_step_invalid_action_raises(env: WargameEnv) -> None:
     """Action out of bounds for a model raises ValueError."""
     env.reset(seed=42)

--- a/tests/test_event_stream.py
+++ b/tests/test_event_stream.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from wargame_rl.wargame.envs.state import (
@@ -19,6 +21,7 @@ from wargame_rl.wargame.envs.state import (
 )
 from wargame_rl.wargame.envs.types import WargameEnvAction, WargameEnvConfig
 from wargame_rl.wargame.envs.wargame import WargameEnv
+from wargame_rl.wargame.model.common.event_log_callback import EventLogCallback
 
 
 @pytest.fixture
@@ -337,3 +340,73 @@ class TestEnvIntegration:
 
         assert len(exp1.log) == 6
         assert len(exp2.log) == 6
+
+
+class TestEventLogCallback:
+    """The callback must persist a log mid-run, not only after fit() returns."""
+
+    @staticmethod
+    def _populated_exporter() -> EventLogExporter:
+        exporter = EventLogExporter(anchor_interval=5)
+        cfg = WargameEnvConfig(
+            board_width=10,
+            board_height=10,
+            number_of_wargame_models=1,
+            number_of_objectives=1,
+            number_of_battle_rounds=3,
+        )
+        env = WargameEnv(config=cfg, state_exporters=[exporter])
+        env.reset(seed=1)
+        for _ in range(3):
+            env.step(WargameEnvAction(actions=env.action_space.sample()))
+        return exporter
+
+    def test_epoch_start_writes_a_decodable_log(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A killed run must still leave a readable recording behind."""
+        monkeypatch.chdir(tmp_path)
+        exporter = self._populated_exporter()
+        callback = EventLogCallback("test-run", exporter)
+
+        callback.on_train_epoch_start(None, None)  # type: ignore[arg-type]
+
+        assert callback.output_path.exists()
+        decoded = JsonMatchCodec().decode(callback.output_path.read_bytes())
+        assert len(decoded) == len(exporter.log)
+
+    def test_write_is_a_noop_before_any_episode(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An epoch that recorded nothing must not leave an empty file."""
+        monkeypatch.chdir(tmp_path)
+        callback = EventLogCallback("test-run", EventLogExporter())
+
+        assert callback.write() is False
+        assert not callback.output_path.exists()
+
+    def test_reset_only_log_is_not_written(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A just-reset episode must not overwrite a usable recording.
+
+        Regression: writing at this moment produced a 1-event file that decoded
+        fine but contained no steps to analyse.
+        """
+        monkeypatch.chdir(tmp_path)
+        exporter = EventLogExporter(anchor_interval=5)
+        cfg = WargameEnvConfig(
+            board_width=10,
+            board_height=10,
+            number_of_wargame_models=1,
+            number_of_objectives=1,
+            number_of_battle_rounds=3,
+        )
+        env = WargameEnv(config=cfg, state_exporters=[exporter])
+        env.reset(seed=1)
+
+        callback = EventLogCallback("test-run", exporter)
+
+        assert len(exporter.log) == 1
+        assert callback.write() is False
+        assert not callback.output_path.exists()

--- a/tests/test_reward_phases.py
+++ b/tests/test_reward_phases.py
@@ -20,6 +20,9 @@ from wargame_rl.wargame.envs.reward.calculators.closest_objective_v2 import (
 from wargame_rl.wargame.envs.reward.calculators.group_cohesion import (
     GroupCohesionCalculator,
 )
+from wargame_rl.wargame.envs.reward.calculators.models_at_objectives import (
+    ModelsAtObjectivesCalculator,
+)
 from wargame_rl.wargame.envs.reward.calculators.objective_coverage import (
     ObjectiveCoverageCalculator,
 )
@@ -684,6 +687,78 @@ class TestObjectiveCoverageCalculator:
         calc = build_calculator("objective_coverage", weight=1.0, params={})
         assert isinstance(calc, ObjectiveCoverageCalculator)
         assert calc.weight == 1.0
+
+
+class TestModelsAtObjectivesCalculator:
+    @staticmethod
+    def _env() -> WargameEnv:
+        env = WargameEnv(
+            config=WargameEnvConfig(
+                render_mode=None,
+                board_width=20,
+                board_height=20,
+                number_of_wargame_models=4,
+                number_of_objectives=2,
+                objective_radius_size=2,
+            )
+        )
+        env.reset()
+        env.objectives[0].location = np.array([5, 5])
+        env.objectives[1].location = np.array([15, 15])
+        return env
+
+    def test_fraction_of_models_on_objectives(self) -> None:
+        env = self._env()
+        env.wargame_models[0].location = np.array([5, 5])  # on obj0
+        env.wargame_models[1].location = np.array([15, 15])  # on obj1
+        env.wargame_models[2].location = np.array([0, 0])
+        env.wargame_models[3].location = np.array([0, 19])
+        calc = ModelsAtObjectivesCalculator(weight=1.0)
+
+        ctx = _make_step_context(
+            env, compute_distances(env.wargame_models, env.objectives)
+        )
+        assert calc.calculate(env, ctx) == pytest.approx(0.5)  # 2 of 4
+
+    def test_stacking_one_objective_still_counts_every_model(self) -> None:
+        """Unlike objective_coverage, this does not saturate at one model a point.
+
+        That non-saturation is the whole reason the calculator exists: it is the
+        dense counterpart of the fraction_at_objectives criteria.
+        """
+        env = self._env()
+        for model in env.wargame_models:
+            model.location = np.array([5, 5])
+        calc = ModelsAtObjectivesCalculator(weight=1.0)
+
+        ctx = _make_step_context(
+            env, compute_distances(env.wargame_models, env.objectives)
+        )
+        assert calc.calculate(env, ctx) == pytest.approx(1.0)
+
+    def test_dead_models_leave_the_denominator(self) -> None:
+        env = self._env()
+        env.wargame_models[0].location = np.array([5, 5])  # on obj0
+        for model in env.wargame_models[1:]:
+            model.location = np.array([0, 0])
+        calc = ModelsAtObjectivesCalculator(weight=1.0)
+
+        ctx = _make_step_context(
+            env, compute_distances(env.wargame_models, env.objectives)
+        )
+        assert calc.calculate(env, ctx) == pytest.approx(0.25)  # 1 of 4
+
+        env.wargame_models[1].take_damage(env.wargame_models[1].stats["max_wounds"])
+        env.wargame_models[2].take_damage(env.wargame_models[2].stats["max_wounds"])
+        ctx = _make_step_context(
+            env, compute_distances(env.wargame_models, env.objectives)
+        )
+        assert calc.calculate(env, ctx) == pytest.approx(0.5)  # 1 of 2 alive
+
+    def test_build_models_at_objectives(self) -> None:
+        calc = build_calculator("models_at_objectives", weight=0.5, params={})
+        assert isinstance(calc, ModelsAtObjectivesCalculator)
+        assert calc.weight == 0.5
 
 
 def test_reward_breakdown_matches_total(simple_env: WargameEnv) -> None:

--- a/tests/test_wounds.py
+++ b/tests/test_wounds.py
@@ -79,7 +79,7 @@ def test_is_battle_over_all_eliminated() -> None:
         clock=clock,
         current_turn=0,
         max_turns=100,
-        all_models_at_objectives_flag=False,
+        success_flag=False,
         all_eliminated=True,
     )
     assert result is True
@@ -91,7 +91,7 @@ def test_is_battle_over_without_elimination() -> None:
         clock=clock,
         current_turn=0,
         max_turns=100,
-        all_models_at_objectives_flag=False,
+        success_flag=False,
         all_eliminated=False,
     )
     assert result is False

--- a/tests/test_z_e2e_training.py
+++ b/tests/test_z_e2e_training.py
@@ -34,4 +34,9 @@ def test_training_smoke() -> None:
         no_wandb=True,
         n_steps=64,
         n_eval_episodes=1,
+        # train() is called directly rather than through typer, so every override
+        # must be passed explicitly — an unset one arrives as a typer OptionInfo
+        # and fails the `is not None` guard.
+        gamma=None,
+        ent_coef=None,
     )

--- a/train.py
+++ b/train.py
@@ -194,6 +194,14 @@ def train(
         None,
         help="Override number of evaluation episodes per epoch (defaults to config value)",
     ),
+    gamma: float | None = typer.Option(
+        None,
+        help="Override PPO discount factor (defaults to PPOConfig value)",
+    ),
+    ent_coef: float | None = typer.Option(
+        None,
+        help="Override PPO entropy coefficient (defaults to PPOConfig value)",
+    ),
     resume_ckpt_path: str | None = typer.Option(
         None,
         help="Resume full training state (model, optimizer, epoch/step) from a Lightning checkpoint.",
@@ -313,6 +321,10 @@ def train(
             ppo_config.n_steps = n_steps
         if n_eval_episodes is not None:
             ppo_config.n_episodes = n_eval_episodes
+        if gamma is not None:
+            ppo_config.gamma = gamma
+        if ent_coef is not None:
+            ppo_config.ent_coef = ent_coef
         ppo_training_config = PPOTrainingConfig(
             record_during_training=record_during_training,
             record_after_epoch=record_after_epoch,

--- a/train.py
+++ b/train.py
@@ -1,6 +1,5 @@
 import os
 from enum import Enum
-from pathlib import Path
 from typing import Any, cast
 
 import torch
@@ -11,7 +10,7 @@ from pytorch_lightning import LightningModule, Trainer
 from pytorch_lightning.callbacks import Callback
 from typer.models import OptionInfo
 
-from wargame_rl.wargame.envs.state import EventLogExporter, JsonMatchCodec
+from wargame_rl.wargame.envs.state import EventLogExporter
 from wargame_rl.wargame.envs.types import WargameEnvConfig
 from wargame_rl.wargame.model.common import (
     EnvConfigCallback,
@@ -19,6 +18,7 @@ from wargame_rl.wargame.model.common import (
     get_logger,
     init_wandb,
 )
+from wargame_rl.wargame.model.common.event_log_callback import EventLogCallback
 from wargame_rl.wargame.model.common.factory import create_environment
 from wargame_rl.wargame.model.common.record_episode_callback import (
     RecordEpisodeCallback,
@@ -289,6 +289,8 @@ def train(
                 [env_config_callback]
                 + get_checkpoint_callback(run.name, filename_prefix="dqn"),
             )
+            if event_exporter is not None:
+                dqn_callbacks.append(EventLogCallback(run_name_base, event_exporter))
             if training_config.record_during_training:
                 dqn_callbacks.append(
                     RecordEpisodeCallback(
@@ -358,6 +360,8 @@ def train(
                 [env_config_callback]
                 + get_checkpoint_callback(run.name, filename_prefix="ppo"),
             )
+            if event_exporter is not None:
+                ppo_callbacks.append(EventLogCallback(run_name_base, event_exporter))
             if ppo_training_config.record_during_training:
                 ppo_callbacks.append(
                     RecordEpisodeCallback(
@@ -388,13 +392,16 @@ def train(
 
 
 def _write_event_log(exporter: EventLogExporter, run_name: str) -> None:
-    """Serialise the last recorded episode to a JSONL file in recordings/."""
-    recordings_dir = Path("recordings")
-    recordings_dir.mkdir(exist_ok=True)
-    out_path = recordings_dir / f"{run_name}_events.jsonl"
-    codec = JsonMatchCodec()
-    out_path.write_bytes(codec.encode(exporter.log))
-    log.info(f"Event log written to {out_path} ({len(exporter.log)} events)")
+    """Serialise the last recorded episode to a JSONL file in recordings/.
+
+    Shares its implementation with the per-epoch `EventLogCallback` so both
+    write the same path, and this final call simply supersedes the last one.
+    """
+    callback = EventLogCallback(run_name, exporter)
+    if callback.write():
+        log.info(
+            f"Event log written to {callback.output_path} ({len(exporter.log)} events)"
+        )
 
 
 if __name__ == "__main__":

--- a/wargame_rl/wargame/envs/domain/termination.py
+++ b/wargame_rl/wargame/envs/domain/termination.py
@@ -14,16 +14,18 @@ def is_battle_over(
     clock: GameClock,
     current_turn: int,
     max_turns: int,
-    all_models_at_objectives_flag: bool,
+    success_flag: bool,
     all_eliminated: bool = False,
 ) -> bool:
-    """True when the episode should end: elimination, turn limit, clock complete, or all at objectives.
+    """True when the episode should end: elimination, turn limit, clock complete, or success.
+
+    `success_flag` is the caller's verdict on the active reward phase's success
+    criteria, already gated on that phase's `terminate_on_success`. It is passed
+    in rather than computed here because the criteria are configurable.
 
     Episode length is governed by the game clock (max_turns is derived from
     number_of_battle_rounds), so there are no post-game "dead" steps.
     """
     if all_eliminated:
         return True
-    return (
-        current_turn >= max_turns or clock.is_game_over or all_models_at_objectives_flag
-    )
+    return current_turn >= max_turns or clock.is_game_over or success_flag

--- a/wargame_rl/wargame/envs/env_components/distance_cache.py
+++ b/wargame_rl/wargame/envs/env_components/distance_cache.py
@@ -31,6 +31,24 @@ class DistanceCache:
             per_model = per_model | ~alive_mask
         return bool(per_model.all())
 
+    def fraction_at_objectives(self, alive_mask: np.ndarray | None = None) -> float:
+        """Fraction of alive models within the radius of at least one objective.
+
+        Unlike :meth:`all_models_at_objectives`, dead models are excluded from
+        both numerator and denominator rather than counted as satisfied.
+        Returns 0.0 when no model is alive.
+        """
+        at_objective = self.model_obj_norms_offset <= self.obj_radii
+        per_model: np.ndarray = np.atleast_1d(at_objective.any(axis=1))
+        if alive_mask is not None:
+            per_model = per_model & alive_mask
+            n_alive = int(alive_mask.sum())
+        else:
+            n_alive = int(per_model.size)
+        if n_alive == 0:
+            return 0.0
+        return float(per_model.sum()) / n_alive
+
     def min_distances_to_same_group(
         self,
         group_ids: np.ndarray,

--- a/wargame_rl/wargame/envs/reward/calculators/models_at_objectives.py
+++ b/wargame_rl/wargame/envs/reward/calculators/models_at_objectives.py
@@ -1,0 +1,30 @@
+"""Dense reward for the fraction of models standing on objectives."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from wargame_rl.wargame.envs.domain.entities import alive_mask_for
+from wargame_rl.wargame.envs.reward.calculators.base import GlobalRewardCalculator
+
+if TYPE_CHECKING:
+    from wargame_rl.wargame.envs.domain.battle_view import BattleView
+    from wargame_rl.wargame.envs.reward.step_context import StepContext
+
+
+class ModelsAtObjectivesCalculator(GlobalRewardCalculator):
+    """Dense reward = fraction of alive models within some objective's radius.
+
+    This is the step-wise counterpart of the ``fraction_at_objectives`` success
+    criteria. ``objective_coverage`` pays for *controlling* objectives, which
+    saturates as soon as the player out-counts the opponent — roughly two models
+    per point — and ``closest_objective`` pays for *approaching* rather than
+    staying. Neither rewards massing models on objectives and holding them, so a
+    phase gated on a model fraction had no dense gradient behind its own
+    criteria. Returns unweighted; the phase manager applies the configured
+    weight.
+    """
+
+    def calculate(self, view: BattleView, ctx: StepContext) -> float:
+        alive = alive_mask_for(view.player_models)
+        return ctx.distance_cache.fraction_at_objectives(alive_mask=alive)

--- a/wargame_rl/wargame/envs/reward/calculators/registry.py
+++ b/wargame_rl/wargame/envs/reward/calculators/registry.py
@@ -16,6 +16,9 @@ from wargame_rl.wargame.envs.reward.calculators.group_cohesion import (
     GroupCohesionCalculator,
 )
 from wargame_rl.wargame.envs.reward.calculators.killing import KillingReward
+from wargame_rl.wargame.envs.reward.calculators.models_at_objectives import (
+    ModelsAtObjectivesCalculator,
+)
 from wargame_rl.wargame.envs.reward.calculators.objective_coverage import (
     ObjectiveCoverageCalculator,
 )
@@ -30,6 +33,7 @@ CALCULATOR_REGISTRY: dict[str, type[RewardCalculatorType]] = {
     "closest_objective": ClosestObjectiveCalculator,
     "closest_objective_v2": ClosestObjectiveV2Calculator,
     "group_cohesion": GroupCohesionCalculator,
+    "models_at_objectives": ModelsAtObjectivesCalculator,
     "objective_coverage": ObjectiveCoverageCalculator,
     "objective_flip_bonus": ObjectiveFlipBonusCalculator,
     "vp_gain": VPGainCalculator,

--- a/wargame_rl/wargame/envs/reward/criteria/fraction_at_objectives.py
+++ b/wargame_rl/wargame/envs/reward/criteria/fraction_at_objectives.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from wargame_rl.wargame.envs.domain.entities import alive_mask_for
+from wargame_rl.wargame.envs.reward.criteria.base import SuccessCriteria
+
+if TYPE_CHECKING:
+    from wargame_rl.wargame.envs.domain.battle_view import BattleView
+    from wargame_rl.wargame.envs.reward.step_context import StepContext
+
+
+class FractionAtObjectivesCriteria(SuccessCriteria):
+    """Succeeds when at least ``min_fraction`` of alive models are within the
+    radius of an objective.
+
+    The all-or-nothing ``all_at_objectives`` scales badly with army size: if each
+    model independently has probability ``p`` of being on an objective, success
+    needs ``p**n_models``, which is unreachable well before 25 models. This
+    criteria degrades gracefully instead, so a curriculum can raise the bar in
+    steps.
+
+    Dead models are excluded from numerator and denominator alike, so casualties
+    neither help nor hinder — note this differs from ``all_at_objectives``, which
+    treats dead models as satisfied.
+    """
+
+    def __init__(self, min_fraction: float = 0.5) -> None:
+        if not 0.0 < min_fraction <= 1.0:
+            raise ValueError(
+                f"min_fraction must be in (0, 1], got {min_fraction}. "
+                "Use all_at_objectives for a strict all-models requirement."
+            )
+        self.min_fraction = min_fraction
+
+    def is_successful(self, view: BattleView, ctx: StepContext) -> bool:
+        alive = alive_mask_for(view.player_models)
+        fraction = ctx.distance_cache.fraction_at_objectives(alive_mask=alive)
+        return fraction >= self.min_fraction

--- a/wargame_rl/wargame/envs/reward/criteria/registry.py
+++ b/wargame_rl/wargame/envs/reward/criteria/registry.py
@@ -9,6 +9,9 @@ from wargame_rl.wargame.envs.reward.criteria.all_models_grouped import (
     AllModelsGroupedCriteria,
 )
 from wargame_rl.wargame.envs.reward.criteria.base import SuccessCriteria
+from wargame_rl.wargame.envs.reward.criteria.fraction_at_objectives import (
+    FractionAtObjectivesCriteria,
+)
 from wargame_rl.wargame.envs.reward.criteria.player_ahead_on_vp import (
     PlayerAheadOnVPCriteria,
 )
@@ -16,6 +19,7 @@ from wargame_rl.wargame.envs.reward.criteria.player_vp_min import PlayerVPMinCri
 
 CRITERIA_REGISTRY: dict[str, type[SuccessCriteria]] = {
     "all_at_objectives": AllAtObjectivesCriteria,
+    "fraction_at_objectives": FractionAtObjectivesCriteria,
     "all_models_grouped": AllModelsGroupedCriteria,
     "player_vp_min": PlayerVPMinCriteria,
     "player_ahead_on_vp": PlayerAheadOnVPCriteria,

--- a/wargame_rl/wargame/envs/reward/phase_manager.py
+++ b/wargame_rl/wargame/envs/reward/phase_manager.py
@@ -197,11 +197,20 @@ class RewardPhaseManager:
         # See docs/metrics.md § Reading rules.
         if ctx.is_terminated and phase.terminal_success_bonus != 0.0:
             if phase.criteria.is_successful(view, ctx):
-                # Scale terminal bonus by remaining turns to encourage faster success.
-                remaining = max(0.0, float(ctx.max_turns - ctx.current_turn + 1))
-                denom = float(ctx.max_turns) if ctx.max_turns > 0 else 1.0
-                remaining_frac = remaining / denom
-                bonus = phase.terminal_success_bonus * remaining_frac
+                # The remaining-turns scaling is a *speed* incentive, and it only
+                # means anything when success ends the episode early. With
+                # terminate_on_success disabled every episode runs to max_turns,
+                # so remaining_frac collapses to 1/max_turns and silently scales
+                # the bonus down by that factor (0.05 at 20 rounds) — which made
+                # the configured bonus worth ~1% of episode reward and left the
+                # success criterion with almost no gradient behind it.
+                if phase.terminate_on_success:
+                    remaining = max(0.0, float(ctx.max_turns - ctx.current_turn + 1))
+                    denom = float(ctx.max_turns) if ctx.max_turns > 0 else 1.0
+                    speed_scale = remaining / denom
+                else:
+                    speed_scale = 1.0
+                bonus = phase.terminal_success_bonus * speed_scale
                 reward += bonus
                 if bonus != 0.0:
                     breakdown["terminal_success_bonus"] = bonus

--- a/wargame_rl/wargame/envs/wargame.py
+++ b/wargame_rl/wargame/envs/wargame.py
@@ -516,11 +516,6 @@ class WargameEnv(gym.Env):
         )
 
         any_player_alive = player_alive.any()
-        all_at_objective = (
-            bool(any_player_alive)
-            and cache.all_models_at_objectives(alive_mask=player_alive)
-            and self.phase_manager.terminate_on_success
-        )
 
         all_player_eliminated = (
             self.config.terminate_on_player_elimination and not any_player_alive
@@ -529,15 +524,6 @@ class WargameEnv(gym.Env):
             not m.is_alive for m in self.opponent_models
         )
         all_eliminated = all_player_eliminated or all_opponent_eliminated
-
-        is_terminated = is_battle_over(
-            self._game_clock,
-            self.current_turn,
-            self.max_turns,
-            all_at_objective,
-            all_eliminated=all_eliminated,
-        )
-        self._last_terminated = is_terminated
 
         clock_state = self._game_clock.state
         phase = clock_state.phase or BattlePhase.command
@@ -557,13 +543,17 @@ class WargameEnv(gym.Env):
             and not m.is_alive
         )
 
+        # Built before termination is known because the phase's success criteria
+        # need a context to evaluate against. No criteria reads `is_terminated`,
+        # so the provisional False here cannot change their verdict; it is
+        # corrected below before any reward is calculated.
         ctx = StepContext(
             distance_cache=cache,
             current_turn=self.current_turn,
             max_turns=self.max_turns,
             board_width=self.board_width,
             board_height=self.board_height,
-            is_terminated=is_terminated,
+            is_terminated=False,
             current_round=clock_state.battle_round or 0,
             battle_phase=phase,
             player_damage_dealt=p_dmg,
@@ -571,6 +561,25 @@ class WargameEnv(gym.Env):
             player_models_killed=p_kills,
             opponent_models_killed=o_kills,
         )
+
+        # Consults the *configured* criteria for the active phase rather than a
+        # hardcoded all-models-at-objectives test, so a phase gated on a model
+        # fraction or on VP can end on its own success.
+        succeeded = (
+            bool(any_player_alive)
+            and self.phase_manager.terminate_on_success
+            and self.phase_manager.check_success(self, ctx)
+        )
+
+        is_terminated = is_battle_over(
+            self._game_clock,
+            self.current_turn,
+            self.max_turns,
+            succeeded,
+            all_eliminated=all_eliminated,
+        )
+        self._last_terminated = is_terminated
+        ctx.is_terminated = is_terminated
         self.last_step_context = ctx
         reward = self.phase_manager.calculate_reward(self, ctx)
 

--- a/wargame_rl/wargame/model/common/event_log_callback.py
+++ b/wargame_rl/wargame/model/common/event_log_callback.py
@@ -1,0 +1,59 @@
+"""Callback that persists the recorded event log while training runs."""
+
+from pathlib import Path
+
+from pytorch_lightning import LightningModule, Trainer
+from pytorch_lightning.callbacks import Callback
+
+from wargame_rl.wargame.envs.state import EventLogExporter, JsonMatchCodec
+
+
+class EventLogCallback(Callback):
+    """Writes the exporter's event log to `recordings/` at each epoch end.
+
+    Long training runs are routinely stopped before `trainer.fit()` returns —
+    monitored, judged, and killed. Writing only at the end means those runs
+    produce no recording at all, which is how five 25v25 runs finished with
+    `--record-events` set and nothing on disk.
+
+    `EventLog.record_reset` replaces its event list, so the log always holds a
+    single episode and rewriting the same path each epoch stays cheap.
+    """
+
+    def __init__(self, run_name: str, exporter: EventLogExporter) -> None:
+        self.run_name = run_name
+        self.exporter = exporter
+        self._codec = JsonMatchCodec()
+
+    @property
+    def output_path(self) -> Path:
+        """Destination file for the serialised event log."""
+        return Path("recordings") / f"{self.run_name}_events.jsonl"
+
+    def write(self) -> bool:
+        """Serialise the current log. Returns False when there is nothing useful.
+
+        A log holding only its reset event is skipped: `record_reset` replaces
+        the event list, so that state means an episode has just begun and no
+        steps have been recorded. Writing it would replace a usable recording
+        with a single frame.
+        """
+        if len(self.exporter.log) <= 1:
+            return False
+        self.output_path.parent.mkdir(exist_ok=True)
+        self.output_path.write_bytes(self._codec.encode(self.exporter.log))
+        return True
+
+    def on_train_epoch_start(
+        self, trainer: Trainer, pl_module: LightningModule
+    ) -> None:
+        """Persist the most recent episode so a killed run still leaves a log.
+
+        Deliberately hooked to epoch *start* rather than epoch end. Lightning
+        invokes callback `on_train_epoch_end` before the LightningModule's, and
+        this project runs its evaluation episodes in the module's hook
+        (`lightning_base.on_train_epoch_end`) — so at callback epoch-end the log
+        often holds nothing but a fresh reset. By the next epoch's start those
+        evaluation episodes have completed, so the log holds a whole one.
+        """
+        self.write()


### PR DESCRIPTION
## What

A 25v25 terrain env config, plus the fixes needed to make its reward-phase curriculum advance. The curriculum now reaches the final `win_at_the_end` phase.

## Four structural defects, all measured

**1. `terminal_success_bonus` delivered at 1/40th of its configured value.**
The remaining-turns scale in `RewardPhaseManager` is a *speed* incentive presuming success ends the episode. With `terminate_on_success: false` every episode runs to `max_turns`, collapsing the scale to `1/max_turns`. On this config (`20 rounds x 2 phases = 40`) a nominal 5.0 delivered **0.125**. The criterion the curriculum gates on was worth ~1% of episode reward against 61% for `objective_coverage`.

**2. The advancement gate needed a far higher true rate than its nominal threshold.**
`min_epochs_above_threshold` requires *consecutive* epochs above the bar, each an `n_episodes`-sample binomial. At `n_episodes=10` a run of 10 readings >= 0.7 needs a true rate near **0.85**.

**3. The ladder was not monotonic.**
`mass_on_objectives` at `min_fraction 0.35` measured 0.20 — harder than `win_only_by_vp` and harder than the final `win_at_the_end` criteria. An intermediate rung stricter than the destination stalls everything behind it.

**4. Rungs were sized from best-checkpoint sweeps; the gate reads the live rate.**
Best checkpoints are selected on reward and run 10-15 points optimistic. `mass_on_objectives` held a live mean of 0.174 for 330 epochs against a 0.35 bar — P(one epoch passes) 0.003, P(three running) **2e-8**, unopenable at any budget — while a checkpoint sweep read 0.33 and made it look marginal.

| phase | live mean | threshold | P(3 running) | outcome |
|---|---|---|---|---|
| `approach_objectives` | 0.365 | 0.45 | 0.008 | advanced at epoch 38 |
| `mass_on_objectives` | 0.174 | 0.35 | 2e-8 | never |

## Also

- `models_at_objectives` — the dense counterpart of `fraction_at_objectives`. `objective_coverage` saturates once the player out-counts the opponent (~2 models a point) and `closest_objective` pays for approaching rather than staying, so the criteria had no dense gradient behind it.
- `fraction_at_objectives` criteria — `all_at_objectives` needs `p**25` at this army size and is unreachable.
- `--gamma` / `--ent-coef` PPO overrides, matching the existing `--n-steps` pattern.
- `measure_phase_gates.py` — evaluates every phase criteria against a checkpoint through the same path training uses, and sweeps the whole `min_fraction` curve in one pass.
- `run-summary` recipe for rolling-mean run inspection.
- Both gate traps documented in `docs/reward-phases.md`.

## Result

Curriculum traversal, warm-started: `approach_objectives` -> `mass_on_objectives` (epoch 5) -> `win_only_by_vp` (epoch 30) -> `win_at_the_end` (epoch 50). No prior run advanced past phase 0 in 400+ epochs.

Tuning that did **not** help, recorded so it is not retried: gamma 0.99 (success 45% -> 34%; shifted the discounted split to 59% terminal / 41% dense, and a sparse binary signal cannot replace dense shaping) and ent_coef 0.01 (entropy -1.79 -> -0.59, eval success collapsed to 2% while *raising* every training-rollout component — objectives are randomly placed, so a policy holding ~1.8 actions live overfits to seen layouts).

## Verification

- `just validate` clean; 622 tests pass, including 4 for the new calculator
- Bonus scaling verified empirically against the live config before and after
- Phase advancement confirmed by name in the training log, not just the metric index

🤖 Generated with [Claude Code](https://claude.com/claude-code)