### PR TITLE
feat: land the curriculum and per-model reward work on main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,7 @@ wargame_rl/
 | Analyse a log | `just analyze <file>` · `just analyze-compare <files...>` |
 | Inspect a Wandb run | `just run-summary <run_id> [bucket]` |
 | Measure reward-phase gates | `just measure-phase-gates <ckpt> <config.yaml> [n_episodes]` |
+| Scripted baselines (floor + bar) | `just measure-baselines <config.yaml> [n_episodes] [record]` |
 | Profile | `just profile <config.yaml> [model] [max_epochs]` |
 | Clean | `just clean` |
 
@@ -213,7 +214,9 @@ Detailed patterns live next to the code they govern — read them when working i
 - Env configs live in `examples/env_config/` — copy an existing one to create new scenarios
 - Training logs to Wandb automatically; checkpoints saved to `checkpoints/`. Reward phase index and phase advancement are logged (`reward_phase`, `phase_advanced_at_epoch`) so curriculum runs show phase transitions in the dashboard
 - **Reading run metrics:** see [docs/metrics.md](docs/metrics.md) for what each Wandb key means and the procedure for evaluating a run. Several metrics are means-of-means or change definition silently — check the reading rules there before drawing conclusions from `success_rate`, `terminal_success_bonus`, or any `reward/components/*` value
-- **Always quote a result against a baseline:** `just measure-baselines <env_config>` gives the floor (`random`) and the bar (`squad_march`, a 12-line heuristic). Training logs `eval/baseline_*` automatically. A `success_rate` with no floor and no ceiling is how a policy scoring 17% against an 80% heuristic was read as progress
+- **Always quote a result against a baseline:** `just measure-baselines <env_config> [n] record` gives the floor (`random`, 0.00) and the bar (`squad_march_shoot`, **1.00** on 25v25). Training logs `eval/baseline_*` automatically. A `success_rate` with no floor and no ceiling is how a policy scoring 17% against an 80% heuristic was read as progress. Note the bar is the *shooting* baseline: the movement-only ones cap at 0.78, which is the ceiling of a policy class the agent is not in
+- **Read the traces, not just the aggregates:** `record` also writes reference traces to `recordings/`, so `just analyze-compare <agent> <baseline>` puts them side by side. Only `vp_per_step` ranks policy quality — occupancy saturates for anything competent, and `idle_rate`, `objective_approach_rate` and `tactical_score` are structurally misleading here. See [docs/metrics.md](docs/metrics.md) § Trace metrics
+- **Training configs:** `examples/env_config/25v25_single_phase.yaml` (control) and `25v25_curriculum.yaml` (two rungs). They share a scenario and a final phase, so comparing them isolates the curriculum. Every phase must keep `vp_gain` and at least one per-model calculator — `tests/test_curriculum_configs.py` enforces both
 - **Past experiments:** [reports/](reports/README.md) records findings from previous runs, including refuted hypotheses. **Start with [the correction](reports/2026-08-04-correction-what-was-actually-broken.md)** — it retracts most pre-2026-08-04 conclusions, including the earlier claims that `gamma` 0.99 and `ent_coef` 0.01 were refuted (they were measured under a training loop that never applied the reward being tuned)
 - **Inspecting a run:** `just run-summary <run_id> [bucket]` for rolling means (single-epoch `success_rate` is an `n_episodes`-sample binomial — never read a point value); `just measure-phase-gates <ckpt> <env_config> 40` for per-phase criteria rates and the whole `min_fraction` curve
 - Key CLI options: `--record-during-training`, `--max-epochs`, `--render-mode`, `--algorithm`, `--no-wandb`, `--run-suffix`, `--wandb-group`

--- a/Justfile
+++ b/Justfile
@@ -136,8 +136,9 @@ measure-phase-gates checkpoint env_config n_episodes='30':
 
 # Scripted baseline scores for an env config -- the floor and bar for any learned policy.
 # Pass `record` as the third argument to also write reference traces to recordings/.
-measure-baselines env_config n_episodes='25' record='':
-	@uv run python -m scripts.measure_baselines {{env_config}} {{n_episodes}} {{record}}
+# Pass `seed_base` (e.g. 700000) to score on the same layouts as measure-checkpoint.
+measure-baselines env_config n_episodes='25' record='' seed_base='':
+	@uv run python -m scripts.measure_baselines {{env_config}} {{n_episodes}} "{{record}}" "{{seed_base}}"
 
 # Score a checkpoint on held-out seeds through the same code path as the baselines,
 # so the two are directly comparable. Pass `record` as the fourth argument for a trace.

--- a/Justfile
+++ b/Justfile
@@ -139,6 +139,11 @@ measure-phase-gates checkpoint env_config n_episodes='30':
 measure-baselines env_config n_episodes='25' record='':
 	@uv run python -m scripts.measure_baselines {{env_config}} {{n_episodes}} {{record}}
 
+# Score a checkpoint on held-out seeds through the same code path as the baselines,
+# so the two are directly comparable. Pass `record` as the fourth argument for a trace.
+measure-checkpoint checkpoint env_config n_episodes='30' record='':
+	@uv run python -m scripts.measure_checkpoint {{checkpoint}} {{env_config}} {{n_episodes}} {{record}}
+
 # Analyze a recorded match for training evaluation
 analyze file:
 	uv run analyze_events.py report {{file}}

--- a/Justfile
+++ b/Justfile
@@ -134,9 +134,10 @@ run-summary run_id bucket='50':
 measure-phase-gates checkpoint env_config n_episodes='30':
 	@uv run python -m scripts.measure_phase_gates {{checkpoint}} {{env_config}} {{n_episodes}}
 
-# Scripted baseline scores for an env config -- the floor and bar for any learned policy
-measure-baselines env_config n_episodes='25':
-	@uv run python -m scripts.measure_baselines {{env_config}} {{n_episodes}}
+# Scripted baseline scores for an env config -- the floor and bar for any learned policy.
+# Pass `record` as the third argument to also write reference traces to recordings/.
+measure-baselines env_config n_episodes='25' record='':
+	@uv run python -m scripts.measure_baselines {{env_config}} {{n_episodes}} {{record}}
 
 # Analyze a recorded match for training evaluation
 analyze file:

--- a/analyze_events.py
+++ b/analyze_events.py
@@ -87,6 +87,12 @@ def compare(
         ("Mean dist to obj", [f"{a.mean_distance_to_objective:.1f}" for a in analyses]),
         ("Mean group distance", [f"{a.mean_group_distance:.1f}" for a in analyses]),
         (
+            "On obj (final)",
+            [f"{a.final_fraction_at_objectives:.2f}" for a in analyses],
+        ),
+        ("On obj (peak)", [f"{a.peak_fraction_at_objectives:.2f}" for a in analyses]),
+        ("Drift ratio", [f"{a.objective_drift_ratio:.2f}" for a in analyses]),
+        (
             "Time to first obj",
             [str(a.time_to_first_objective or "never") for a in analyses],
         ),

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -117,7 +117,43 @@ the two are equal; prefer `_epoch`.
 `on_train_start` and constant thereafter. Every `success_rate` in `reports/`
 predating them was quoted with no floor and no ceiling — which is how a policy
 scoring 17% against an 80% heuristic was read as progress. Reproduce or extend
-with `just measure-baselines <env_config>`.
+with `just measure-baselines <env_config> [n] record`.
+
+**The bar is `squad_march_shoot`, not `squad_march`.** Every other baseline is
+movement-only, so their ~0.78 win rate is the ceiling of a policy class the
+agent is not in — it gets a shooting decision every other step. Measured on
+25v25 over 40 held-out episodes:
+
+| baseline | on obj | win | player VP | opp VP |
+|---|---|---|---|---|
+| random | 0.018 | 0.00 | 16.8 | 168.6 |
+| greedy_nearest | 1.000 | 0.53 | 125.9 | 117.9 |
+| split_evenly | 1.000 | 0.78 | 148.4 | 104.8 |
+| squad_march | 1.000 | 0.78 | 147.9 | 102.9 |
+| **squad_march_shoot** | **1.000** | **1.00** | **176.0** | **46.5** |
+
+## 3. Trace metrics (`just analyze`, `just analyze-compare`)
+
+Per-step metrics from recorded event logs. Aggregates hid the objective drift
+that drove the reward redesign; traces showed it immediately. **But most of
+these metrics do not rank policy quality**, which was established by running
+them over the scripted baselines above — a check worth repeating whenever one
+is added.
+
+| metric | discriminates policy quality? |
+|---|---|
+| **`vp_per_step`** | **Yes — the one that does.** 0.00 / 2.13 / 3.75 / 5.00 across the baselines, matching win rate exactly |
+| `final_fraction_at_objectives`, `peak_*`, `objective_drift_ratio` | Only against random. Every competent policy saturates at 1.00 with a drift ratio of 1.00 — the same saturation that makes `models_at_objectives` unable to rank policies |
+| `mean_group_distance` | Measures coherency, not quality. Piling the whole army on one point scores *best*, so read it as a legality check against the phase's `group_max_distance`, never as a score |
+| `target_selection_optimality` | Only defined when shooting happens — `N/A` for every movement-only policy |
+| `idle_rate` | **Ignore.** Structurally ~50%+: it counts every `Stay` regardless of phase, and half of all steps are the shooting phase where `Stay` is often the only legal action |
+| `objective_approach_rate` | **Inverted.** Falls once models *arrive* and stop approaching, so competent policies score 13–15% and random scores 24% |
+| `tactical_score` | **Ignore.** Composed from `idle_rate` and `objective_approach_rate`, so it penalises competent play — it scored random 50/100 and every scripted policy 30/100 |
+
+Two of these were fixed rather than documented: `mean_group_distance` used to be
+an all-pairs army-wide mean (so concentration read as cohesion), and
+`oscillation_rate` counted a stationary model as oscillating every step, scoring
+holding policies at ~70% against random's 5%.
 
 ### Reward components (per epoch, from training rollouts)
 

--- a/docs/reward-phases.md
+++ b/docs/reward-phases.md
@@ -86,7 +86,19 @@ reward_phases:
 | `vp_gain` | global | *(none)* | Reward = weight × ((player_vp_delta - opponent_vp_delta) / cap_per_turn). `cap_per_turn` is read from mission config (default 15), so net VP swings are normalized to turn cap scale. Use in a "Win the game" phase. |
 | `objective_flip_bonus` | global | `bonus_capture_first` (float, default 5.0), `bonus_flip_to_contested` (float, default 3.0), `bonus_contested_to_controlled` (float, default 5.0), `loss_penalty_scale` (float, default 1.0) | Symmetric control-state potential under the same OC/count rule as VP scoring. Gaining control adds value (neutral→player = `bonus_capture_first`; opponent→contested = `bonus_flip_to_contested`; contested→player = `bonus_contested_to_controlled`); losing control subtracts the mirror value × `loss_penalty_scale`. At `loss_penalty_scale=1.0` it is a pure (farming-proof) potential. Returns unweighted. |
 | `objective_coverage` | global | *(none)* | Dense reward = (number of player-controlled objectives) / (number of objectives), using the same OC/count rule as VP scoring. Paid every step, so it rewards spreading models to hold *multiple distinct* objectives rather than over-stacking one. Returns unweighted. |
-| `models_at_objectives` | global | *(none)* | Dense reward = (alive models within some objective radius) / (alive models). The step-wise counterpart of the `fraction_at_objectives` criteria — unlike `objective_coverage` it does **not** saturate once a point is controlled, so it keeps paying as more models arrive. Dead models leave both numerator and denominator. Returns unweighted. |
+| `models_at_objectives` | global | *(none)* | Dense reward = (alive models within some objective radius) / (alive models). The step-wise counterpart of the `fraction_at_objectives` criteria — unlike `objective_coverage` it does **not** saturate once a point is controlled, so it keeps paying as more models arrive. Dead models leave both numerator and denominator. Returns unweighted. **Not recommended:** every competent scripted baseline saturates it at 1.000, so it scores a 0.53-win policy and a 0.78-win policy identically. Prefer `objective_hold`. |
+| `objective_hold` | **per-model** | `player_value` (float, default 1.0), `contested_value` (float, default 0.5), `opponent_value` (float, default 0.25) | Value of the objective this model occupies, keyed on control state under the same OC/count rule as VP scoring; 0 when off every objective. The **only calculator that pays a model while it is stationary** — `closest_objective`'s progress is a potential that exhausts on arrival and is exactly 0 on shooting steps, and `group_cohesion` returns 0 inside its limit, so without this all models share an identical reward for most of an episode. Pays for *controlling* rather than standing, and supplies a gradient across `neutral → contested → player`, which `objective_coverage` and `vp_gain` are both flat across because control is a strict count comparison. |
+| `model_kills` | **per-model** | `bonus_per_kill` (float, default 2.0) | Bonus for each opponent **this model** killed this step. The per-model counterpart of `killing`: under that global term every model is paid the same whether it fired, missed, or stood still, leaving the shooting head — half the agent's decisions — with no credit path. Note the scale difference: `killing` broadcasts its bonus to all N models per kill, so its default 5.0 makes a 25-model wipe worth 125 per model. |
+| `killing` | global | `bonus_killing_opponent` (float, default 5.0) | Bonus × opponent models killed this step. **Prefer `model_kills`:** this spreads kill credit flat across the army, and at the default bonus it is easily the largest term in a phase. |
+
+### Choosing calculators
+
+Two rules, both learned by measurement rather than taste:
+
+- **Every phase needs at least one per-model calculator.** Only `closest_objective`, `closest_objective_v2`, `group_cohesion`, `objective_hold` and `model_kills` are per-model; the rest are broadcast bit-identically to every model. A phase built purely from global terms gives all models the same reward and undoes per-model credit assignment by configuration.
+- **Every phase should keep `vp_gain`.** A rung that drops the goal signal trains away from it: win rate fell 62% → 47% when a curriculum advanced into a phase that rewarded occupancy and had no VP term, while `success_rate` held at ~80%.
+
+`tests/test_curriculum_configs.py` enforces both over the shipped configs.
 
 ## Available Success Criteria
 
@@ -225,9 +237,12 @@ wargame_rl/wargame/envs/reward/
     closest_objective.py           # Closest-objective reward
     closest_objective_v2.py        # OC/count-margin closest-objective reward
     group_cohesion.py              # Group cohesion penalty
+    model_kills.py                 # Per-model credit for this model's kills
     models_at_objectives.py        # Dense fraction-of-models-on-objectives reward
     objective_coverage.py          # Dense fraction-of-objectives-controlled reward
     objective_flip_bonus.py        # Symmetric objective control-state potential
+    objective_hold.py              # Per-model control-scaled occupancy reward
+    killing.py                     # Global kill bonus (prefer model_kills)
     vp_gain.py                     # VP gain reward (global)
     registry.py                    # Type-string -> class mapping
   criteria/

--- a/examples/env_config/25v25_curriculum.yaml
+++ b/examples/env_config/25v25_curriculum.yaml
@@ -1,0 +1,174 @@
+config_name: 25v25_curriculum
+number_of_wargame_models: 25
+number_of_opponent_models: 25
+number_of_objectives: 3
+objective_radius_size: 3
+board_width: 60
+board_height: 44
+max_groups: 5
+turn_order: random
+number_of_battle_rounds: 20
+skip_phases:
+  - command
+  - charge
+  - fight
+
+deployment_zone: [0, 0, 20, 44]
+opponent_deployment_zone: [40, 0, 60, 44]
+
+opponent_policy:
+  type: scripted_advance_to_objective
+
+# Terrain blocks line-of-sight only (models can still move through it).
+# Symmetric layout: a central ruin plus mirrored mid-field and flank ruins,
+# so neither side gets a clean firing lane into the objective band.
+terrain:
+  - { footprint: [28, 19, 34, 25] } # centre
+  - { footprint: [26, 8, 32, 14] } # mid-field north
+  - { footprint: [26, 30, 32, 36] } # mid-field south
+  - { footprint: [16, 18, 22, 24] } # player-side approach
+  - { footprint: [38, 18, 44, 24] } # opponent-side approach
+  - { footprint: [30, 0, 36, 4] } # north flank
+  - { footprint: [30, 40, 36, 43] } # south flank
+
+# 5 groups of 5. `weapons` is required for shooting to resolve at all — with an
+# empty list a model cannot shoot, which also makes terrain LOS inert.
+# range 12 on a 60x44 board puts the engagement band at a scale where a ~6-cell
+# ruin actually breaks a firing lane.
+models:
+  - { group_id: 0, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 0, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 0, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 0, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 0, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 1, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 1, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 1, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 1, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 1, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 2, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 2, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 2, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 2, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 2, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 3, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 3, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 3, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 3, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 3, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 4, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 4, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 4, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 4, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 4, weapons: [{ range: 12, attacks: 1 }] }
+
+opponent_models:
+  - { group_id: 0, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 0, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 0, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 0, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 0, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 1, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 1, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 1, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 1, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 1, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 2, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 2, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 2, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 2, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 2, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 3, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 3, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 3, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 3, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 3, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 4, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 4, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 4, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 4, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 4, weapons: [{ range: 12, attacks: 1 }] }
+
+# No `objectives:` block -> the 3 objectives (number_of_objectives) are placed
+# randomly outside both deployment zones at the start of every episode.
+
+
+# ---------------------------------------------------------------------------
+# Two-rung curriculum — the ARM under test against 25v25_single_phase.yaml.
+#
+# Two rungs, not four. The previous ladder's rungs were each stack-passable,
+# redundant, or inert, and one of them measurably trained away from the goal:
+# win rate fell 62% -> 47% on advancing to a phase with no VP term.
+#
+# The rungs share a calculator set and differ only in weighting, so advancing
+# is a handover rather than a change of task. Every rung keeps vp_gain and at
+# least one per-model term. See 25v25_single_phase.yaml for why each calculator
+# is present, absent, and weighted as it is.
+# ---------------------------------------------------------------------------
+reward_phases:
+  # R0 — establish control. Shaping leads while the policy learns to arrive and
+  # hold; the goal signal is present but not yet dominant.
+  - name: establish_control
+    terminate_on_success: false
+    terminal_success_bonus: 2.0
+    reward_calculators:
+      - type: closest_objective_v2
+        weight: 1.0
+        params:
+          progress_scale: 6.0
+          fallback_to_nearest: true
+          overstack_penalty_per_extra: 0.01
+      - type: objective_hold
+        weight: 0.4
+      - type: model_kills
+        weight: 0.5
+        params: { bonus_per_kill: 2.0 }
+      - type: group_cohesion
+        weight: 0.3
+        params: { group_max_distance: 6.0, violation_penalty: -0.05 }
+      - type: vp_gain
+        weight: 1.0
+      - type: objective_coverage
+        weight: 0.4
+    # 0.40 x 285 = 114 VP. A stack on one objective caps at 19 scoring rounds
+    # x 5 VP = 95 VP = 0.3333 of the theoretical max, so this is the smallest
+    # bar a one-objective stack provably cannot clear. That bound is
+    # arithmetic, not measurement, so it survives any future policy.
+    success_criteria:
+      type: player_vp_min
+      params: { fraction_of_max: 0.40 }
+    # Measured: a 30-epoch policy clears 114 VP on 0.47 of eval episodes, and
+    # scores 112.7 +- 35.7 VP. At n_eval_episodes=30 and k=3 the gate costs
+    # ~12 epochs when the true rate equals the threshold and ~5 at +0.05, and
+    # stalls below -0.07 — so this sits just under the measured rate.
+    success_threshold: 0.40
+    min_epochs: 15
+    min_epochs_above_threshold: 3
+
+  # R1 — win. Identical to 25v25_single_phase.yaml's only phase, so the two
+  # configs converge on the same reward and differ only in how they get there.
+  - name: win
+    terminate_on_success: false
+    terminal_success_bonus: 2.0
+    reward_calculators:
+      - type: closest_objective_v2
+        weight: 1.0
+        params:
+          progress_scale: 6.0
+          fallback_to_nearest: true
+          overstack_penalty_per_extra: 0.01
+      - type: objective_hold
+        weight: 0.25
+      - type: model_kills
+        weight: 1.0
+        params: { bonus_per_kill: 2.0 }
+      - type: group_cohesion
+        weight: 0.3
+        params: { group_max_distance: 6.0, violation_penalty: -0.05 }
+      - type: vp_gain
+        weight: 2.0
+      - type: objective_coverage
+        weight: 0.3
+    success_criteria:
+      type: player_ahead_on_vp
+      params: {}

--- a/examples/env_config/25v25_single_phase.yaml
+++ b/examples/env_config/25v25_single_phase.yaml
@@ -1,0 +1,178 @@
+config_name: 25v25_single_phase
+number_of_wargame_models: 25
+number_of_opponent_models: 25
+number_of_objectives: 3
+objective_radius_size: 3
+board_width: 60
+board_height: 44
+max_groups: 5
+turn_order: random
+number_of_battle_rounds: 20
+skip_phases:
+  - command
+  - charge
+  - fight
+
+deployment_zone: [0, 0, 20, 44]
+opponent_deployment_zone: [40, 0, 60, 44]
+
+opponent_policy:
+  type: scripted_advance_to_objective
+
+# Terrain blocks line-of-sight only (models can still move through it).
+# Symmetric layout: a central ruin plus mirrored mid-field and flank ruins,
+# so neither side gets a clean firing lane into the objective band.
+terrain:
+  - { footprint: [28, 19, 34, 25] } # centre
+  - { footprint: [26, 8, 32, 14] } # mid-field north
+  - { footprint: [26, 30, 32, 36] } # mid-field south
+  - { footprint: [16, 18, 22, 24] } # player-side approach
+  - { footprint: [38, 18, 44, 24] } # opponent-side approach
+  - { footprint: [30, 0, 36, 4] } # north flank
+  - { footprint: [30, 40, 36, 43] } # south flank
+
+# 5 groups of 5. `weapons` is required for shooting to resolve at all — with an
+# empty list a model cannot shoot, which also makes terrain LOS inert.
+# range 12 on a 60x44 board puts the engagement band at a scale where a ~6-cell
+# ruin actually breaks a firing lane.
+models:
+  - { group_id: 0, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 0, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 0, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 0, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 0, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 1, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 1, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 1, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 1, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 1, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 2, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 2, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 2, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 2, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 2, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 3, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 3, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 3, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 3, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 3, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 4, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 4, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 4, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 4, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 4, weapons: [{ range: 12, attacks: 1 }] }
+
+opponent_models:
+  - { group_id: 0, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 0, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 0, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 0, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 0, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 1, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 1, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 1, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 1, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 1, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 2, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 2, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 2, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 2, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 2, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 3, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 3, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 3, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 3, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 3, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 4, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 4, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 4, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 4, weapons: [{ range: 12, attacks: 1 }] }
+  - { group_id: 4, weapons: [{ range: 12, attacks: 1 }] }
+
+# No `objectives:` block -> the 3 objectives (number_of_objectives) are placed
+# randomly outside both deployment zones at the start of every episode.
+
+
+# ---------------------------------------------------------------------------
+# Single reward phase — the CONTROL for "does the curriculum help at all?"
+#
+# That question has never been asked. The phase ladder was in place for seven
+# runs but never reached the rollout envs, so its later phases have never
+# influenced a gradient. The one time a phase boundary was measured, the effect
+# was negative: win rate fell 62% -> 47% when the curriculum advanced to a rung
+# that rewarded occupancy and contained no VP term.
+#
+# Compare this file against 25v25_curriculum.yaml on the same seeds, reading
+# eval/win_rate and eval/vp_margin against eval/baseline_* — never success_rate,
+# which changes definition across the ladder and is not comparable between the
+# two configs.
+#
+# Design rules, each traceable to a measurement:
+#   * Every phase keeps vp_gain. Nothing here trains away from the goal.
+#   * Every phase carries per-model terms. Only 3 of 8 calculators are
+#     per-model, and a phase built purely from global ones hands all 25 models
+#     a bit-identical reward, undoing per-model credit assignment by config.
+#   * No term integrates far above ~10 over an episode. The entire gap between
+#     a 0.53-win policy and a 0.78-win policy is worth ~3 reward units, so a
+#     large shaping term drowns the thing being taught.
+#   * models_at_objectives and objective_flip_bonus are deliberately absent:
+#     every competent baseline saturates the former at 1.000, making it unable
+#     to rank policies, and objective_hold covers the latter's contested-state
+#     gradient continuously rather than as a one-shot potential.
+# ---------------------------------------------------------------------------
+reward_phases:
+  - name: win
+    # Required for the terminal bonus to be delivered at full strength; with
+    # terminate_on_success true it is scaled by the remaining-turn fraction.
+    terminate_on_success: false
+    terminal_success_bonus: 2.0
+    reward_calculators:
+      # ---- per-model ----
+      # Potential-based, so policy-invariant: it can bias nothing and never
+      # needs decaying. fallback_to_nearest matters here because each objective
+      # is assigned to at most one group, and 5 groups over 3 objectives leaves
+      # two groups unassigned and unshaped without it.
+      - type: closest_objective_v2
+        weight: 1.0
+        params:
+          progress_scale: 6.0
+          fallback_to_nearest: true
+          # The anti-stack knob. Objective radius 3 holds 29 cells and models
+          # do not collide, so 25 models on one point is legal and scores 1.00
+          # on every occupancy metric.
+          overstack_penalty_per_extra: 0.01
+      # The only term that pays a model while it is stationary, and the only
+      # per-model path to the central behaviour. Scaled by control state, so it
+      # pays for holding a point rather than merely standing on one.
+      - type: objective_hold
+        weight: 0.25
+      # Credits the model that actually fired. Shooting is half the agent's
+      # decisions; under the global `killing` term every model was paid the
+      # same whether it fired, missed, or stood still.
+      - type: model_kills
+        weight: 1.0
+        params: { bonus_per_kill: 2.0 }
+      # Coherency. Limit 6.0, not 5.0: squad_march measures 3.8 as a mean of
+      # per-episode maxima. Penalty -0.05, not -0.2: at -0.2 a strung-out model
+      # loses ~26 per episode, enough to rank split_evenly (148 VP) below
+      # greedy_nearest (126 VP).
+      - type: group_cohesion
+        weight: 0.3
+        params: { group_max_distance: 6.0, violation_penalty: -0.05 }
+      # ---- global (broadcast whole to each model, not divided by 25) ----
+      # The actual objective. Largest weight because its realistic dynamic
+      # range is the smallest.
+      - type: vp_gain
+        weight: 2.0
+      # Equals player coverage, where vp_gain is player minus opponent
+      # coverage. Paid every step against vp_gain's ~19 scoring events, so this
+      # weight keeps VP dominant while giving a per-step spreading gradient.
+      - type: objective_coverage
+        weight: 0.3
+    # Final phase: success_threshold, min_epochs and min_epochs_above_threshold
+    # are never read, because try_advance returns at is_final_phase. The
+    # criteria still selects terminal-bonus eligibility and defines the logged
+    # success_rate.
+    success_criteria:
+      type: player_ahead_on_vp
+      params: {}

--- a/reports/2026-08-04-reward-calculation-changes.md
+++ b/reports/2026-08-04-reward-calculation-changes.md
@@ -1,0 +1,258 @@
+# 2026-08-04 — how the reward calculation changed
+
+**Question:** the 25v25 agent was being paid a single number for the joint behaviour of 25
+models, and most of what it was paid for did not distinguish a good policy from a mediocre
+one. What changed in the reward calculation, and what does the evidence support?
+
+**Scope.** This report covers the reward side only: `envs/reward/` and the phase blocks of
+the env configs. The PPO-side plumbing that consumes it (per-model ratios, per-model value
+head, entropy meaning) is in
+[mechanism defects](2026-08-04-mechanism-defects.md) and
+[the correction](2026-08-04-correction-what-was-actually-broken.md). **They shipped
+together**, which is the central confound — see [Confounds](#confounds).
+
+---
+
+## 1. The reward became a vector, not a scalar
+
+`RewardPhaseManager.calculate_reward` previously reduced everything to one float:
+
+```
+reward = mean_over_alive_models(per_model_terms) + sum(global_terms)
+```
+
+Averaging 25 models into one number leaves each model's action explaining roughly 4% of the
+signal it is credited with. Every model was told "the army did well" regardless of whether
+it advanced, stood still, or fired into an empty sky.
+
+The manager now also records `last_per_model_reward`, shape `(n_player_models,)`:
+
+- a **per-model** term contributes its own value to its own model
+  (`per_model_rewards[i] += contribution`)
+- a **global** term is broadcast *whole* to every alive model, not divided among them —
+  these are the part of the outcome genuinely not attributable to one model, so every model
+  should see the same signal. Dividing by N would shrink the goal term as the army grows
+- terminal bonuses (`terminal_success_bonus`, `terminal_vp_bonus`) are treated as global
+
+The scalar return value is **unchanged**, so anything reading the old number still works;
+PPO reads the vector (`ppo/lightning.py:661`, consumed at `:290`).
+
+Relative balance between terms is preserved: a per-model term contributes its own value to
+one model where it previously contributed `1/N` of the army's sum to the shared scalar, and
+a global term contributes its full value in both. An earlier claim that per-model terms
+became "25× louder" was checked against the code and is wrong.
+
+### `CurriculumPosition`
+
+Phase progress moved out of the manager into a shared `CurriculumPosition` (`index`,
+`epoch_entered`, `consecutive_epochs_above_threshold`). Each env needs its *own* calculators
+— they carry per-episode state (`closest_objective`'s previous distance,
+`objective_flip_bonus`'s potential) that one env resetting would corrupt for the others —
+but all envs must reward the phase the curriculum has actually reached. Sharing the position
+object means there is no synchronisation step for a future code path to forget, which is
+exactly how the rollout envs came to train on phase 0 for every run to date while
+`reward_phase` reported otherwise.
+
+---
+
+## 2. Two new per-model calculators
+
+The credit-assignment change was largely inert without these. Only **3 of 8** calculators
+were per-model, and both useful ones go silent once models arrive:
+
+```
+after arrival (~step 10 of 40):
+  closest_objective progress -> 0   (potential exhausted; exactly 0 on shooting steps)
+  group_cohesion             -> 0   (hard 0 inside the limit)
+  => all 25 advantages identical for ~30 of 40 steps
+```
+
+**`objective_hold`** (per-model) — value keyed on the control state of the objective the
+model occupies, reusing the existing `objective_states_from_norms_offset`, which already
+implements the OC/count rule VP scoring uses:
+
+| state of the objective the model is in | value |
+|---|---|
+| player-controlled | 1.0 |
+| contested | 0.5 |
+| opponent-held | 0.25 |
+| not on any objective | 0.0 |
+
+The only term that pays a model while stationary. It pays for *controlling* rather than
+merely standing, and supplies a continuous gradient across `neutral → contested → player` —
+the tie-break region both `objective_coverage` and `vp_gain` are flat across, since control
+is a strict count comparison.
+
+**`model_kills`** (per-model) — `bonus_per_kill × kills made by this model this step`.
+Shooting is half the agent's decisions and previously had **no credit path**: the global
+`killing` term paid every model identically whether it fired, missed, or stood still.
+Required threading attribution that already existed but was discarded —
+`StepContext.player_kills_by_model`, shape `(n_player_models,)`, populated from
+`PairedShootingResult.attacker_idx`.
+
+Measured: within-step across-model reward spread is **2.3× higher** under the new config
+(sd 0.319 vs 0.103).
+
+---
+
+## 3. A bug fixed in the global `killing` term
+
+Two defects in one four-line calculator:
+
+```python
+# before
+diff = ctx.opponent_models_killed - self._previous_opponent_models_killed
+self._previous_opponent_models_killed = ctx.opponent_models_killed
+return self.bonus_killing_opponent * diff
+```
+
+1. **It read the wrong field.** `opponent_models_killed` means "models the opponent killed"
+   — the agent's *own* losses. The `player_` prefix means "by the player", matching
+   `player_damage_dealt`. The agent was being paid for being shot.
+2. **It telescoped.** The context field is already a per-step count, so subtracting a
+   running total made the reward accumulate to the final step and go *negative* on the step
+   after any kill.
+
+Now `return self.bonus_killing_opponent * float(ctx.player_models_killed)`. This is
+arithmetic, not measurement — it holds regardless of any run.
+
+---
+
+## 4. Three terms dropped from the configs
+
+| dropped | why |
+|---|---|
+| `models_at_objectives` | **Zero discriminative power.** All three competent scripted baselines saturate it at 1.000 — the 0.57-win policy and the 0.77-win policy score identically. It is a don't-be-random detector, and it was 83% of the old phase-0 reward budget. `objective_hold` strictly dominates it |
+| `objective_flip_bonus` | Superseded by `objective_hold`'s continuous control gradient |
+| `killing` (global) | Superseded by `model_kills`. Its default bonus is **5.0** paid to *all* N models per kill, so a 25-model wipe was worth 5 × 25 = 125 per model — larger than every other term combined, against an opponent that cannot shoot back |
+
+The calculators remain registered and tested; only the configs stopped using them.
+
+---
+
+## 5. Config restructuring
+
+The old ladder had four rungs, each stack-passable, redundant, or inert (a final phase's
+`success_threshold` is never read, because `try_advance` returns at `is_final_phase`). Two
+configs replace it, sharing a scenario block and an identical final phase so that comparing
+them isolates the curriculum:
+
+**`25v25_single_phase.yaml`** — one phase, `player_ahead_on_vp`:
+
+| term | kind | weight | ≈ episode integral |
+|---|---|---|---|
+| `closest_objective_v2` | per-model | 1.0 | ≤ 8 |
+| `objective_hold` | per-model | 0.25 | +7.5 while holding |
+| `model_kills` | per-model | 1.0 (`bonus_per_kill` 2.0) | varies |
+| `group_cohesion` | per-model | 0.3 (`group_max_distance` 6.0, `violation_penalty` −0.05) | ≤ 0 |
+| `vp_gain` | global | 2.0 | ≈ +6 |
+| `objective_coverage` | global | 0.3 | ≈ +6 |
+
+Per-model episode integral ≈ 23, and no term exceeds ~8. That ceiling is deliberate: the
+whole gap between a 0.57-win policy and a 0.77-win policy is worth **~3 reward units** at
+weight 1.0, so any shaping term integrating above ~10 drowns the thing being taught.
+
+**`25v25_curriculum.yaml`** — same terms at R0 with the goal signal present but not yet
+leading (`vp_gain` 1.0, `objective_coverage` 0.4, `objective_hold` 0.4, `model_kills` 0.5),
+then an R1 identical to the single-phase config.
+
+R0's gate uses one arithmetic bound: a one-objective stack caps at 19 scoring rounds × 5 VP
+= **95 VP = 0.3333 of the 285 theoretical max**, so `player_vp_min` above 1/3 is the
+smallest bar a stack provably cannot clear. 0.40 (114 VP) sits above it. This is arithmetic,
+so it survives any future policy.
+
+Two parameter notes that are easy to get wrong: `group_cohesion` takes
+`group_max_distance` / `violation_penalty` (anything else is a `TypeError` at config load),
+and `violation_penalty` is −0.05 rather than −0.2 because at −0.2 a strung-out model eats
+−26 per episode, enough to rank `split_evenly` (145 VP) below `greedy_nearest` (132 VP).
+
+`tests/test_curriculum_configs.py` enforces that every phase in both configs keeps
+`vp_gain` and at least one per-model calculator — the config-level check for the two defects
+that produced the earlier 62% → 47% decline.
+
+---
+
+## 6. What was measured
+
+All figures from 30 held-out episodes on `25v25_single_phase.yaml`, seeds 700 000–700 029,
+agent and baselines scored by the same code on identical layouts
+(`just measure-checkpoint`, `just measure-baselines … 700000`).
+
+| policy | on obj | win | player VP | opp VP | VP margin | worst cohesion |
+|---|---|---|---|---|---|---|
+| random | 0.017 | 0.00 | 14.5 | 173.0 | −158.5 | 24.5 |
+| greedy_nearest | 1.000 | 0.57 | 132.3 | 115.2 | 17.1 | 10.3 |
+| squad_march | 1.000 | 0.67 | 138.8 | 113.3 | 25.5 | 3.8 |
+| split_evenly | 1.000 | 0.77 | 145.2 | 105.5 | 39.7 | 17.1 |
+| **agent, single-phase** | 0.852 | **0.97** | 141.8 | 52.8 | 89.0 | 12.8 |
+| **agent, ladder** | 0.887 | 0.93 | 161.7 | 59.5 | **102.2** | 14.0 |
+| squad_march_shoot | 1.000 | **1.00** | 175.5 | 46.3 | 129.2 | 3.8 |
+
+Measured, and attributable to the reward change *only under the confound below*:
+
+- **Win rate 0.17 → 0.93–0.97**, against a movement-only bar of 0.67 and a shooting bar of
+  1.00. Both agents beat every movement-only baseline decisively.
+- **`entropy/shooting` rises**, 0.11 → 0.74 and 0.13 → 0.60 across two runs. The shooting
+  head began near-deterministic and became exploratory — the signature expected from giving
+  it a credit path it did not previously have.
+- **`target_selection_optimality` 100%** in the traces: every shot at the best
+  expected-damage target.
+- **Objective drift ratio ≈ 3.0 → 1.00–1.11.** Drift was the failure that motivated the
+  whole redesign; `objective_hold` was the term added to flatten it.
+- **`entropy/movement` falls** 4.52 → 2.97–3.17 with `clip_fraction` in the healthy
+  0.15–0.17 band and `explained_variance` reaching 0.55–0.62.
+
+---
+
+## Confounds
+
+**The reward changes cannot be separated from the PPO mechanism changes.** They shipped in
+the same two branches, and four mechanism defects were fixed alongside. The 0.17 → 0.96 jump
+is the *joint* effect of per-model credit assignment, the mechanism fixes, the new
+calculators, the dropped terms and the config rewrite. Nothing here isolates the
+contribution of any one of them, and no ablation was run.
+
+What *is* independently established is narrower and does not depend on any run:
+
+- the `killing` field-name and telescoping defects (arithmetic)
+- `models_at_objectives` saturating at 1.000 for every competent baseline (measured on the
+  baselines, no learned policy involved)
+- the 95 VP = 0.3333 stack bound (arithmetic)
+
+Single seed per config for the curriculum comparison until the repeat; two seeds now.
+
+---
+
+## What the reward still gets wrong
+
+1. **Occupancy is traded away.** Both agents finish at 0.85–0.89 of models on objectives
+   where every competent baseline saturates at 1.000. They are buying kills with position.
+   Whether that is a defect depends on whether VP margin or board control is the goal —
+   they currently disagree.
+2. **Stragglers break coherency and the reward barely notices.** Per-step out-of-coherency
+   is 5.2–5.5% for the agents versus 5.5–6.1% for `squad_march`/`squad_march_shoot`, so the
+   agents are *not* systematically worse during play. The difference is at the end: the
+   baselines recover to **0.0%** out of coherency while the agents leave **3.0–3.2%** — about
+   0.8 models per episode — stranded, and the worst offender sits **12.7–13.8** from its
+   nearest squadmate against a limit of 6.0. `violation_penalty` −0.05 prices this too
+   cheaply to fix a straggler that is otherwise scoring.
+3. **Tabling the opponent truncates VP.** `is_battle_over` returns immediately on
+   `all_eliminated`, so annihilation ends scoring. A traced episode killed all 25 opponents
+   by step 26 losing nobody and finished on 85 VP, where an episode that left one enemy
+   alive ran the full 40 steps and scored 165–5. `squad_march_shoot` shows the same
+   signature (24 steps, 120 VP). No reward term accounts for this, so a policy optimising VP
+   is implicitly taught to leave one enemy alive. This is a rules decision, not obviously a
+   bug.
+4. **The opponent cannot shoot back.** Every kill-related term is measured against a
+   defenceless enemy, which flatters `model_kills` and `squad_march_shoot` alike. The 1.00
+   shooting bar says more about the opponent policy than about the agent.
+
+## What this does not establish
+
+- That the curriculum helps. Two seeds say the two-rung ladder is indistinguishable from
+  the single-phase config at 100 epochs (win 97.0/99.3 then 98.7/98.7; single ahead on VP
+  margin both times). The ladder's R0 gate does clear reliably, so the gate design is sound
+  — it simply is not buying anything yet.
+- Which individual reward term is responsible for any of the improvement.
+- That the weights are near-optimal. They were sized from the ~3-unit argument above and
+  from one round of episode-integral arithmetic, not from a sweep.

--- a/reports/2026-08-04-reward-calculation-changes.md
+++ b/reports/2026-08-04-reward-calculation-changes.md
@@ -1,5 +1,34 @@
 # 2026-08-04 — how the reward calculation changed
 
+## TL;DR
+
+Imagine coaching 25 players but only ever shouting one score at the whole team. Nobody
+learns what *they* did right. That was the reward: 25 models, one number, averaged.
+
+Five things changed:
+
+1. **Everyone gets their own score now.** Each model is paid for what it did; team-wide
+   things (like winning) are still shouted to everyone equally.
+2. **Added "hold the point you're standing on."** Every other reward went quiet once
+   models stopped moving, so for most of the game all 25 got identical scores again.
+3. **Added "you personally shot someone."** Shooting is half the decisions and previously
+   paid every model the same whether it fired, missed, or napped.
+4. **Deleted rewards everyone already maxed out.** "Models on objectives" scored a perfect
+   1.000 for good *and* mediocre policies, so it taught nothing — and it was 83% of the
+   early reward.
+5. **Fixed a genuine bug: the agent was paid when its own models died.** The code read
+   "models killed by the opponent" where it meant "killed by us", and double-counted on top.
+
+**Result:** win rate went from 17% to 93–97%, against a hand-written baseline that scores
+67%. **But** these changes shipped together with a batch of PPO fixes, so we cannot say
+which one earned it.
+
+**Still wrong:** the agent leaves ~1 model per episode stranded away from its squad, gives
+up some ground to chase kills, and — oddly — wiping out the enemy *ends the game early and
+costs it points*.
+
+---
+
 **Question:** the 25v25 agent was being paid a single number for the joint behaviour of 25
 models, and most of what it was paid for did not distinguish a good policy from a mediocre
 one. What changed in the reward calculation, and what does the evidence support?

--- a/reports/README.md
+++ b/reports/README.md
@@ -11,6 +11,7 @@ was asked, what was measured, and what the measurement does and does not support
 | [2026-08-04 — reward-phase curriculum](2026-08-04-reward-phase-curriculum.md) | Why does the 25v25 curriculum never leave phase 0, and can it reach `win_at_the_end`? | ⚠️ Substantially retracted — training reward never left phase 0, so no cross-run conclusion holds |
 | [2026-08-04 — mechanism defects](2026-08-04-mechanism-defects.md) | Detailed evidence for each defect found | D1/D2/D4 survive (arithmetic); D3/D5's numbers measured a near-random policy |
 | [2026-08-04 — objective drift](2026-08-04-objective-drift.md) | What does the agent actually do during an episode? | Drift is real; ⚠️ its explanation is superseded — a uniform policy produces the same trace |
+| [2026-08-04 — reward calculation changes](2026-08-04-reward-calculation-changes.md) | What changed in the reward, and what does the evidence support? | Reward became per-model; two calculators added, three dropped, one arithmetic bug fixed. Win 0.17 → 0.93–0.97 vs a 0.67 movement bar — but **confounded** with the PPO fixes that shipped alongside |
 
 ## Conventions
 

--- a/scripts/measure_baselines.py
+++ b/scripts/measure_baselines.py
@@ -19,7 +19,15 @@ from wargame_rl.wargame.envs.types.config import WargameEnvConfig
 from wargame_rl.wargame.model.common.factory import create_environment
 
 # Ordered weakest to strongest so the printed table reads as a scale.
-BASELINES = ("random", "greedy_nearest", "split_evenly", "squad_march")
+# `squad_march_shoot` is the only one that fires, and therefore the only bar
+# set by the policy class the learned agent is actually in.
+BASELINES = (
+    "random",
+    "greedy_nearest",
+    "split_evenly",
+    "squad_march",
+    "squad_march_shoot",
+)
 
 # Held out from the training seed space so baselines stay a genuine reference.
 EVAL_SEED_BASE = 10_000

--- a/scripts/measure_baselines.py
+++ b/scripts/measure_baselines.py
@@ -4,16 +4,24 @@ Gives learned-policy numbers a floor and a reference bar. `squad_march` is the
 bar to beat; the spread between the baselines says *what kind* of mistake a
 policy is making rather than only that it is losing.
 
-Usage: just measure-baselines <env_config> [n_episodes]
+Pass `record` as a third argument to also write one event log per baseline to
+`recordings/`, giving `just analyze-compare` a reference trace to put beside an
+agent's.
+
+Usage: just measure-baselines <env_config> [n_episodes] [record]
 """
 
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 
 from pydantic_yaml import parse_yaml_raw_as
 
-from wargame_rl.wargame.envs.baseline.evaluate import evaluate_baseline
+from wargame_rl.wargame.envs.baseline.evaluate import (
+    evaluate_baseline,
+    record_baseline_episode,
+)
 from wargame_rl.wargame.envs.baseline.registry import build_baseline_policy
 from wargame_rl.wargame.envs.types.config import WargameEnvConfig
 from wargame_rl.wargame.model.common.factory import create_environment
@@ -41,6 +49,7 @@ def main() -> None:
 
     config_path = sys.argv[1]
     n_episodes = int(sys.argv[2]) if len(sys.argv) > 2 else 25
+    record = len(sys.argv) > 3 and sys.argv[3].lower() in {"record", "true", "1"}
 
     with open(config_path) as handle:
         env_config = parse_yaml_raw_as(WargameEnvConfig, handle.read())
@@ -49,21 +58,37 @@ def main() -> None:
     seeds = [EVAL_SEED_BASE + i for i in range(n_episodes)]
 
     print(f"\n{config_path}  ({n_episodes} episodes, seeds {seeds[0]}-{seeds[-1]})\n")
-    header = f"{'baseline':<16}{'on_obj':>9}{'win':>8}{'player_vp':>11}"
+    header = f"{'baseline':<18}{'on_obj':>9}{'win':>8}{'player_vp':>11}"
     print(f"{header}{'opp_vp':>9}{'cohesion_gap':>14}")
-    print("-" * 67)
+    print("-" * 69)
 
+    recorded: list[Path] = []
     for name in BASELINES:
         policy = build_baseline_policy(name)
         result = evaluate_baseline(policy, env, seeds)
         print(
-            f"{name:<16}"
+            f"{name:<18}"
             f"{result.final_fraction_at_objectives:>9.3f}"
             f"{result.win_rate:>8.2f}"
             f"{result.player_vp:>11.1f}"
             f"{result.opponent_vp:>9.1f}"
             f"{result.worst_cohesion_gap:>14.1f}"
         )
+        if record:
+            recorded.append(
+                record_baseline_episode(
+                    build_baseline_policy(name),
+                    env_config,
+                    seeds[0],
+                    Path("recordings") / f"baseline_{name}.jsonl",
+                )
+            )
+
+    if recorded:
+        print("\nreference traces:")
+        for path in recorded:
+            print(f"  {path}")
+        print(f"\n  just analyze-compare {' '.join(str(p) for p in recorded)}")
     print()
 
 

--- a/scripts/measure_baselines.py
+++ b/scripts/measure_baselines.py
@@ -50,12 +50,20 @@ def main() -> None:
     config_path = sys.argv[1]
     n_episodes = int(sys.argv[2]) if len(sys.argv) > 2 else 25
     record = len(sys.argv) > 3 and sys.argv[3].lower() in {"record", "true", "1"}
+    # Pass the checkpoint script's base to put an agent and the baselines on
+    # identical layouts; objective placement dominates episode variance, so an
+    # unpaired comparison spends several VP of it on which maps each drew.
+    # Empty means "not given" — the recipe passes every optional argument
+    # through, so an omitted one arrives as "" rather than being absent.
+    seed_base = (
+        int(sys.argv[4]) if len(sys.argv) > 4 and sys.argv[4] else EVAL_SEED_BASE
+    )
 
     with open(config_path) as handle:
         env_config = parse_yaml_raw_as(WargameEnvConfig, handle.read())
 
     env = create_environment(env_config=env_config)
-    seeds = [EVAL_SEED_BASE + i for i in range(n_episodes)]
+    seeds = [seed_base + i for i in range(n_episodes)]
 
     print(f"\n{config_path}  ({n_episodes} episodes, seeds {seeds[0]}-{seeds[-1]})\n")
     header = f"{'baseline':<18}{'on_obj':>9}{'win':>8}{'player_vp':>11}"

--- a/scripts/measure_checkpoint.py
+++ b/scripts/measure_checkpoint.py
@@ -1,0 +1,133 @@
+"""Score a trained checkpoint on held-out seeds, next to the scripted baselines.
+
+A `success_rate` from a training log is not comparable across configs — it
+changes definition with the reward phase, and it is a per-epoch binomial over
+`n_eval_episodes`. This runs a checkpoint through the *same* code path as
+`measure-baselines`, on the same kind of fixed seed set, so a learned policy and
+`squad_march_shoot` land in one table on identical layouts.
+
+Pass `record` as a fourth argument to also write an event log to `recordings/`,
+which `just analyze-compare <agent> <baseline>` reads.
+
+Usage: just measure-checkpoint <checkpoint> <env_config> [n_episodes] [record]
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import torch
+from pydantic_yaml import parse_yaml_raw_as
+
+from wargame_rl.wargame.envs.baseline.evaluate import (
+    ActionSelector,
+    BaselineResult,
+    evaluate_selector,
+    record_episode,
+)
+from wargame_rl.wargame.envs.types import (
+    WargameEnvAction,
+    WargameEnvConfig,
+    WargameEnvObservation,
+)
+from wargame_rl.wargame.envs.wargame import WargameEnv
+from wargame_rl.wargame.model.common.factory import create_environment
+from wargame_rl.wargame.model.common.observation import observation_to_tensor
+from wargame_rl.wargame.model.net import TransformerNetwork
+
+# Disjoint from ROLLOUT_SEED_BASE (0), the training eval base (500_000) and the
+# baseline base (10_000), so a checkpoint is scored on layouts it never trained
+# or model-selected on.
+HELDOUT_SEED_BASE = 700_000
+
+
+def build_selector(
+    checkpoint_path: str, env: WargameEnv
+) -> tuple[ActionSelector, TransformerNetwork]:
+    """Load a policy network and wrap it as an `ActionSelector`.
+
+    Greedy (argmax) rather than sampled: this measures the policy the agent
+    would play, not the exploration distribution around it. The network applies
+    the action mask internally, so illegal actions cannot be selected.
+    """
+    policy_net = TransformerNetwork.from_checkpoint(env, checkpoint_path)
+    policy_net.eval()
+
+    def select(
+        observation: WargameEnvObservation, env_: WargameEnv
+    ) -> WargameEnvAction:
+        with torch.no_grad():
+            state = observation_to_tensor(observation, policy_net.device)
+            logits = policy_net(state)
+            actions = logits.argmax(dim=-1)
+        return WargameEnvAction(actions=[int(a) for a in actions.flatten().tolist()])
+
+    return select, policy_net
+
+
+def label_for(checkpoint_path: str) -> str:
+    """Name a run by its `--run-suffix`, falling back to the directory name.
+
+    Checkpoint directories are `<scenario>-<YYYY-MM-DD-HH-MM-SS>[-<suffix>]`, and
+    the scenario part is identical across the arms of a screen — so the suffix
+    is the only part that identifies which arm a row belongs to.
+    """
+    directory = Path(checkpoint_path).parent.name
+    match = re.search(r"\d{4}(?:-\d{2}){5}-(.+)$", directory)
+    return match.group(1) if match else directory
+
+
+def format_result(result: BaselineResult) -> str:
+    """One aligned row: the fields that rank policies, in one line."""
+    return (
+        f"{result.name:<28}{result.final_fraction_at_objectives:>10.3f}"
+        f"{result.win_rate:>9.2f}{result.player_vp:>12.1f}"
+        f"{result.opponent_vp:>10.1f}{result.vp_margin:>11.1f}"
+        f"{result.worst_cohesion_gap:>11.1f}"
+    )
+
+
+def main() -> None:
+    """Score one checkpoint and print its row of the baseline table."""
+    if len(sys.argv) < 3:
+        print(__doc__)
+        raise SystemExit(1)
+
+    checkpoint_path = sys.argv[1]
+    config_path = sys.argv[2]
+    n_episodes = int(sys.argv[3]) if len(sys.argv) > 3 else 30
+    record = len(sys.argv) > 4 and sys.argv[4].lower() in {"record", "true", "1"}
+
+    with open(config_path) as handle:
+        env_config = parse_yaml_raw_as(WargameEnvConfig, handle.read())
+    env_config.render_mode = None
+
+    env = create_environment(env_config=env_config)
+    select, _policy_net = build_selector(checkpoint_path, env)
+    seeds = [HELDOUT_SEED_BASE + i for i in range(n_episodes)]
+
+    name = label_for(checkpoint_path)
+    print(f"\n{checkpoint_path}")
+    print(f"{config_path}  ({n_episodes} episodes, seeds {seeds[0]}-{seeds[-1]})\n")
+    header = (
+        f"{'policy':<28}{'on obj':>10}{'win':>9}{'player VP':>12}"
+        f"{'opp VP':>10}{'VP margin':>11}{'cohesion':>11}"
+    )
+    print(header)
+    print("-" * len(header))
+
+    result = evaluate_selector(select, env, seeds, name)
+    print(format_result(result))
+
+    if record:
+        output = Path("recordings") / f"agent_{name}.jsonl"
+        written = record_episode(select, env_config, seeds[0], output)
+        print(f"\nwrote {written}")
+
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_baselines.py
+++ b/tests/test_baselines.py
@@ -2,18 +2,32 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import numpy as np
 import pytest
+import torch
 
-from wargame_rl.wargame.envs.baseline.evaluate import evaluate_baseline
+from wargame_rl.wargame.envs.baseline.evaluate import (
+    evaluate_baseline,
+    evaluate_selector,
+    record_episode,
+    selector_for,
+)
 from wargame_rl.wargame.envs.baseline.registry import (
     build_baseline_policy,
     get_registry,
 )
 from wargame_rl.wargame.envs.domain.entities import alive_mask_for
 from wargame_rl.wargame.envs.env_components.distance_cache import compute_distances
-from wargame_rl.wargame.envs.types import WargameEnvConfig
+from wargame_rl.wargame.envs.types import (
+    WargameEnvAction,
+    WargameEnvConfig,
+    WargameEnvObservation,
+)
 from wargame_rl.wargame.envs.wargame import WargameEnv
+from wargame_rl.wargame.model.common.observation import observation_to_tensor
+from wargame_rl.wargame.model.net import TransformerNetwork
 
 BASELINE_NAMES = ("random", "greedy_nearest", "split_evenly", "squad_march")
 
@@ -120,3 +134,53 @@ def test_evaluate_baseline_is_deterministic_for_a_seed_set() -> None:
     first = evaluate_baseline(build_baseline_policy("squad_march"), env, seeds)
     second = evaluate_baseline(build_baseline_policy("squad_march"), env, seeds)
     assert first == second
+
+
+def test_a_learned_policy_scores_through_the_same_path_as_a_baseline() -> None:
+    """A network-driven selector is scored by the identical code as a baseline.
+
+    This is what makes "agent 0.95 vs squad_march_shoot 1.00" a comparison
+    rather than two numbers from two loops that can drift apart. Uses an
+    untrained network — the point is the plumbing, not the score.
+    """
+    env = _make_env()
+    policy_net = TransformerNetwork.policy_from_env(env)
+    policy_net.eval()
+
+    def select(
+        observation: WargameEnvObservation, _env: WargameEnv
+    ) -> WargameEnvAction:
+        with torch.no_grad():
+            logits = policy_net(observation_to_tensor(observation, policy_net.device))
+        actions = logits.argmax(dim=-1).flatten().tolist()
+        return WargameEnvAction(actions=[int(a) for a in actions])
+
+    result = evaluate_selector(select, env, [0, 1], name="untrained")
+
+    assert result.name == "untrained"
+    assert result.n_episodes == 2
+    assert 0.0 <= result.final_fraction_at_objectives <= 1.0
+    assert result.vp_margin == result.player_vp - result.opponent_vp
+
+
+def test_recorded_episode_is_written_for_a_selector(tmp_path: Path) -> None:
+    """`record_episode` accepts any selector, so agent traces are comparable.
+
+    The reference traces `just analyze-compare` reads are only meaningful if the
+    agent's trace is produced by the same recorder as the baseline's.
+    """
+    env_config = WargameEnvConfig(
+        render_mode=None,
+        number_of_wargame_models=4,
+        number_of_objectives=2,
+        number_of_battle_rounds=4,
+    )
+    policy = build_baseline_policy("squad_march")
+    output = tmp_path / "trace.jsonl"
+
+    written = record_episode(
+        selector_for(policy), env_config, seed=3, output_path=output
+    )
+
+    assert written.exists()
+    assert written.stat().st_size > 0

--- a/tests/test_batched_eval.py
+++ b/tests/test_batched_eval.py
@@ -1,0 +1,120 @@
+"""Tests for lockstep batched evaluation.
+
+Evaluation used to run every episode sequentially through a single env. Because
+`terminate_on_success: false` makes every episode exactly `max_turns` steps,
+episodes can run lockstep across several envs with one batched forward pass —
+measured 2.5x faster on the 25v25 config, ~21% of an epoch.
+
+The property that matters is that batching changes only the speed.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from wargame_rl.wargame.envs.types import WargameEnvAction, WargameEnvConfig
+from wargame_rl.wargame.envs.wargame import WargameEnv
+from wargame_rl.wargame.model.common.lightning_base import EVAL_SEED_BASE
+from wargame_rl.wargame.model.common.observation import observation_to_tensor
+from wargame_rl.wargame.model.ppo.lightning import PPOLightning
+from wargame_rl.wargame.model.ppo.ppo import PPO_Transformer
+
+N_EPISODES = 4
+
+
+def _make_module() -> PPOLightning:
+    env = WargameEnv(
+        config=WargameEnvConfig(
+            render_mode=None,
+            number_of_wargame_models=3,
+            number_of_objectives=2,
+            number_of_battle_rounds=4,
+        )
+    )
+    return PPOLightning(
+        env=env,
+        ppo_model=PPO_Transformer.from_env(env),
+        log=False,
+        n_steps=8,
+        batch_size=4,
+        n_epochs=1,
+        num_rollout_envs=2,
+    )
+
+
+def test_batched_evaluation_matches_sequential() -> None:
+    """Batching the forward pass changes throughput, not results.
+
+    Runs the same greedy policy over the same seeds one env at a time, and
+    asserts the batched path produces identical VP and step counts.
+    """
+    module = _make_module()
+    module._set_policy_mode(True)
+    seeds = [EVAL_SEED_BASE + i for i in range(N_EPISODES)]
+
+    with torch.no_grad():
+        batched = module._run_episodes_batched(N_EPISODES, seeds)
+    assert batched is not None
+    _rewards, steps, _successes, player_vps, opponent_vps = batched
+
+    env = module.env
+    sequential_vps: list[float] = []
+    sequential_steps: list[int] = []
+    with torch.no_grad():
+        for seed in seeds:
+            observation, _ = env.reset(seed=seed)
+            terminated = truncated = False
+            count = 0
+            while not (terminated or truncated):
+                actions = module._batch_greedy_actions(
+                    observation_to_tensor(observation, module._policy_model_device())
+                )
+                action = WargameEnvAction(actions=[int(a) for a in actions[0].tolist()])
+                observation, _r, terminated, truncated, _info = env.step(action)
+                count += 1
+            sequential_vps.append(float(env.player_vp))
+            sequential_steps.append(count)
+
+    assert player_vps == pytest.approx(sequential_vps)
+    assert steps == sequential_steps
+    assert len(opponent_vps) == N_EPISODES
+
+
+def test_evaluation_uses_fixed_seeds_across_calls() -> None:
+    """Two evaluations of an unchanged policy give identical numbers.
+
+    Objective placement dominates episode variance, so resampling layouts each
+    epoch would make a training curve mostly a record of which maps were drawn.
+    Fixed seeds make epoch-to-epoch movement attributable to the policy.
+    """
+    module = _make_module()
+    module._set_policy_mode(True)
+    seeds = [EVAL_SEED_BASE + i for i in range(N_EPISODES)]
+
+    with torch.no_grad():
+        first = module._run_episodes_batched(N_EPISODES, seeds)
+        second = module._run_episodes_batched(N_EPISODES, seeds)
+
+    assert first is not None and second is not None
+    assert first == second
+
+
+def test_eval_envs_share_the_curriculum_position() -> None:
+    """Evaluation scores the phase the curriculum has actually reached."""
+    module = _make_module()
+    envs = module._ensure_eval_envs(2)
+
+    assert envs
+    for env in envs:
+        assert env.phase_manager.position is module.env.phase_manager.position
+
+
+def test_eval_envs_are_built_once_and_reused() -> None:
+    """Eval envs persist across evaluations rather than being rebuilt."""
+    module = _make_module()
+
+    first = module._ensure_eval_envs(2)
+    second = module._ensure_eval_envs(2)
+
+    assert first[0] is second[0]

--- a/tests/test_batched_eval.py
+++ b/tests/test_batched_eval.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import pytest
 import torch
 
+from wargame_rl.wargame.envs.state import EventLogExporter
 from wargame_rl.wargame.envs.types import WargameEnvAction, WargameEnvConfig
 from wargame_rl.wargame.envs.wargame import WargameEnv
 from wargame_rl.wargame.model.common.lightning_base import EVAL_SEED_BASE
@@ -118,3 +119,46 @@ def test_eval_envs_are_built_once_and_reused() -> None:
     second = module._ensure_eval_envs(2)
 
     assert first[0] is second[0]
+
+
+def test_evaluation_still_records_event_logs() -> None:
+    """`--record-events` keeps working once evaluation runs on its own envs.
+
+    The exporter is attached to the training env, which batched evaluation no
+    longer steps. Without forwarding it, a run set to record silently produces
+    an empty log — the same failure that left five earlier runs with
+    `--record-events` set and nothing on disk.
+
+    Only env 0 records; recording every env would interleave concurrent
+    episodes into a single log.
+    """
+    env = WargameEnv(
+        config=WargameEnvConfig(
+            render_mode=None,
+            number_of_wargame_models=3,
+            number_of_objectives=2,
+            number_of_battle_rounds=4,
+        ),
+        state_exporters=[EventLogExporter(anchor_interval=10)],
+    )
+    module = PPOLightning(
+        env=env,
+        ppo_model=PPO_Transformer.from_env(env),
+        log=False,
+        n_steps=8,
+        batch_size=4,
+        n_epochs=1,
+        num_rollout_envs=2,
+    )
+    module._set_policy_mode(True)
+
+    with torch.no_grad():
+        module._run_episodes_batched(2, [EVAL_SEED_BASE, EVAL_SEED_BASE + 1])
+
+    exporter = env.state_exporters[0]
+    assert isinstance(exporter, EventLogExporter)
+    assert len(exporter.log) > 1, "evaluation recorded no steps"
+
+    eval_envs = module._eval_envs or []
+    assert eval_envs[0].state_exporters
+    assert not eval_envs[1].state_exporters

--- a/tests/test_curriculum_configs.py
+++ b/tests/test_curriculum_configs.py
@@ -1,0 +1,154 @@
+"""Config-level checks for the two 25v25 training configs.
+
+These encode the design rules that came out of the diagnostic, as assertions
+rather than comments. The failure they guard against is concrete: win rate fell
+62% -> 47% when the curriculum advanced to a phase that rewarded occupancy and
+carried no VP term, while `success_rate` held at ~80%.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic_yaml import parse_yaml_raw_as
+
+from wargame_rl.wargame.envs.reward.phase_manager import RewardPhaseManager
+from wargame_rl.wargame.envs.types.config import WargameEnvConfig
+
+CONFIG_PATHS = [
+    Path("examples/env_config/25v25_single_phase.yaml"),
+    Path("examples/env_config/25v25_curriculum.yaml"),
+]
+
+# A one-objective stack caps at 19 scoring rounds x 5 VP = 95 of a 285
+# theoretical max. Any VP gate at or below this is passable without ever
+# contesting a second objective.
+ONE_OBJECTIVE_STACK_FRACTION = 95 / 285
+
+
+def _load(path: Path) -> WargameEnvConfig:
+    config: WargameEnvConfig = parse_yaml_raw_as(WargameEnvConfig, path.read_text())
+    return config
+
+
+@pytest.fixture(params=CONFIG_PATHS, ids=lambda p: p.stem)
+def config(request: pytest.FixtureRequest) -> WargameEnvConfig:
+    path: Path = request.param
+    return _load(path)
+
+
+def test_config_loads_and_builds_its_phases(config: WargameEnvConfig) -> None:
+    """Every calculator name and parameter is valid.
+
+    `build_calculator` passes params straight to the constructor, so a
+    misspelled parameter is a TypeError at load rather than a silent default.
+    """
+    manager = RewardPhaseManager.from_configs(config.reward_phases)
+
+    assert manager.phases
+
+
+def test_every_phase_keeps_the_goal_signal(config: WargameEnvConfig) -> None:
+    """No rung trains away from winning.
+
+    This is the rule the old ladder broke: its `mass_on_objectives` phase
+    rewarded occupancy and dropped VP entirely.
+    """
+    for phase in config.reward_phases:
+        types = {c.type for c in phase.reward_calculators}
+        assert "vp_gain" in types, f"phase '{phase.name}' has no VP signal"
+
+
+def test_every_phase_carries_per_model_credit(config: WargameEnvConfig) -> None:
+    """Each phase has at least one per-model calculator.
+
+    Only 3 of 8 calculators are per-model; the rest are broadcast identically
+    to all 25 models. A phase built purely from global terms hands every model
+    the same reward, undoing per-model credit assignment by configuration.
+    """
+    manager = RewardPhaseManager.from_configs(config.reward_phases)
+
+    for phase in manager.phases:
+        assert phase.per_model_calculators, (
+            f"phase '{phase.name}' is entirely global, so all models share "
+            "one reward and the advantage cannot differentiate them"
+        )
+
+
+def test_no_phase_relies_on_a_saturating_occupancy_term(
+    config: WargameEnvConfig,
+) -> None:
+    """`models_at_objectives` cannot rank policies and is excluded.
+
+    Every competent scripted baseline saturates it at 1.000, so it scores a
+    0.53-win policy and a 0.78-win policy identically.
+    """
+    for phase in config.reward_phases:
+        types = {c.type for c in phase.reward_calculators}
+        assert "models_at_objectives" not in types
+
+
+def test_vp_gates_are_above_the_one_objective_stack_ceiling(
+    config: WargameEnvConfig,
+) -> None:
+    """A VP gate must require contesting more than one objective.
+
+    Objective discs hold 29 cells and models do not collide, so parking the
+    whole army on one point is legal and saturates every occupancy metric.
+    """
+    for phase in config.reward_phases:
+        if phase.success_criteria.type != "player_vp_min":
+            continue
+        fraction = phase.success_criteria.params["fraction_of_max"]
+        assert fraction > ONE_OBJECTIVE_STACK_FRACTION, (
+            f"phase '{phase.name}' gate of {fraction} is clearable by a stack "
+            f"on one objective ({ONE_OBJECTIVE_STACK_FRACTION:.4f})"
+        )
+
+
+def test_terminal_bonus_is_delivered_at_full_strength(
+    config: WargameEnvConfig,
+) -> None:
+    """`terminate_on_success` must stay false wherever a terminal bonus is set.
+
+    With it true the bonus is scaled by the remaining-turn fraction, which
+    collapses to 1/max_turns when episodes run to the limit.
+    """
+    for phase in config.reward_phases:
+        if phase.terminal_success_bonus != 0.0:
+            assert not phase.terminate_on_success, phase.name
+
+
+def test_group_cohesion_parameters_are_named_correctly(
+    config: WargameEnvConfig,
+) -> None:
+    """Guards a config-only failure mode: params go straight to the constructor.
+
+    `max_dist` or `penalty` would raise at load; a silently wrong name cannot
+    happen, but pinning the expected keys documents them.
+    """
+    for phase in config.reward_phases:
+        for calculator in phase.reward_calculators:
+            if calculator.type != "group_cohesion":
+                continue
+            assert set(calculator.params) <= {
+                "group_max_distance",
+                "violation_penalty",
+            }
+
+
+def test_the_two_configs_share_a_final_phase() -> None:
+    """The control and the ladder converge on the same reward.
+
+    They must differ only in how the policy gets there, or a comparison
+    between them measures two things at once.
+    """
+    single, curriculum = (_load(path) for path in CONFIG_PATHS)
+
+    assert single.reward_phases[-1].reward_calculators == (
+        curriculum.reward_phases[-1].reward_calculators
+    )
+    assert single.reward_phases[-1].success_criteria == (
+        curriculum.reward_phases[-1].success_criteria
+    )

--- a/tests/test_new_per_model_calculators.py
+++ b/tests/test_new_per_model_calculators.py
@@ -1,0 +1,273 @@
+"""Tests for the two per-model calculators added for credit assignment.
+
+Only 3 of 8 existing calculators were per-model, and both of the useful ones go
+silent once models arrive — `closest_objective`'s progress is a potential that
+exhausts on arrival and is exactly 0 on shooting steps, and `group_cohesion`
+returns a hard 0 inside its limit. So all 25 models shared an identical reward
+for most of an episode, which defeats per-model credit assignment.
+
+`objective_hold` fires while stationary; `model_kills` gives the shooting head
+a credit path it did not have.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from wargame_rl.wargame.envs.env_components.distance_cache import compute_distances
+from wargame_rl.wargame.envs.reward.calculators.model_kills import ModelKillsCalculator
+from wargame_rl.wargame.envs.reward.calculators.objective_hold import (
+    ObjectiveHoldCalculator,
+)
+from wargame_rl.wargame.envs.reward.calculators.registry import build_calculator
+from wargame_rl.wargame.envs.reward.step_context import StepContext
+from wargame_rl.wargame.envs.types import (
+    ModelConfig,
+    ObjectiveConfig,
+    OpponentPolicyConfig,
+    WargameEnvAction,
+    WargameEnvConfig,
+)
+from wargame_rl.wargame.envs.types.config import WeaponProfile
+from wargame_rl.wargame.envs.types.game_timing import BattlePhase
+from wargame_rl.wargame.envs.wargame import WargameEnv
+
+OBJECTIVE = (20, 20)
+
+
+def _make_env(n_player_on_objective: int, n_opponent_on_objective: int) -> WargameEnv:
+    """Env with a controllable number of models standing on one objective.
+
+    Models not on the objective are parked far away in their own corner.
+    """
+    player = [
+        ModelConfig(x=OBJECTIVE[0], y=OBJECTIVE[1], group_id=0)
+        for _ in range(n_player_on_objective)
+    ] + [ModelConfig(x=2, y=2, group_id=0)]
+    opponent = [
+        ModelConfig(x=OBJECTIVE[0], y=OBJECTIVE[1], group_id=0)
+        for _ in range(n_opponent_on_objective)
+    ] + [ModelConfig(x=38, y=38, group_id=0)]
+
+    config = WargameEnvConfig(
+        render_mode=None,
+        board_width=40,
+        board_height=40,
+        number_of_wargame_models=len(player),
+        number_of_opponent_models=len(opponent),
+        number_of_objectives=1,
+        objective_radius_size=2,
+        number_of_battle_rounds=4,
+        models=player,
+        opponent_models=opponent,
+        objectives=[ObjectiveConfig(x=OBJECTIVE[0], y=OBJECTIVE[1])],
+        opponent_policy=OpponentPolicyConfig(type="scripted_advance_to_objective"),
+    )
+    env = WargameEnv(config=config)
+    env.reset(seed=0)
+    return env
+
+
+def _context(env: WargameEnv, **kwargs: object) -> StepContext:
+    return StepContext(
+        distance_cache=compute_distances(env.wargame_models, env.objectives),
+        current_turn=1,
+        max_turns=env.max_turns,
+        board_width=env.board_width,
+        board_height=env.board_height,
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+# --------------------------------------------------------------------------
+# objective_hold
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("n_player", "n_opponent", "expected"),
+    [
+        (3, 1, 1.0),  # player-controlled: strictly more models
+        (2, 2, 0.5),  # contested: equal counts, nobody scores
+        (1, 3, 0.25),  # opponent-held
+    ],
+)
+def test_value_scales_with_control_state(
+    n_player: int, n_opponent: int, expected: float
+) -> None:
+    """A model on an objective is paid by who controls it, not merely by standing.
+
+    This is what makes it dominate `models_at_objectives`, which every
+    competent baseline saturates at 1.0 and so cannot rank policies.
+    """
+    env = _make_env(n_player, n_opponent)
+    calculator = ObjectiveHoldCalculator()
+
+    value = calculator.calculate(0, env.wargame_models[0], env, _context(env))
+
+    assert value == pytest.approx(expected)
+
+
+def test_model_off_the_objective_scores_nothing() -> None:
+    """Only models actually standing on an objective are paid."""
+    env = _make_env(3, 1)
+    calculator = ObjectiveHoldCalculator()
+    off_objective_index = len(env.wargame_models) - 1
+
+    value = calculator.calculate(
+        off_objective_index, env.wargame_models[off_objective_index], env, _context(env)
+    )
+
+    assert value == pytest.approx(0.0)
+
+
+def test_values_differ_across_models_in_the_same_step() -> None:
+    """The whole point: the reward vector is not constant across models."""
+    env = _make_env(3, 1)
+    calculator = ObjectiveHoldCalculator()
+    ctx = _context(env)
+
+    values = [
+        calculator.calculate(i, model, env, ctx)
+        for i, model in enumerate(env.wargame_models)
+    ]
+
+    assert len(set(values)) > 1
+
+
+def test_control_state_is_computed_once_per_step() -> None:
+    """The opponent cache is built once a step, not once per model.
+
+    `calculate` runs per model and deriving control needs opponent distances,
+    so without caching a 25-model army would rebuild it 25 times a step.
+    """
+    env = _make_env(3, 1)
+    calculator = ObjectiveHoldCalculator()
+    ctx = _context(env)
+
+    calculator.calculate(0, env.wargame_models[0], env, ctx)
+    cached = calculator._cached_values
+    calculator.calculate(1, env.wargame_models[1], env, ctx)
+
+    assert calculator._cached_values is cached
+
+
+# --------------------------------------------------------------------------
+# model_kills
+# --------------------------------------------------------------------------
+
+
+def test_kills_are_credited_to_the_model_that_made_them() -> None:
+    """A model that killed twice scores twice; one that fired and missed scores 0.
+
+    Under the global `killing` calculator every model receives the same value
+    regardless of who shot, so this is the assertion that fails today.
+    """
+    env = _make_env(3, 1)
+    calculator = ModelKillsCalculator(bonus_per_kill=2.0)
+    kills = np.zeros(len(env.wargame_models), dtype=np.int64)
+    kills[0] = 2
+
+    ctx = _context(env, player_kills_by_model=kills)
+    scores = [
+        calculator.calculate(i, model, env, ctx)
+        for i, model in enumerate(env.wargame_models)
+    ]
+
+    assert scores[0] == pytest.approx(4.0)
+    assert all(s == pytest.approx(0.0) for s in scores[1:])
+
+
+def test_no_shooting_resolved_scores_nothing() -> None:
+    """A step with no shooting pays nothing rather than erroring."""
+    env = _make_env(3, 1)
+    calculator = ModelKillsCalculator()
+
+    value = calculator.calculate(0, env.wargame_models[0], env, _context(env))
+
+    assert value == pytest.approx(0.0)
+
+
+def _make_shooting_env() -> WargameEnv:
+    """Armed player models in range of, but not engaged with, the opponent.
+
+    Weapons are required (`ModelConfig.weapons` defaults to empty, which means
+    a model cannot shoot at all), and the two sides must be more than
+    `ENGAGEMENT_RANGE` apart or the shooting mask forbids firing.
+    """
+    weapon = WeaponProfile(range=12, attacks=2)
+    config = WargameEnvConfig(
+        render_mode=None,
+        board_width=40,
+        board_height=40,
+        number_of_wargame_models=3,
+        number_of_opponent_models=3,
+        number_of_objectives=1,
+        objective_radius_size=2,
+        number_of_battle_rounds=6,
+        # The default skips every non-movement phase, so the shooting phase
+        # would never execute and no shot could resolve.
+        skip_phases=[BattlePhase.command, BattlePhase.charge, BattlePhase.fight],
+        models=[
+            ModelConfig(x=10, y=20 + i, group_id=0, weapons=[weapon]) for i in range(3)
+        ],
+        opponent_models=[ModelConfig(x=18, y=20 + i, group_id=0) for i in range(3)],
+        objectives=[ObjectiveConfig(x=OBJECTIVE[0], y=OBJECTIVE[1])],
+        opponent_policy=OpponentPolicyConfig(type="scripted_advance_to_objective"),
+    )
+    env = WargameEnv(config=config)
+    env.reset(seed=0)
+    return env
+
+
+def test_env_attributes_kills_to_the_firing_model() -> None:
+    """End-to-end: the per-model kill vector always sums to the scalar count.
+
+    Exercises the real shooting path rather than a hand-built context, so it
+    covers the `PairedShootingResult.killed` flag and the wiring in `step`.
+    """
+    env = _make_shooting_env()
+    total_kills = 0
+    per_model_total = np.zeros(len(env.wargame_models), dtype=np.int64)
+    shooting_slice = env.player_action_handler.shooting_slice
+    assert shooting_slice is not None
+
+    for episode in range(6):
+        env.reset(seed=episode)
+        terminated = truncated = False
+        while not (terminated or truncated):
+            # Fire deliberately rather than sampling: a random action lands in
+            # the shooting slice only ~3% of the time, which would make this
+            # test pass or fail on the dice.
+            if env.game_clock_state.phase is BattlePhase.shooting:
+                actions = [shooting_slice.start] * len(env.wargame_models)
+            else:
+                actions = [0] * len(env.wargame_models)
+            _obs, _r, terminated, truncated, _info = env.step(
+                WargameEnvAction(actions=actions)
+            )
+            ctx = env.last_step_context
+            assert ctx is not None and ctx.player_kills_by_model is not None
+            per_model_total += ctx.player_kills_by_model
+            total_kills += ctx.player_models_killed
+
+    # Guard against a vacuous pass: with no weapons, or with both sides inside
+    # engagement range, no shot ever resolves and the assertion below is 0 == 0.
+    assert total_kills > 0
+    assert int(per_model_total.sum()) == total_kills
+
+
+# --------------------------------------------------------------------------
+# registry
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", ["objective_hold", "model_kills"])
+def test_calculators_are_registered_and_per_model(name: str) -> None:
+    """Both are buildable by name and carry per-model credit."""
+    from wargame_rl.wargame.envs.reward.calculators.base import PerModelRewardCalculator
+
+    calculator = build_calculator(name, weight=1.0, params={})
+
+    assert isinstance(calculator, PerModelRewardCalculator)

--- a/tests/test_shooting_baseline.py
+++ b/tests/test_shooting_baseline.py
@@ -1,0 +1,155 @@
+"""Tests for the shooting baseline.
+
+Every other baseline is movement-only, so their win rate is the ceiling of a
+policy class the learned agent is not in — it gets a shooting decision every
+other step. Measured on the 25v25 config over 40 held-out episodes,
+`squad_march` wins 0.78 while `squad_march_shoot` wins 1.00, so calibrating a
+final gate against the movement-only bar would aim at 80% of what is reachable.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from wargame_rl.wargame.envs.baseline.registry import build_baseline_policy
+from wargame_rl.wargame.envs.types import (
+    ModelConfig,
+    ObjectiveConfig,
+    OpponentPolicyConfig,
+    WargameEnvConfig,
+)
+from wargame_rl.wargame.envs.types.config import WeaponProfile
+from wargame_rl.wargame.envs.types.game_timing import BattlePhase
+from wargame_rl.wargame.envs.wargame import WargameEnv
+
+
+def _make_env(*, armed: bool = True) -> WargameEnv:
+    """Player models in weapon range of the opponent but not engaged with it."""
+    weapons = [WeaponProfile(range=12, attacks=2)] if armed else []
+    config = WargameEnvConfig(
+        render_mode=None,
+        board_width=40,
+        board_height=40,
+        number_of_wargame_models=4,
+        number_of_opponent_models=4,
+        number_of_objectives=2,
+        objective_radius_size=2,
+        number_of_battle_rounds=6,
+        max_groups=2,
+        skip_phases=[BattlePhase.command, BattlePhase.charge, BattlePhase.fight],
+        models=[
+            ModelConfig(x=10, y=18 + i, group_id=i // 2, weapons=weapons)
+            for i in range(4)
+        ],
+        opponent_models=[ModelConfig(x=18, y=18 + i, group_id=0) for i in range(4)],
+        objectives=[ObjectiveConfig(x=20, y=20), ObjectiveConfig(x=20, y=30)],
+        opponent_policy=OpponentPolicyConfig(type="scripted_advance_to_objective"),
+    )
+    return WargameEnv(config=config)
+
+
+def _run(policy_name: str, env: WargameEnv, seed: int = 0) -> list[int]:
+    """Run one episode and return the shooting actions actually issued."""
+    policy = build_baseline_policy(policy_name)
+    observation, _ = env.reset(seed=seed)
+    shooting_slice = env.player_action_handler.shooting_slice
+    assert shooting_slice is not None
+    fired: list[int] = []
+
+    terminated = truncated = False
+    while not (terminated or truncated):
+        is_shooting = env.game_clock_state.phase is BattlePhase.shooting
+        action = policy.select_action(
+            env.wargame_models, env, action_mask=observation.action_mask
+        )
+        if is_shooting:
+            fired.extend(
+                a
+                for a in action.actions
+                if shooting_slice.start <= a < shooting_slice.end
+            )
+        observation, _r, terminated, truncated, _info = env.step(action)
+    return fired
+
+
+def test_shooting_baseline_actually_fires() -> None:
+    """The shooting baseline issues shooting-slice actions; squad_march does not."""
+    assert _run("squad_march_shoot", _make_env()) != []
+    assert _run("squad_march", _make_env()) == []
+
+
+def test_only_masked_in_targets_are_chosen() -> None:
+    """Every shot respects the env mask: range, line of sight, alive, engagement.
+
+    Honouring the mask is what keeps the baseline playing by the same rules as
+    the learned policy, so its score is a fair bar rather than a cheat.
+    """
+    env = _make_env()
+    policy = build_baseline_policy("squad_march_shoot")
+    observation, _ = env.reset(seed=0)
+    shooting_slice = env.player_action_handler.shooting_slice
+    assert shooting_slice is not None
+
+    terminated = truncated = False
+    while not (terminated or truncated):
+        mask = observation.action_mask
+        assert mask is not None
+        action = policy.select_action(env.wargame_models, env, action_mask=mask)
+        if env.game_clock_state.phase is BattlePhase.shooting:
+            for index, chosen in enumerate(action.actions):
+                if shooting_slice.start <= chosen < shooting_slice.end:
+                    assert bool(mask[index, chosen])
+        observation, _r, terminated, truncated, _info = env.step(action)
+
+
+def test_unarmed_models_hold_fire() -> None:
+    """With no weapons the mask offers no targets, so nothing is fired."""
+    assert _run("squad_march_shoot", _make_env(armed=False)) == []
+
+
+def test_shooting_baseline_kills_more_than_the_movement_only_one() -> None:
+    """The point of the bar: firing changes the outcome.
+
+    Uses opponent survivors rather than win rate, which needs many episodes to
+    separate; casualties separate in one.
+    """
+
+    def survivors(policy_name: str) -> int:
+        env = _make_env()
+        _run(policy_name, env)
+        return sum(1 for m in env.opponent_models if m.is_alive)
+
+    assert survivors("squad_march_shoot") < survivors("squad_march")
+
+
+def test_target_choice_is_the_nearest_valid_one() -> None:
+    """Ties aside, each model shoots the closest target the mask allows."""
+    env = _make_env()
+    policy = build_baseline_policy("squad_march_shoot")
+    observation, _ = env.reset(seed=0)
+    shooting_slice = env.player_action_handler.shooting_slice
+    assert shooting_slice is not None
+
+    while env.game_clock_state.phase is not BattlePhase.shooting:
+        action = policy.select_action(
+            env.wargame_models, env, action_mask=observation.action_mask
+        )
+        observation, _r, _t, _tr, _i = env.step(action)
+
+    mask = observation.action_mask
+    assert mask is not None
+    action = policy.select_action(env.wargame_models, env, action_mask=mask)
+    locations = np.array([m.location for m in env.opponent_models], dtype=float)
+    for index, chosen in enumerate(action.actions):
+        if not (shooting_slice.start <= chosen < shooting_slice.end):
+            continue
+        valid = np.flatnonzero(mask[index, shooting_slice.start : shooting_slice.end])
+        distances = np.linalg.norm(
+            locations[valid]
+            - np.asarray(env.wargame_models[index].location, dtype=float),
+            axis=1,
+        )
+        assert chosen - shooting_slice.start == pytest.approx(
+            valid[int(np.argmin(distances))]
+        )

--- a/wargame_rl/wargame/envs/baseline/evaluate.py
+++ b/wargame_rl/wargame/envs/baseline/evaluate.py
@@ -7,16 +7,19 @@ next to a learned policy is produced by exactly the same code path.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import numpy as np
 
 from wargame_rl.wargame.envs.domain.entities import alive_mask_for
 from wargame_rl.wargame.envs.env_components.distance_cache import compute_distances
+from wargame_rl.wargame.envs.state import EventLogExporter, JsonMatchCodec
+from wargame_rl.wargame.envs.types import WargameEnvConfig
+from wargame_rl.wargame.envs.wargame import WargameEnv
 
 if TYPE_CHECKING:
     from wargame_rl.wargame.envs.baseline.policy import BaselinePolicy
-    from wargame_rl.wargame.envs.wargame import WargameEnv
 
 
 @dataclass(frozen=True)
@@ -51,6 +54,39 @@ def _worst_cohesion_gap(env: WargameEnv) -> float:
     group_ids = np.array([m.group_id for m in models], dtype=np.intp)
     distances = cache.min_distances_to_same_group(group_ids, alive_mask=alive)
     return float(distances[alive].max())
+
+
+def record_baseline_episode(
+    policy: BaselinePolicy,
+    config: WargameEnvConfig,
+    seed: int,
+    output_path: Path,
+) -> Path:
+    """Run one episode with event recording and write the log.
+
+    Reference traces are what give a per-step metric a scale: an agent's
+    `oscillation_rate` of 0.3 means nothing until a known-good policy's is on
+    the same chart. `just analyze-compare <agent> <baseline>` consumes these.
+
+    One episode rather than the whole seed set, because `EventLog.record_reset`
+    replaces the event list — the log only ever holds the most recent episode.
+    """
+    exporter = EventLogExporter()
+    env = WargameEnv(config, renderer=None, state_exporters=[exporter])
+    try:
+        observation, _ = env.reset(seed=seed)
+        terminated = truncated = False
+        while not (terminated or truncated):
+            action = policy.select_action(
+                env.wargame_models, env, action_mask=observation.action_mask
+            )
+            observation, _reward, terminated, truncated, _info = env.step(action)
+    finally:
+        env.close()
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_bytes(JsonMatchCodec().encode(exporter.log))
+    return output_path
 
 
 def evaluate_baseline(

--- a/wargame_rl/wargame/envs/baseline/evaluate.py
+++ b/wargame_rl/wargame/envs/baseline/evaluate.py
@@ -6,20 +6,32 @@ next to a learned policy is produced by exactly the same code path.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeAlias
 
 import numpy as np
 
 from wargame_rl.wargame.envs.domain.entities import alive_mask_for
 from wargame_rl.wargame.envs.env_components.distance_cache import compute_distances
 from wargame_rl.wargame.envs.state import EventLogExporter, JsonMatchCodec
-from wargame_rl.wargame.envs.types import WargameEnvConfig
+from wargame_rl.wargame.envs.types import (
+    WargameEnvAction,
+    WargameEnvConfig,
+    WargameEnvObservation,
+)
 from wargame_rl.wargame.envs.wargame import WargameEnv
 
 if TYPE_CHECKING:
     from wargame_rl.wargame.envs.baseline.policy import BaselinePolicy
+
+# Anything that can drive the player's models for one step. Scripted baselines
+# and learned checkpoints both reduce to this, so they can be scored and
+# recorded by identical code rather than by two loops that drift apart.
+ActionSelector: TypeAlias = Callable[
+    [WargameEnvObservation, WargameEnv], WargameEnvAction
+]
 
 
 @dataclass(frozen=True)
@@ -56,8 +68,19 @@ def _worst_cohesion_gap(env: WargameEnv) -> float:
     return float(distances[alive].max())
 
 
-def record_baseline_episode(
-    policy: BaselinePolicy,
+def selector_for(policy: BaselinePolicy) -> ActionSelector:
+    """Adapt a scripted baseline to the `ActionSelector` calling convention."""
+
+    def select(observation: WargameEnvObservation, env: WargameEnv) -> WargameEnvAction:
+        return policy.select_action(
+            env.wargame_models, env, action_mask=observation.action_mask
+        )
+
+    return select
+
+
+def record_episode(
+    select: ActionSelector,
     config: WargameEnvConfig,
     seed: int,
     output_path: Path,
@@ -77,9 +100,7 @@ def record_baseline_episode(
         observation, _ = env.reset(seed=seed)
         terminated = truncated = False
         while not (terminated or truncated):
-            action = policy.select_action(
-                env.wargame_models, env, action_mask=observation.action_mask
-            )
+            action = select(observation, env)
             observation, _reward, terminated, truncated, _info = env.step(action)
     finally:
         env.close()
@@ -89,18 +110,39 @@ def record_baseline_episode(
     return output_path
 
 
+def record_baseline_episode(
+    policy: BaselinePolicy,
+    config: WargameEnvConfig,
+    seed: int,
+    output_path: Path,
+) -> Path:
+    """Record one episode driven by a scripted baseline."""
+    return record_episode(selector_for(policy), config, seed, output_path)
+
+
 def evaluate_baseline(
     policy: BaselinePolicy,
     env: WargameEnv,
     seeds: list[int],
 ) -> BaselineResult:
-    """Run `policy` on `env` once per seed and aggregate the outcome.
+    """Run a scripted baseline on `env` once per seed and aggregate the outcome."""
+    return evaluate_selector(selector_for(policy), env, seeds, type(policy).__name__)
 
-    Episodes are seeded so two baselines are compared on identical layouts —
+
+def evaluate_selector(
+    select: ActionSelector,
+    env: WargameEnv,
+    seeds: list[int],
+    name: str,
+) -> BaselineResult:
+    """Run `select` on `env` once per seed and aggregate the outcome.
+
+    Episodes are seeded so two policies are compared on identical layouts —
     objective placement dominates episode variance, so resampling would make
-    the comparison mostly a question of which maps each policy drew.
+    the comparison mostly a question of which maps each policy drew. A learned
+    checkpoint scored through here is therefore directly comparable to the
+    baseline table, because it is the same code.
     """
-    name = type(policy).__name__
     fractions: list[float] = []
     wins: list[float] = []
     player_vps: list[float] = []
@@ -114,9 +156,7 @@ def evaluate_baseline(
             # The observation's mask already encodes range, line of sight,
             # target-alive and engagement-range validity, so a shooting
             # baseline plays by exactly the rules the learned policy does.
-            action = policy.select_action(
-                env.wargame_models, env, action_mask=observation.action_mask
-            )
+            action = select(observation, env)
             observation, _reward, terminated, truncated, _info = env.step(action)
 
         alive = alive_mask_for(env.wargame_models)

--- a/wargame_rl/wargame/envs/baseline/evaluate.py
+++ b/wargame_rl/wargame/envs/baseline/evaluate.py
@@ -75,7 +75,12 @@ def evaluate_baseline(
         observation, _ = env.reset(seed=seed)
         terminated = truncated = False
         while not (terminated or truncated):
-            action = policy.select_action(env.wargame_models, env)
+            # The observation's mask already encodes range, line of sight,
+            # target-alive and engagement-range validity, so a shooting
+            # baseline plays by exactly the rules the learned policy does.
+            action = policy.select_action(
+                env.wargame_models, env, action_mask=observation.action_mask
+            )
             observation, _reward, terminated, truncated, _info = env.step(action)
 
         alive = alive_mask_for(env.wargame_models)

--- a/wargame_rl/wargame/envs/baseline/policy.py
+++ b/wargame_rl/wargame/envs/baseline/policy.py
@@ -33,13 +33,17 @@ class BaselinePolicy(ABC):
     ) -> WargameEnvAction:
         """Return one action per player model.
 
-        Baselines act only in the movement phase; every other phase yields
-        ``STAY``. They deliberately do not shoot, so they measure positional
-        play alone and stay a conservative bar for the learned policy.
+        Movement and shooting are dispatched separately; every other phase
+        yields ``STAY``. Most baselines do not shoot, which makes them a
+        conservative positional bar — see `ScriptedSquadMarchShootPolicy` for
+        the one that does.
         """
-        if env.game_clock_state.phase is not BattlePhase.movement:
-            return WargameEnvAction(actions=[STAY_ACTION] * len(models))
-        return self.select_movement(models, env)
+        phase = env.game_clock_state.phase
+        if phase is BattlePhase.movement:
+            return self.select_movement(models, env)
+        if phase is BattlePhase.shooting:
+            return self.select_shooting(models, env, action_mask)
+        return WargameEnvAction(actions=[STAY_ACTION] * len(models))
 
     @abstractmethod
     def select_movement(
@@ -47,6 +51,19 @@ class BaselinePolicy(ABC):
     ) -> WargameEnvAction:
         """Return one movement-phase action per player model."""
         ...
+
+    def select_shooting(
+        self,
+        models: list[WargameModel],
+        env: WargameEnv,
+        action_mask: np.ndarray | None = None,
+    ) -> WargameEnvAction:
+        """Return one shooting-phase action per player model.
+
+        Defaults to holding fire, so existing baselines are unchanged and stay
+        a pure measure of positional play.
+        """
+        return WargameEnvAction(actions=[STAY_ACTION] * len(models))
 
 
 def step_toward_objective(

--- a/wargame_rl/wargame/envs/baseline/registry.py
+++ b/wargame_rl/wargame/envs/baseline/registry.py
@@ -31,6 +31,7 @@ def _auto_register() -> None:
         "wargame_rl.wargame.envs.baseline.scripted_greedy_nearest",
         "wargame_rl.wargame.envs.baseline.scripted_split_evenly",
         "wargame_rl.wargame.envs.baseline.scripted_squad_march",
+        "wargame_rl.wargame.envs.baseline.scripted_squad_march_shoot",
     ):
         importlib.import_module(module)
 

--- a/wargame_rl/wargame/envs/baseline/scripted_squad_march_shoot.py
+++ b/wargame_rl/wargame/envs/baseline/scripted_squad_march_shoot.py
@@ -1,0 +1,74 @@
+"""Baseline: march squads onto objectives, and shoot when a target is valid."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from wargame_rl.wargame.envs.baseline.registry import register_baseline
+from wargame_rl.wargame.envs.baseline.scripted_squad_march import (
+    ScriptedSquadMarchPolicy,
+)
+from wargame_rl.wargame.envs.env_components.actions import STAY_ACTION
+from wargame_rl.wargame.envs.types import WargameEnvAction
+
+if TYPE_CHECKING:
+    from wargame_rl.wargame.envs.domain.entities import WargameModel
+    from wargame_rl.wargame.envs.wargame import WargameEnv
+
+
+class ScriptedSquadMarchShootPolicy(ScriptedSquadMarchPolicy):
+    """`squad_march`, plus firing at the nearest valid target each shooting phase.
+
+    The reference bar for a policy class the agent is actually in. Every other
+    baseline is movement-only, so their ~0.78 win rate is the ceiling of a
+    policy that never fires — while the agent gets 20 shooting decisions per
+    episode against an opponent that cannot shoot back. Calibrating the final
+    curriculum gate against a movement-only score would aim below what a
+    competent shooter should reach.
+
+    Target choice is nearest-first rather than best-expected-damage. With a
+    homogeneous army every target has identical expected damage, so the two
+    agree; nearest is simpler and stays correct if stats diverge only slightly.
+    """
+
+    def select_shooting(
+        self,
+        models: list[WargameModel],
+        env: WargameEnv,
+        action_mask: np.ndarray | None = None,
+    ) -> WargameEnvAction:
+        """Fire each model at its nearest valid target, or hold if it has none."""
+        shooting_slice = env.player_action_handler.shooting_slice
+        actions = [STAY_ACTION] * len(models)
+        if shooting_slice is None or action_mask is None:
+            return WargameEnvAction(actions=actions)
+
+        opponents = env.opponent_models
+        if not opponents:
+            return WargameEnvAction(actions=actions)
+        opponent_locations = np.array([m.location for m in opponents], dtype=float)
+
+        for index, model in enumerate(models):
+            if not model.is_alive:
+                continue
+            # The env mask already encodes range, line of sight, target-alive
+            # and engagement-range validity, so honouring it is what keeps this
+            # baseline playing by the same rules as the learned policy.
+            valid = np.flatnonzero(
+                action_mask[index, shooting_slice.start : shooting_slice.end]
+            )
+            if valid.size == 0:
+                continue
+            distances = np.linalg.norm(
+                opponent_locations[valid] - np.asarray(model.location, dtype=float),
+                axis=1,
+            )
+            target = int(valid[int(np.argmin(distances))])
+            actions[index] = shooting_slice.start + target
+
+        return WargameEnvAction(actions=actions)
+
+
+register_baseline("squad_march_shoot", ScriptedSquadMarchShootPolicy)

--- a/wargame_rl/wargame/envs/domain/shooting.py
+++ b/wargame_rl/wargame/envs/domain/shooting.py
@@ -55,6 +55,11 @@ class PairedShootingResult:
     attacker_idx: int
     target_idx: int
     result: ShootingResult
+    # Whether this shot is what took the target to zero wounds. Recorded at
+    # resolution time because it cannot be recovered afterwards: several
+    # attackers may fire on the same target in one phase, and only one of them
+    # made the kill.
+    killed: bool = False
 
 
 def wound_roll_threshold(strength: int, toughness: int) -> int:

--- a/wargame_rl/wargame/envs/reward/calculators/model_kills.py
+++ b/wargame_rl/wargame/envs/reward/calculators/model_kills.py
@@ -1,0 +1,51 @@
+"""Per-model reward for kills the model itself made."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from wargame_rl.wargame.envs.reward.calculators.base import PerModelRewardCalculator
+
+if TYPE_CHECKING:
+    from wargame_rl.wargame.envs.domain.battle_view import BattleView
+    from wargame_rl.wargame.envs.reward.step_context import StepContext
+    from wargame_rl.wargame.envs.wargame_model import WargameModel
+
+DEFAULT_BONUS_PER_KILL = 2.0
+
+
+class ModelKillsCalculator(PerModelRewardCalculator):
+    """Reward each model for the opponents *it* killed this step.
+
+    The per-model counterpart of the global ``killing`` calculator. Shooting is
+    half the agent's decisions, and under a global term every model receives an
+    identical reward whether it fired, missed, or stood still — so the shooting
+    head has no credit path at all. This gives it one.
+
+    Note the scale difference from ``killing``: that calculator's default bonus
+    of 5.0 is paid to all N models for every kill, so a 25-model wipe is worth
+    5 x 25 = 125 per model. Here a wipe is worth roughly one kill's bonus per
+    model, because the kills are divided among the shooters rather than
+    broadcast.
+    """
+
+    def __init__(
+        self,
+        weight: float = 1.0,
+        bonus_per_kill: float = DEFAULT_BONUS_PER_KILL,
+    ) -> None:
+        super().__init__(weight=weight)
+        self.bonus_per_kill = bonus_per_kill
+
+    def calculate(
+        self,
+        model_idx: int,
+        model: WargameModel,
+        view: BattleView,
+        ctx: StepContext,
+    ) -> float:
+        """Return the bonus for kills this model made on this step."""
+        kills = ctx.player_kills_by_model
+        if kills is None or model_idx >= len(kills):
+            return 0.0
+        return self.bonus_per_kill * float(kills[model_idx])

--- a/wargame_rl/wargame/envs/reward/calculators/objective_hold.py
+++ b/wargame_rl/wargame/envs/reward/calculators/objective_hold.py
@@ -1,0 +1,122 @@
+"""Per-model reward for occupying an objective, scaled by who controls it."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from wargame_rl.wargame.envs.domain.entities import alive_mask_for
+from wargame_rl.wargame.envs.env_components.distance_cache import (
+    compute_distances,
+    objective_states_from_norms_offset,
+)
+from wargame_rl.wargame.envs.reward.calculators.base import PerModelRewardCalculator
+
+if TYPE_CHECKING:
+    from wargame_rl.wargame.envs.domain.battle_view import BattleView
+    from wargame_rl.wargame.envs.reward.step_context import StepContext
+    from wargame_rl.wargame.envs.wargame_model import WargameModel
+
+DEFAULT_PLAYER_VALUE = 1.0
+DEFAULT_CONTESTED_VALUE = 0.5
+DEFAULT_OPPONENT_VALUE = 0.25
+
+
+class ObjectiveHoldCalculator(PerModelRewardCalculator):
+    """Per-model reward for standing on an objective, scaled by control state.
+
+    This is the only calculator that pays a model for what it is doing while
+    *stationary*. Every other per-model term goes silent once models arrive:
+    ``closest_objective``'s progress is a potential that exhausts on arrival and
+    is exactly zero on shooting steps, and ``group_cohesion`` returns a hard 0
+    inside its limit. Without this, all models share an identical reward for
+    roughly three quarters of an episode, which defeats per-model credit
+    assignment.
+
+    It pays for *controlling*, not merely standing, so it strictly dominates the
+    global ``models_at_objectives`` — which every competent scripted baseline
+    saturates at 1.0, making that term unable to tell a weak policy from a
+    strong one. Scaling by control state also supplies a gradient across the
+    ``neutral -> contested -> player`` region that ``objective_coverage`` and
+    ``vp_gain`` are both flat across, since control is a strict count
+    comparison.
+    """
+
+    def __init__(
+        self,
+        weight: float = 1.0,
+        player_value: float = DEFAULT_PLAYER_VALUE,
+        contested_value: float = DEFAULT_CONTESTED_VALUE,
+        opponent_value: float = DEFAULT_OPPONENT_VALUE,
+    ) -> None:
+        super().__init__(weight=weight)
+        self.player_value = player_value
+        self.contested_value = contested_value
+        self.opponent_value = opponent_value
+        self._cached_ctx: StepContext | None = None
+        self._cached_values: np.ndarray | None = None
+
+    def reset_episode(self) -> None:
+        """Drop the per-step control-state cache."""
+        self._cached_ctx = None
+        self._cached_values = None
+
+    def _value_for_state(self, state: str) -> float:
+        if state == "player":
+            return self.player_value
+        if state == "contested":
+            return self.contested_value
+        if state == "opponent":
+            return self.opponent_value
+        return 0.0  # neutral: occupied by nobody, so holding it is worth nothing
+
+    def _objective_values(self, view: BattleView, ctx: StepContext) -> np.ndarray:
+        """Per-objective value, computed once per step and reused across models.
+
+        `calculate` is invoked once per model, and deriving control needs the
+        opponent's distances, so without this the opponent cache would be
+        rebuilt 25 times a step. A fresh `StepContext` is built every step and
+        held by the env, so identity comparison is a safe cache key.
+        """
+        if ctx is self._cached_ctx and self._cached_values is not None:
+            return self._cached_values
+
+        n_objectives = len(view.objectives)
+        if view.opponent_models:
+            opponent_alive = alive_mask_for(view.opponent_models)
+            opponent_norms = compute_distances(
+                view.opponent_models, view.objectives, alive_mask=opponent_alive
+            ).model_obj_norms_offset
+        else:
+            opponent_norms = np.zeros((0, n_objectives), dtype=np.float64)
+
+        states = objective_states_from_norms_offset(
+            ctx.distance_cache.model_obj_norms_offset,
+            opponent_norms,
+            ctx.distance_cache.obj_radii,
+        )
+        values = np.array([self._value_for_state(s) for s in states], dtype=np.float64)
+        self._cached_ctx = ctx
+        self._cached_values = values
+        return values
+
+    def calculate(
+        self,
+        model_idx: int,
+        model: WargameModel,
+        view: BattleView,
+        ctx: StepContext,
+    ) -> float:
+        """Return the control-scaled value of the objective this model occupies.
+
+        A model inside overlapping objectives is credited with the best of them.
+        """
+        if not view.objectives:
+            return 0.0
+        cache = ctx.distance_cache
+        inside = cache.model_obj_norms_offset[model_idx] <= cache.obj_radii
+        if not bool(np.any(inside)):
+            return 0.0
+        values = self._objective_values(view, ctx)
+        return float(np.max(values[inside]))

--- a/wargame_rl/wargame/envs/reward/calculators/registry.py
+++ b/wargame_rl/wargame/envs/reward/calculators/registry.py
@@ -16,6 +16,7 @@ from wargame_rl.wargame.envs.reward.calculators.group_cohesion import (
     GroupCohesionCalculator,
 )
 from wargame_rl.wargame.envs.reward.calculators.killing import KillingReward
+from wargame_rl.wargame.envs.reward.calculators.model_kills import ModelKillsCalculator
 from wargame_rl.wargame.envs.reward.calculators.models_at_objectives import (
     ModelsAtObjectivesCalculator,
 )
@@ -25,6 +26,9 @@ from wargame_rl.wargame.envs.reward.calculators.objective_coverage import (
 from wargame_rl.wargame.envs.reward.calculators.objective_flip_bonus import (
     ObjectiveFlipBonusCalculator,
 )
+from wargame_rl.wargame.envs.reward.calculators.objective_hold import (
+    ObjectiveHoldCalculator,
+)
 from wargame_rl.wargame.envs.reward.calculators.vp_gain import VPGainCalculator
 
 RewardCalculatorType = PerModelRewardCalculator | GlobalRewardCalculator
@@ -33,9 +37,11 @@ CALCULATOR_REGISTRY: dict[str, type[RewardCalculatorType]] = {
     "closest_objective": ClosestObjectiveCalculator,
     "closest_objective_v2": ClosestObjectiveV2Calculator,
     "group_cohesion": GroupCohesionCalculator,
+    "model_kills": ModelKillsCalculator,
     "models_at_objectives": ModelsAtObjectivesCalculator,
     "objective_coverage": ObjectiveCoverageCalculator,
     "objective_flip_bonus": ObjectiveFlipBonusCalculator,
+    "objective_hold": ObjectiveHoldCalculator,
     "vp_gain": VPGainCalculator,
     "killing": KillingReward,
 }

--- a/wargame_rl/wargame/envs/reward/step_context.py
+++ b/wargame_rl/wargame/envs/reward/step_context.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+import numpy as np
+
 from wargame_rl.wargame.envs.types.game_timing import BattlePhase
 
 if TYPE_CHECKING:
@@ -30,3 +32,8 @@ class StepContext:
     opponent_damage_dealt: int = 0
     player_models_killed: int = 0
     opponent_models_killed: int = 0
+    # Kills made by each player model this step, shape (n_player_models,).
+    # `player_models_killed` is its sum; the vector exists so shooting can be
+    # credited to the model that actually fired rather than shared flat across
+    # the army. None when no shooting has been resolved this step.
+    player_kills_by_model: np.ndarray | None = None

--- a/wargame_rl/wargame/envs/state/analysis.py
+++ b/wargame_rl/wargame/envs/state/analysis.py
@@ -39,11 +39,27 @@ class MatchAnalysis(BaseModel):
 
     # Tactical quality
     mean_group_distance: float = Field(
-        default=0.0, description="Average pairwise distance between player models"
+        default=0.0,
+        description="Average distance from a model to its nearest same-group model",
     )
     time_to_first_objective: int | None = Field(
         default=None,
         description="First step where any player model reaches an objective",
+    )
+    final_fraction_at_objectives: float = Field(
+        default=0.0,
+        description="Fraction of alive models on an objective at the final step",
+    )
+    peak_fraction_at_objectives: float = Field(
+        default=0.0,
+        description="Highest fraction of alive models on an objective in any step",
+    )
+    objective_drift_ratio: float = Field(
+        default=1.0,
+        description=(
+            "peak / final occupancy. 1.0 means models held what they took; "
+            "higher means they reached objectives and then left"
+        ),
     )
     vp_per_step: float = Field(
         default=0.0, description="Total VP gained divided by episode steps"
@@ -97,6 +113,9 @@ class MatchAnalysis(BaseModel):
             f"  Mean group distance:     {self.mean_group_distance:.1f}",
             f"  Time to first objective: {self.time_to_first_objective or 'never'}",
             f"  VP per step:             {self.vp_per_step:.3f}",
+            f"  On objectives (final):   {self.final_fraction_at_objectives:.2f}",
+            f"  On objectives (peak):    {self.peak_fraction_at_objectives:.2f}",
+            f"  Objective drift ratio:   {self.objective_drift_ratio:.2f}",
             f"  Target selection opt.:   {_fmt_opt(self.target_selection_optimality)}",
             "",
             "RULE COMPLIANCE",
@@ -226,6 +245,9 @@ def analyze_match(
         time_to_first_objective=tactical.time_to_first_objective,
         vp_per_step=tactical.vp_per_step,
         target_selection_optimality=tactical.target_selection_optimality,
+        final_fraction_at_objectives=tactical.final_fraction_at_objectives,
+        peak_fraction_at_objectives=tactical.peak_fraction_at_objectives,
+        objective_drift_ratio=tactical.objective_drift_ratio,
         movement_violations=rules.movement_violations,
         bounds_violations=rules.bounds_violations,
         action_entropy=degenerate.action_entropy,
@@ -253,6 +275,17 @@ class _TacticalMetrics(BaseModel):
     time_to_first_objective: int | None = None
     vp_per_step: float = 0.0
     target_selection_optimality: float | None = None
+    final_fraction_at_objectives: float = 0.0
+    peak_fraction_at_objectives: float = 0.0
+    objective_drift_ratio: float = 1.0
+
+
+def _fraction_at_objectives(snapshot: GameStateSnapshot) -> float:
+    """Fraction of alive player models standing on any objective."""
+    alive = [m for m in snapshot.player_models if m.alive]
+    if not alive:
+        return 0.0
+    return sum(1 for m in alive if any(m.at_objective)) / len(alive)
 
 
 class _RuleMetrics(BaseModel):
@@ -345,16 +378,26 @@ def _analyze_tactical(snapshots: list[GameStateSnapshot]) -> _TacticalMetrics:
     total_attacks = 0
 
     for snap in snapshots:
+        # Distance to the nearest *same-group* model, matching the definition
+        # `group_cohesion` uses. An all-pairs army-wide mean measures dispersion
+        # rather than cohesion, and ranks the two backwards: a policy that piles
+        # every model onto one objective scores better than one that correctly
+        # splits squads across three.
         alive_models = [m for m in snap.player_models if m.alive]
-        if len(alive_models) >= 2:
-            pairwise = []
-            for i in range(len(alive_models)):
-                for j in range(i + 1, len(alive_models)):
-                    dx = alive_models[i].location[0] - alive_models[j].location[0]
-                    dy = alive_models[i].location[1] - alive_models[j].location[1]
-                    pairwise.append(math.sqrt(dx * dx + dy * dy))
-            if pairwise:
-                group_distances.append(sum(pairwise) / len(pairwise))
+        nearest_same_group: list[float] = []
+        for model in alive_models:
+            squadmates = [
+                other
+                for other in alive_models
+                if other is not model and other.group_id == model.group_id
+            ]
+            if not squadmates:
+                continue
+            nearest_same_group.append(
+                min(math.dist(model.location, other.location) for other in squadmates)
+            )
+        if nearest_same_group:
+            group_distances.append(sum(nearest_same_group) / len(nearest_same_group))
 
         # Time to first objective
         if time_to_first_obj is None:
@@ -386,6 +429,14 @@ def _analyze_tactical(snapshots: list[GameStateSnapshot]) -> _TacticalMetrics:
     vp_gained = last.player_vp - first.player_vp
     vp_per_step = vp_gained / n_steps if n_steps > 0 else 0.0
 
+    # Occupancy over the episode. The drift ratio is the signal that started
+    # this project's reward redesign: recorded matches showed the policy
+    # reaching objectives and then leaving them, which every episode-level
+    # metric reported as success because occupancy is judged at the last step.
+    occupancy = [_fraction_at_objectives(s) for s in snapshots]
+    final_occupancy = occupancy[-1] if occupancy else 0.0
+    peak_occupancy = max(occupancy) if occupancy else 0.0
+
     return _TacticalMetrics(
         mean_group_distance=(
             sum(group_distances) / len(group_distances) if group_distances else 0.0
@@ -394,6 +445,11 @@ def _analyze_tactical(snapshots: list[GameStateSnapshot]) -> _TacticalMetrics:
         vp_per_step=vp_per_step,
         target_selection_optimality=(
             total_optimal / total_attacks if total_attacks > 0 else None
+        ),
+        final_fraction_at_objectives=final_occupancy,
+        peak_fraction_at_objectives=peak_occupancy,
+        objective_drift_ratio=(
+            peak_occupancy / final_occupancy if final_occupancy > 0 else float("inf")
         ),
     )
 
@@ -453,7 +509,12 @@ def _analyze_degenerate(snapshots: list[GameStateSnapshot]) -> _DegenerateMetric
             if p > 0:
                 entropy -= p * math.log2(p)
 
-    # Oscillation detection (model returns to a position within 3 steps)
+    # Oscillation: a model *leaves* a cell and comes back within 3 steps.
+    #
+    # The `pos != previous` guard is what makes this measure oscillation rather
+    # than stationarity. Without it, a model holding an objective — the exact
+    # behaviour the reward is designed to produce — matched its own previous
+    # position every step and scored ~70%, while a random walk scored ~5%.
     oscillation_events = 0
     total_model_steps = 0
     for m_idx in range(len(snapshots[0].player_models)):
@@ -466,7 +527,9 @@ def _analyze_degenerate(snapshots: list[GameStateSnapshot]) -> _DegenerateMetric
                 continue
             pos = (m.location[0], m.location[1])
             total_model_steps += 1
-            if pos in recent_positions[:-1]:
+            previous = recent_positions[-1] if recent_positions else None
+            returned = pos in recent_positions[:-1] and pos != previous
+            if returned:
                 oscillation_events += 1
             recent_positions.append(pos)
             if len(recent_positions) > 4:

--- a/wargame_rl/wargame/envs/wargame.py
+++ b/wargame_rl/wargame/envs/wargame.py
@@ -213,6 +213,11 @@ class WargameEnv(gym.Env):
         return self._action_handler
 
     @property
+    def state_exporters(self) -> list[StateExporter]:
+        """Exporters recording this env's steps (empty when not recording)."""
+        return list(self._state_exporters)
+
+    @property
     def opponent_action_space(self) -> spaces.Tuple:
         """Action space for opponent models (used by policies)."""
         return self._opponent_action_handler.action_space

--- a/wargame_rl/wargame/envs/wargame.py
+++ b/wargame_rl/wargame/envs/wargame.py
@@ -425,11 +425,18 @@ class WargameEnv(gym.Env):
                 save=target.stats["save"],
             )
             result = resolve_shooting(w, defender, self._combat_rng)
+            killed = False
             if result.damage_dealt > 0:
                 targets[target_idx].take_damage(result.damage_dealt)
+                # The target was alive at the range check above, so a dead
+                # target here means this shot made the kill.
+                killed = not targets[target_idx].is_alive
             results.append(
                 PairedShootingResult(
-                    attacker_idx=i, target_idx=target_idx, result=result
+                    attacker_idx=i,
+                    target_idx=target_idx,
+                    result=result,
+                    killed=killed,
                 )
             )
         return results
@@ -564,6 +571,12 @@ class WargameEnv(gym.Env):
             and player_alive_before[i]
             and not m.is_alive
         )
+        # Attribute each kill to the model that fired it, so shooting reward
+        # lands on that model's advantage rather than being shared flat.
+        p_kills_by_model = np.zeros(len(self.wargame_models), dtype=np.int64)
+        for shot in self._last_player_shooting_results:
+            if shot.killed and shot.attacker_idx < len(p_kills_by_model):
+                p_kills_by_model[shot.attacker_idx] += 1
 
         # Built before termination is known because the phase's success criteria
         # need a context to evaluate against. No criteria reads `is_terminated`,
@@ -582,6 +595,7 @@ class WargameEnv(gym.Env):
             opponent_damage_dealt=o_dmg,
             player_models_killed=p_kills,
             opponent_models_killed=o_kills,
+            player_kills_by_model=p_kills_by_model,
         )
 
         # Consults the *configured* criteria for the active phase rather than a

--- a/wargame_rl/wargame/model/common/lightning_base.py
+++ b/wargame_rl/wargame/model/common/lightning_base.py
@@ -131,8 +131,14 @@ class WargameLightningBase(LightningModule, ABC):
                 self.env.config,
                 renderer=None,
                 phase_position=self.env.phase_manager.position,
+                # Only env 0 records. `--record-events` attaches its exporter to
+                # the training env, which batched evaluation no longer steps —
+                # without this, a run set to record produces nothing, which is
+                # exactly the failure EventLogCallback was written to fix.
+                # Recording every env would interleave episodes into one log.
+                state_exporters=self.env.state_exporters if index == 0 else None,
             )
-            for _ in range(wave_size)
+            for index in range(wave_size)
         ]
         self._eval_envs = envs
         return envs

--- a/wargame_rl/wargame/model/common/lightning_base.py
+++ b/wargame_rl/wargame/model/common/lightning_base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import Any
 
 import numpy as np
 import torch
@@ -10,6 +11,7 @@ from pytorch_lightning import LightningModule
 
 from wargame_rl.wargame.envs.baseline.evaluate import evaluate_baseline
 from wargame_rl.wargame.envs.baseline.registry import build_baseline_policy
+from wargame_rl.wargame.envs.types import WargameEnvAction
 from wargame_rl.wargame.envs.wargame import WargameEnv
 from wargame_rl.wargame.model.common.agent_base import BaseAgent
 
@@ -19,6 +21,14 @@ BASELINE_POLICIES = ("random", "squad_march")
 BASELINE_EPISODES = 20
 # Held out from ROLLOUT_SEED_BASE so baselines never share training layouts.
 BASELINE_SEED_BASE = 10_000
+# Evaluation layouts, disjoint from both training and baseline seeds. Fixed
+# across epochs on purpose: objective placement dominates episode variance, so
+# resampling every epoch makes a curve mostly report which maps were drawn.
+EVAL_SEED_BASE = 500_000
+# Eval episodes run lockstep in waves of this size. Every episode is exactly
+# `max_turns` steps, so a wave costs `max_turns` batched forward passes instead
+# of `wave_size * max_turns` sequential ones.
+EVAL_WAVE_SIZE = 16
 
 
 class WargameLightningBase(LightningModule, ABC):
@@ -39,6 +49,8 @@ class WargameLightningBase(LightningModule, ABC):
         self.agent = agent
         self.eval_log_prefix = eval_log_prefix
         self.mean_episode_reward = 0.0
+        # Built lazily on first evaluation and reused, like the rollout envs.
+        self._eval_envs: list[WargameEnv] | None = None
 
     @abstractmethod
     def _policy_model(self) -> nn.Module:
@@ -96,6 +108,104 @@ class WargameLightningBase(LightningModule, ABC):
         else:
             policy.train()
 
+    def _batch_greedy_actions(self, state_tensors: list[torch.Tensor]) -> Any:
+        """Greedy actions `(batch, n_models)` for a batch of observations.
+
+        Returning None disables batched evaluation and falls back to the
+        sequential path. Subclasses that can score a whole batch override it;
+        DQN and PPO differ in where the action mask is applied, so this cannot
+        be written once here.
+        """
+        return None
+
+    def _ensure_eval_envs(self, wave_size: int) -> list[WargameEnv]:
+        """Build the lockstep evaluation environments once and reuse them.
+
+        They share the training env's `CurriculumPosition`, so evaluation
+        always scores the phase the curriculum has actually reached.
+        """
+        if self._eval_envs is not None and len(self._eval_envs) >= wave_size:
+            return self._eval_envs[:wave_size]
+        envs = [
+            WargameEnv(
+                self.env.config,
+                renderer=None,
+                phase_position=self.env.phase_manager.position,
+            )
+            for _ in range(wave_size)
+        ]
+        self._eval_envs = envs
+        return envs
+
+    def _run_episodes_batched(
+        self, total_episodes: int, seeds: list[int]
+    ) -> tuple[list[float], list[int], list[bool], list[float], list[float]] | None:
+        """Run evaluation episodes in lockstep waves, batching the forward pass.
+
+        Returns None when the subclass cannot score a batch, so the caller can
+        fall back. Episodes within a wave all run to `max_turns` unless a phase
+        enables `terminate_on_success`, in which case finished envs simply stop
+        being stepped while the wave completes.
+        """
+        from wargame_rl.wargame.model.common.observation import (
+            observations_to_tensor_batch,
+        )
+
+        device = self._policy_model_device()
+        rewards: list[float] = []
+        steps: list[int] = []
+        successes: list[bool] = []
+        player_vps: list[float] = []
+        opponent_vps: list[float] = []
+
+        for start in range(0, total_episodes, EVAL_WAVE_SIZE):
+            wave = min(EVAL_WAVE_SIZE, total_episodes - start)
+            envs = self._ensure_eval_envs(wave)
+            observations = [
+                env.reset(seed=seeds[start + i])[0] for i, env in enumerate(envs)
+            ]
+            wave_rewards = [0.0] * wave
+            wave_steps = [0] * wave
+            done = [False] * wave
+
+            while not all(done):
+                active = [i for i in range(wave) if not done[i]]
+                batch = observations_to_tensor_batch(
+                    [observations[i] for i in active], device=device
+                )
+                actions = self._batch_greedy_actions(batch)
+                if actions is None:
+                    return None
+                action_rows = actions.detach().cpu().numpy()
+
+                for row, env_index in enumerate(active):
+                    env = envs[env_index]
+                    env_action = WargameEnvAction(
+                        actions=[int(a) for a in action_rows[row]]
+                    )
+                    obs, reward, terminated, truncated, _info = env.step(env_action)
+                    observations[env_index] = obs
+                    wave_rewards[env_index] += float(reward)
+                    wave_steps[env_index] += 1
+                    done[env_index] = bool(terminated or truncated)
+
+            for i, env in enumerate(envs):
+                rewards.append(wave_rewards[i])
+                steps.append(wave_steps[i])
+                player_vps.append(float(env.player_vp))
+                opponent_vps.append(float(env.opponent_vp))
+                if env.last_step_context is not None:
+                    successes.append(
+                        env.phase_manager.check_success(env, env.last_step_context)
+                    )
+
+        return rewards, steps, successes, player_vps, opponent_vps
+
+    def _policy_model_device(self) -> torch.device:
+        """Device the policy model's parameters live on."""
+        parameter = next(self._policy_model().parameters(), None)
+        return parameter.device if parameter is not None else torch.device("cpu")
+
     def _evaluate_episodes(
         self,
         *,
@@ -116,19 +226,40 @@ class WargameLightningBase(LightningModule, ABC):
 
         self._set_policy_mode(True)
 
-        with torch.no_grad():
-            for _ in range(total_episodes):
-                reward, steps = self._run_episode_eval(epsilon)
-                episode_rewards.append(reward)
-                steps_s.append(steps)
-                player_vps.append(float(self.env.player_vp))
-                opponent_vps.append(float(self.env.opponent_vp))
+        # Fixed seeds so every epoch scores the same layouts. Objective
+        # placement dominates episode variance, so resampling each epoch would
+        # make the curve mostly a record of which maps were drawn.
+        seeds = [EVAL_SEED_BASE + i for i in range(total_episodes)]
 
-                if self.env.last_step_context is not None:
-                    success = self.env.phase_manager.check_success(
-                        self.env, self.env.last_step_context
-                    )
-                    episode_successes.append(success)
+        with torch.no_grad():
+            batched = (
+                self._run_episodes_batched(total_episodes, seeds)
+                if epsilon == 0.0
+                else None
+            )
+            if batched is not None:
+                (
+                    episode_rewards,
+                    steps_s,
+                    episode_successes,
+                    player_vps,
+                    opponent_vps,
+                ) = batched
+            else:
+                # Sequential fallback: exploration-epsilon evaluation, or a
+                # subclass that cannot score a batch.
+                for _ in range(total_episodes):
+                    reward, steps = self._run_episode_eval(epsilon)
+                    episode_rewards.append(reward)
+                    steps_s.append(steps)
+                    player_vps.append(float(self.env.player_vp))
+                    opponent_vps.append(float(self.env.opponent_vp))
+
+                    if self.env.last_step_context is not None:
+                        success = self.env.phase_manager.check_success(
+                            self.env, self.env.last_step_context
+                        )
+                        episode_successes.append(success)
 
         self._set_policy_mode(False)
 

--- a/wargame_rl/wargame/model/dqn/lightning.py
+++ b/wargame_rl/wargame/model/dqn/lightning.py
@@ -212,3 +212,14 @@ class DQNLightning(WargameLightningBase):
 
     def _policy_model(self) -> RL_Network:
         return self.policy_net
+
+    def _batch_greedy_actions(self, state_tensors: list[Tensor]) -> Tensor:
+        """Greedy per-model actions for a batch of observations.
+
+        Unlike the PPO net, the Q-network does not mask internally, so the
+        env-provided mask (tensor slot 5) is applied here.
+        """
+        q_values = self.policy_net(state_tensors[:5])
+        q_values = apply_action_mask(q_values, state_tensors[5])
+        actions: Tensor = q_values.argmax(dim=-1)
+        return actions

--- a/wargame_rl/wargame/model/ppo/config.py
+++ b/wargame_rl/wargame/model/ppo/config.py
@@ -9,7 +9,16 @@ class PPOConfig(BaseModel):
     # Training parameters
     batch_size: int = 128
     lr: float = 3e-4
-    gamma: float = 0.9
+    # 0.9^40 = 0.015, so under the old default a terminal bonus was worth 0.044
+    # at t=0 and the effective horizon was ~10 steps of a 40-step episode --
+    # while the decisions that matter here (which objective a squad walks to)
+    # pay off 20-35 steps later. With a hard 40-step cap, 1/(1-0.99) = 100 is
+    # effectively undiscounted, the standard choice for an episodic task.
+    #
+    # The earlier "0.99 is worse" finding is retracted as unmeasured: it was
+    # taken under a training loop that never applied the reward being tuned.
+    # Re-tested as the first screen arm.
+    gamma: float = 0.99
     gae_lambda: float = 0.95  # 0.9 is quite low, 0.95 - 0.99 is common, above 0.99 is very future oriented
     # Controls bias–variance tradeoff in GAE (Generalized Advantage Estimation).
     # λ = 1 → Monte Carlo (low bias, high variance)
@@ -24,15 +33,13 @@ class PPOConfig(BaseModel):
     #
     # It used to multiply the entropy *summed* over models, so its effective
     # magnitude scaled with army size: 0.03 at 25 models was an effective 0.75,
-    # which is ~25x a conventional setting and is why a measured 3x change in
-    # this value moved total policy entropy by ~1%. 0.75 is set here to hold
-    # the pre-change pressure constant at 25 models, so that switching to
-    # per-model credit assignment is the only variable under test.
+    # ~25x a conventional setting, which is why a measured 3x change in the
+    # nominal value moved total policy entropy by only ~1%.
     #
-    # 0.03 is the scale-free conventional value and the obvious second arm:
-    # `--ent-coef 0.03`. Expect it to matter, since the movement head has been
-    # measured sitting at 98.6% of maximum entropy after 945 epochs.
-    ent_coef: float = 0.75
+    # 0.03 is measured, not assumed. Two 30-epoch arms differing in nothing
+    # else: at 0.75 movement entropy stayed flat at 4.52 and the agent won 0%
+    # of episodes; at 0.03 it fell 4.52 -> 3.95 and win rate reached ~55%.
+    ent_coef: float = 0.03
     max_grad_norm: float = 0.5  # Gradient Stabilization (prevent exploding gradients)
     n_epochs: int = 5
     n_steps: int = 2048

--- a/wargame_rl/wargame/model/ppo/config.py
+++ b/wargame_rl/wargame/model/ppo/config.py
@@ -9,16 +9,25 @@ class PPOConfig(BaseModel):
     # Training parameters
     batch_size: int = 128
     lr: float = 3e-4
-    # 0.9^40 = 0.015, so under the old default a terminal bonus was worth 0.044
-    # at t=0 and the effective horizon was ~10 steps of a 40-step episode --
-    # while the decisions that matter here (which objective a squad walks to)
-    # pay off 20-35 steps later. With a hard 40-step cap, 1/(1-0.99) = 100 is
-    # effectively undiscounted, the standard choice for an episodic task.
+    # 0.9, kept because it was measured -- twice now, against the theory.
     #
-    # The earlier "0.99 is worse" finding is retracted as unmeasured: it was
-    # taken under a training loop that never applied the reward being tuned.
-    # Re-tested as the first screen arm.
-    gamma: float = 0.99
+    # The theoretical case for 0.99 is real: 0.9^40 = 0.015, so a terminal
+    # bonus is worth 0.044 at t=0 and the effective horizon is ~10 steps of a
+    # 40-step episode, while squad-assignment decisions pay off 20-35 steps
+    # later. A hard 40-step cap makes 1/(1-0.99) = 100 effectively undiscounted.
+    #
+    # Measured anyway, two 100-epoch arms on 25v25_single_phase.yaml differing
+    # in nothing else, scored on 60 fresh held-out seeds:
+    #
+    #                win    player VP   opp VP   on objectives
+    #   gamma 0.99   0.97       121.2     41.1           0.697
+    #   gamma 0.90   0.95       147.4     33.6           0.907
+    #
+    # Win rate is saturated near the 1.00 ceiling and cannot separate them, but
+    # VP margin (+114 vs +80) and occupancy both favour 0.90 clearly. Retest if
+    # the reward's time structure changes -- the theoretical argument does not
+    # go away, it is simply outweighed here.
+    gamma: float = 0.9
     gae_lambda: float = 0.95  # 0.9 is quite low, 0.95 - 0.99 is common, above 0.99 is very future oriented
     # Controls bias–variance tradeoff in GAE (Generalized Advantage Estimation).
     # λ = 1 → Monte Carlo (low bias, high variance)

--- a/wargame_rl/wargame/model/ppo/lightning.py
+++ b/wargame_rl/wargame/model/ppo/lightning.py
@@ -785,3 +785,9 @@ class PPOLightning(WargameLightningBase):
 
     def _policy_model(self) -> PPOModel:
         return self.ppo_model
+
+    def _batch_greedy_actions(self, state_tensors: list[Tensor]) -> Tensor:
+        """Greedy per-model actions for a batch. The net masks internally."""
+        logits, _values = self.ppo_model(state_tensors)
+        actions: Tensor = logits.argmax(dim=-1)
+        return actions


### PR DESCRIPTION
## Why this PR exists

#129 was merged, but its changes never reached `main`.

#128 merged to `main` at 19:03:40. #129 merged at 19:05:21 — into `fix/per-model-credit-assignment`, its original base, which had already been merged away. GitHub only retargets a stacked PR when the base branch is deleted on merge; it was not, so #129 landed on a dead branch.

This PR is that branch, unchanged: `main` plus exactly the 12 commits of #129 (and #129's merge commit). No cherry-picking, no rewriting, no conflicts — the content is byte-identical to what already passed CI on #129.

**Why it matters:** `main` currently has #128's PPO machinery for per-model credit assignment but none of the reward terms that make it do anything. Only 3 of 8 calculators are per-model there, and both useful ones go silent once models arrive — the state the report calls "largely inert".

## What lands

| | |
|---|---|
| `objective_hold`, `model_kills` | the two per-model calculators |
| `25v25_single_phase.yaml`, `25v25_curriculum.yaml` | the control and the two-rung ladder |
| `squad_march_shoot` | the shooting baseline; raises the bar from 0.78 to 1.00 |
| batched evaluation | lockstep waves, 2.5x, results bit-identical |
| `measure-checkpoint` | scores a checkpoint through the baseline measurement path |
| trace-metric fixes | `mean_group_distance` and `oscillation_rate` were both wrong |
| `gamma` 0.99 -> 0.9 | reverted; measured, against the theory |
| `reports/2026-08-04-reward-calculation-changes.md` | what changed and what the evidence supports |

+2368 / −61 across 32 files.

## Results

Held-out scoring, 30 episodes, seeds 700 000–700 029, agent and baselines on identical layouts:

| policy | on obj | win | player VP | opp VP | VP margin |
|---|---|---|---|---|---|
| random | 0.017 | 0.00 | 14.5 | 173.0 | −158.5 |
| squad_march | 1.000 | 0.67 | 138.8 | 113.3 | 25.5 |
| **agent, single-phase** | 0.852 | **0.97** | 141.8 | 52.8 | 89.0 |
| **agent, ladder** | 0.887 | 0.93 | 161.7 | 59.5 | **102.2** |
| squad_march_shoot | 1.000 | **1.00** | 175.5 | 46.3 | 129.2 |

Win rate 0.17 → 0.93–0.97 against a 0.67 movement-only bar. **Confounded** with #128's mechanism fixes, which shipped alongside — no ablation isolates either. Two seeds say the curriculum makes no measurable difference over a single phase.

See #129 for the full write-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
