### PR TITLE
feat: add a scripted opponent that advances and shoots

### DIFF
--- a/docs/opponent-policies.md
+++ b/docs/opponent-policies.md
@@ -118,6 +118,26 @@ opponent_policy:
 
 **Use case:** Provides goal-directed opposition that competes for the same objectives as the player. Good for training agents that need to learn to reach objectives before the opponent does.
 
+**Note:** this policy never fires, even when its models carry weapons. Use `scripted_advance_and_shoot` for an opponent that shoots back.
+
+### `scripted_advance_and_shoot`
+
+Identical movement to `scripted_advance_to_objective`, which it subclasses. In each shooting phase every alive model fires at a uniformly random target drawn from the ones its action mask allows — alive, in weapon range, line of sight clear, and not locked in engagement range. A model with no valid target holds fire.
+
+```yaml
+opponent_policy:
+  type: scripted_advance_and_shoot
+  params: { cohesion_weight: 0.3 }   # optional, inherited from the movement policy
+```
+
+**Parameters:** `cohesion_weight` (default `0.3`), as for `scripted_advance_to_objective`.
+
+Target choice is uniform rather than nearest-first. Nearest-first would concentrate fire and make the opponent a sharper threat than "returns fire" warrants; uniform keeps it a plain two-sided-game fixture whose damage output is easy to reason about. Targets are drawn from `env.np_random`, so a seeded episode replays exactly.
+
+**Use case:** the only opponent that makes the game two-sided. Every other policy leaves the player facing an enemy that cannot answer, which is why the `squad_march_shoot` baseline scores 1.00 on 25v25 — a bar set against a defenceless opponent. **Adopting this policy in a config invalidates any baseline or agent score measured on it; re-run `just measure-baselines` before reading a result.**
+
+Requires the shooting phase to be active (`skip_phases` must not contain `shooting`) and `opponent_models` entries to carry `weapons`.
+
 ## Planned Policies (Not Yet Implemented)
 
 The following policies are designed in the architecture but raise `NotImplementedError` if used:
@@ -175,6 +195,12 @@ opponent_policy:
 
 The `select_action` method receives the list of opponent `WargameModel` instances, the full `WargameEnv`, and optionally `action_mask` (phase-aware valid actions), giving access to objectives, board dimensions, the action handler's `best_action_toward()` helper, and any other env state needed to compute actions.
 
+### Policies that shoot
+
+Set the class attribute `shoots = True` on any policy that emits shooting-slice actions. The env only refines that policy's action mask with range, line-of-sight and engagement-range validity when the flag is set, because doing so costs up to `n_opponent × n_player` line-of-sight walks per shooting phase and most policies never fire. Without the flag the mask allows any target and `_resolve_shooting_action` applies the shot unchecked — a policy could shoot through terrain from across the board.
+
+Given the flag, honouring `action_mask` is all a policy needs to do to play by the same rules the player does.
+
 ### Naming convention
 
 Scripted policies are prefixed with `Scripted` in the class name and `scripted_` in the registry key (e.g. `ScriptedFlankPolicy` / `"scripted_flank"`). This distinguishes hand-coded behaviour from learned or external policies.
@@ -203,6 +229,7 @@ wargame_rl/wargame/envs/opponent/
   registry.py                                   # Type-string -> class registry + factory
   random_policy.py                              # RandomPolicy
   scripted_advance_to_objective_policy.py        # ScriptedAdvanceToObjectivePolicy
+  scripted_advance_and_shoot_policy.py           # ScriptedAdvanceAndShootPolicy
 
 examples/env_config/with_opponents/
   4v4_random_opponent.yaml                      # 4v4 with random opponent

--- a/docs/shooting.md
+++ b/docs/shooting.md
@@ -64,6 +64,14 @@ The overlay is computed by `compute_shooting_masks()` (a pure function in `env_c
 
 If no targets are valid for a model, only `STAY_ACTION` remains — the model passes its shooting.
 
+### Both sides are masked
+
+The player's overlay is applied in `build_observation` (`env_components/observation_builder.py`); the opponent's is applied in `WargameEnv._opponent_action_mask`, with the sides swapped. `compute_shooting_masks` is positional despite its `player_`/`opponent_` parameter names, so the same function serves both.
+
+The opponent's overlay is built **only for policies that declare `shoots = True`** (see [opponent-policies.md](opponent-policies.md#policies-that-shoot)). It costs up to `n_opponent × n_player` line-of-sight walks per shooting phase, which is not worth paying for the movement-only policies that most configs run.
+
+This masking is the *only* enforcement of shooting legality. `_resolve_shooting_action` re-checks nothing beyond attacker-alive, target-alive and the action falling inside the shooting slice — it trusts the mask for both sides.
+
 ### Range Calculation
 
 Range uses Euclidean distance on the grid, consistent with the `DistanceCache`. A model's effective range is the **maximum** across all its weapons — a target is "in range" if any weapon can reach it.

--- a/tests/test_shooting_opponent.py
+++ b/tests/test_shooting_opponent.py
@@ -1,0 +1,202 @@
+"""Tests for the shooting opponent.
+
+Every other opponent policy is movement-only, so opponent models carry weapons
+they never fire and the player faces an enemy that cannot answer. These tests
+pin down the two halves of `scripted_advance_and_shoot`: that it fires at all,
+and that its shots obey the same range / line-of-sight / engagement rules the
+player's do — the env only started enforcing those for the opponent alongside
+this policy.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from wargame_rl.wargame.envs.domain.shooting import PairedShootingResult
+from wargame_rl.wargame.envs.opponent.registry import (
+    build_opponent_policy,
+    get_registry,
+)
+from wargame_rl.wargame.envs.opponent.scripted_advance_and_shoot_policy import (
+    ScriptedAdvanceAndShootPolicy,
+)
+from wargame_rl.wargame.envs.types import (
+    ModelConfig,
+    ObjectiveConfig,
+    OpponentPolicyConfig,
+    WargameEnvAction,
+    WargameEnvConfig,
+)
+from wargame_rl.wargame.envs.types.config import WeaponProfile
+from wargame_rl.wargame.envs.types.game_timing import BattlePhase
+from wargame_rl.wargame.envs.wargame import WargameEnv
+
+SHOOTING_POLICY = "scripted_advance_and_shoot"
+MOVEMENT_POLICY = "scripted_advance_to_objective"
+
+PLAYER_X = 10
+OPPONENT_X = 18
+WEAPON_RANGE = 12
+WALL_X = 14
+
+
+def _wall_at(column: int, width: int, height: int) -> list[list[bool]]:
+    """A full-height blocking column, as a `blocking_mask` grid (rows are y)."""
+    return [[x == column for x in range(width)] for _ in range(height)]
+
+
+def _make_env(
+    *,
+    policy: str = SHOOTING_POLICY,
+    armed: bool = True,
+    walled: bool = False,
+    objective: tuple[int, int] = (OPPONENT_X, 19),
+) -> WargameEnv:
+    """Opponents holding an objective, in weapon range of a stationary player.
+
+    By default the objective sits on top of the opponents so
+    `scripted_advance_to_objective` keeps them still: the geometry then stays
+    fixed for the whole episode, which is what lets the line-of-sight
+    assertions below read positions after the fact.
+    """
+    width, height = 40, 40
+    weapons = [WeaponProfile(range=WEAPON_RANGE, attacks=2)] if armed else []
+    config = WargameEnvConfig(
+        render_mode=None,
+        board_width=width,
+        board_height=height,
+        number_of_wargame_models=4,
+        number_of_opponent_models=4,
+        number_of_objectives=1,
+        objective_radius_size=3,
+        number_of_battle_rounds=4,
+        skip_phases=[BattlePhase.command, BattlePhase.charge, BattlePhase.fight],
+        models=[ModelConfig(x=PLAYER_X, y=18 + i, max_wounds=20) for i in range(4)],
+        opponent_models=[
+            ModelConfig(x=OPPONENT_X, y=18 + i, weapons=weapons) for i in range(4)
+        ],
+        objectives=[ObjectiveConfig(x=objective[0], y=objective[1])],
+        opponent_policy=OpponentPolicyConfig(type=policy),
+        blocking_mask=_wall_at(WALL_X, width, height) if walled else None,
+    )
+    return WargameEnv(config=config)
+
+
+def _run_episode(env: WargameEnv, seed: int = 42) -> list[PairedShootingResult]:
+    """Play a full episode with the player holding still; collect opponent shots."""
+    env.reset(seed=seed)
+    shots: list[PairedShootingResult] = []
+    terminated = truncated = False
+    while not (terminated or truncated):
+        stay = WargameEnvAction(actions=[0] * len(env.wargame_models))
+        _obs, _r, terminated, truncated, _info = env.step(stay)
+        shots.extend(env.last_opponent_shooting_results)
+    return shots
+
+
+def test_the_shooting_opponent_fires_and_the_movement_one_does_not() -> None:
+    """The gap this policy closes: armed opponents that never pulled a trigger."""
+    assert _run_episode(_make_env(policy=SHOOTING_POLICY)) != []
+    assert _run_episode(_make_env(policy=MOVEMENT_POLICY)) == []
+
+
+def test_the_shooting_opponent_inflicts_casualties() -> None:
+    """Firing has to change the game, not just appear in the results list."""
+    env = _make_env()
+    _run_episode(env)
+    total_wounds = sum(m.stats["current_wounds"] for m in env.wargame_models)
+    assert total_wounds < 4 * 20
+
+
+def test_every_shot_is_in_range_and_in_line_of_sight() -> None:
+    """Shots obey the rules the player's do — the mask is not decorative."""
+    env = _make_env()
+    shots = _run_episode(env)
+    assert shots != []
+
+    for shot in shots:
+        attacker = env.opponent_models[shot.attacker_idx]
+        target = env.wargame_models[shot.target_idx]
+        distance = float(
+            np.linalg.norm(
+                np.asarray(attacker.location, dtype=float)
+                - np.asarray(target.location, dtype=float)
+            )
+        )
+        assert distance <= WEAPON_RANGE
+        assert env.has_line_of_sight_between_cells(
+            int(attacker.location[0]),
+            int(attacker.location[1]),
+            int(target.location[0]),
+            int(target.location[1]),
+        )
+
+
+def test_a_wall_between_the_lines_stops_every_shot() -> None:
+    """Blocked line of sight means hold fire, not shoot through terrain.
+
+    This is the regression test for the opponent mask: before it was refined,
+    the same policy would have fired straight through the wall.
+    """
+    assert _run_episode(_make_env(walled=True)) == []
+    assert _run_episode(_make_env(walled=False)) != []
+
+
+def test_unarmed_opponents_hold_fire() -> None:
+    """No weapons means no valid targets, and no crash."""
+    assert _run_episode(_make_env(armed=False)) == []
+
+
+def test_movement_matches_the_policy_it_extends() -> None:
+    """Shooting is added to `scripted_advance_to_objective`, not swapped in.
+
+    The objective sits away from both lines so the opponents actually march;
+    with the default static setup this assertion would hold vacuously. The
+    opponents are unarmed so neither arm can end the episode early by wiping
+    the player out, which would make the two tracks differ in length rather
+    than in movement.
+    """
+
+    def opponent_track(policy: str) -> list[list[tuple[int, int]]]:
+        env = _make_env(policy=policy, armed=False, objective=(30, 30))
+        env.reset(seed=7)
+        track: list[list[tuple[int, int]]] = []
+        terminated = truncated = False
+        while not (terminated or truncated):
+            stay = WargameEnvAction(actions=[0] * len(env.wargame_models))
+            _obs, _r, terminated, truncated, _info = env.step(stay)
+            track.append(
+                [(int(m.location[0]), int(m.location[1])) for m in env.opponent_models]
+            )
+        return track
+
+    assert opponent_track(SHOOTING_POLICY) == opponent_track(MOVEMENT_POLICY)
+
+
+def test_target_choice_is_reproducible_for_a_seed() -> None:
+    """Targets come from `env.np_random`, so a seeded episode replays exactly."""
+
+    def targets(seed: int) -> list[tuple[int, int]]:
+        return [
+            (s.attacker_idx, s.target_idx) for s in _run_episode(_make_env(), seed=seed)
+        ]
+
+    assert targets(42) == targets(42)
+
+
+def test_registered_under_its_config_name() -> None:
+    """The YAML identifier resolves to the policy class."""
+    assert get_registry()[SHOOTING_POLICY] is ScriptedAdvanceAndShootPolicy
+    env = _make_env()
+    policy = build_opponent_policy(OpponentPolicyConfig(type=SHOOTING_POLICY), env)
+    assert isinstance(policy, ScriptedAdvanceAndShootPolicy)
+    assert policy.shoots is True
+
+
+@pytest.mark.parametrize("policy", [SHOOTING_POLICY, MOVEMENT_POLICY])
+def test_episode_completes_without_error(policy: str) -> None:
+    """Backward compatibility: both opponents drive a full episode."""
+    env = _make_env(policy=policy)
+    _run_episode(env)
+    assert env.current_turn > 0

--- a/wargame_rl/wargame/envs/CLAUDE.md
+++ b/wargame_rl/wargame/envs/CLAUDE.md
@@ -25,8 +25,10 @@ Applies to everything under `wargame_rl/wargame/envs/`.
 
 - Reuse `WargameModel`/`ModelConfig`; YAML keys: `number_of_opponent_models`, `opponent_models`, `turn_order`, `opponent_policy`
 - `TurnOrder`: `player`/`opponent`/`random`
-- Policies in `envs/opponent/`, registry: `RandomPolicy("random")`, `ScriptedAdvanceToObjectivePolicy("scripted_advance_to_objective")`
+- Policies in `envs/opponent/`, registry: `RandomPolicy("random")`, `ScriptedAdvanceToObjectivePolicy("scripted_advance_to_objective")`, `ScriptedAdvanceAndShootPolicy("scripted_advance_and_shoot")`
 - New policies: one class per behaviour, `Scripted` prefix, register as `"scripted_<name>"`; implement `select_action(opponent_models, env, action_mask=None)`
+- A policy that fires must set `shoots = True`; only then does the env overlay range/LOS/engagement validity on its mask (`_opponent_action_mask`). Nothing downstream re-checks legality — see [docs/shooting.md](../../../docs/shooting.md)
+- Only `scripted_advance_and_shoot` shoots back. Switching a config to it invalidates every baseline and agent score measured on that config
 - `number_of_opponent_models=0` (default) → no policy, env unchanged
 
 ## Rendering

--- a/wargame_rl/wargame/envs/opponent/policy.py
+++ b/wargame_rl/wargame/envs/opponent/policy.py
@@ -17,6 +17,12 @@ if TYPE_CHECKING:
 class OpponentPolicy(ABC):
     """Selects actions for opponent models each turn."""
 
+    # Whether this policy ever emits shooting-slice actions. Refining the
+    # opponent's mask with range/LOS validity costs up to n_opponent x n_player
+    # line-of-sight walks per shooting phase, so the env only pays it for
+    # policies that can actually fire.
+    shoots: bool = False
+
     @abstractmethod
     def select_action(
         self,

--- a/wargame_rl/wargame/envs/opponent/random_policy.py
+++ b/wargame_rl/wargame/envs/opponent/random_policy.py
@@ -18,6 +18,10 @@ if TYPE_CHECKING:
 class RandomPolicy(OpponentPolicy):
     """Each opponent model picks a uniformly random action."""
 
+    # It samples from whatever mask it is handed, so it fires in the shooting
+    # phase and needs that mask to be a legal one.
+    shoots = True
+
     def __init__(self, env: WargameEnv, **kwargs: object) -> None:
         self._env = env
 

--- a/wargame_rl/wargame/envs/opponent/registry.py
+++ b/wargame_rl/wargame/envs/opponent/registry.py
@@ -38,6 +38,7 @@ def _auto_register() -> None:
     for mod in (
         "wargame_rl.wargame.envs.opponent.random_policy",
         "wargame_rl.wargame.envs.opponent.scripted_advance_to_objective_policy",
+        "wargame_rl.wargame.envs.opponent.scripted_advance_and_shoot_policy",
     ):
         importlib.import_module(mod)
 

--- a/wargame_rl/wargame/envs/opponent/scripted_advance_and_shoot_policy.py
+++ b/wargame_rl/wargame/envs/opponent/scripted_advance_and_shoot_policy.py
@@ -1,0 +1,83 @@
+"""Opponent policy: advance onto objectives, and shoot whenever a target is up."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from wargame_rl.wargame.envs.env_components.actions import STAY_ACTION
+from wargame_rl.wargame.envs.opponent.registry import register_policy
+from wargame_rl.wargame.envs.opponent.scripted_advance_to_objective_policy import (
+    ScriptedAdvanceToObjectivePolicy,
+)
+from wargame_rl.wargame.envs.types import WargameEnvAction
+from wargame_rl.wargame.envs.types.game_timing import BattlePhase
+
+if TYPE_CHECKING:
+    from wargame_rl.wargame.envs.wargame import WargameEnv
+    from wargame_rl.wargame.envs.wargame_model import WargameModel
+
+
+class ScriptedAdvanceAndShootPolicy(ScriptedAdvanceToObjectivePolicy):
+    """`scripted_advance_to_objective`, plus firing every shooting phase.
+
+    Every other opponent policy is movement-only, so opponent models carry
+    weapons they never fire and the player faces an enemy that cannot answer.
+    That is what makes the `squad_march_shoot` baseline's 1.00 win rate a
+    weaker bar than it looks.
+
+    Target choice is a uniform draw over the valid targets rather than
+    nearest-first. Nearest-first would concentrate fire and make the opponent a
+    sharper threat than "returns fire" warrants; uniform keeps it a plain
+    two-sided-game fixture whose damage output is easy to reason about.
+    """
+
+    # The env only refines this policy's mask with range/LOS validity because
+    # of this flag -- without it the shots below would be unchecked.
+    shoots = True
+
+    def select_action(
+        self,
+        opponent_models: list[WargameModel],
+        env: WargameEnv,
+        action_mask: np.ndarray | None = None,
+    ) -> WargameEnvAction:
+        """Shoot during the shooting phase, otherwise advance as the base does."""
+        if env.game_clock_state.phase is BattlePhase.shooting:
+            return self._select_shooting(opponent_models, env, action_mask)
+        return super().select_action(opponent_models, env, action_mask)
+
+    def _select_shooting(
+        self,
+        opponent_models: list[WargameModel],
+        env: WargameEnv,
+        action_mask: np.ndarray | None,
+    ) -> WargameEnvAction:
+        """Fire each model at a random valid target, or hold if it has none."""
+        actions = [STAY_ACTION] * len(opponent_models)
+        shooting_slice = env.opponent_action_handler.shooting_slice
+        if shooting_slice is None or action_mask is None or not env.wargame_models:
+            return WargameEnvAction(actions=actions)
+
+        for index, model in enumerate(opponent_models):
+            if not model.is_alive:
+                continue
+            # The env mask already encodes target-alive, range, line of sight
+            # and engagement-range validity, so honouring it is what keeps this
+            # opponent playing by the same rules as the player.
+            valid = np.flatnonzero(
+                action_mask[index, shooting_slice.start : shooting_slice.end]
+            )
+            if valid.size == 0:
+                continue
+            # env.np_random rather than the global RNG so a seeded episode
+            # replays identically -- the same generator the combat rolls and
+            # placement already derive from.
+            target = int(env.np_random.choice(valid))
+            actions[index] = shooting_slice.start + target
+
+        return WargameEnvAction(actions=actions)
+
+
+register_policy("scripted_advance_and_shoot", ScriptedAdvanceAndShootPolicy)

--- a/wargame_rl/wargame/envs/wargame.py
+++ b/wargame_rl/wargame/envs/wargame.py
@@ -21,6 +21,7 @@ from wargame_rl.wargame.envs.domain.game_clock import GameClock
 from wargame_rl.wargame.envs.domain.los import has_line_of_sight, iter_los_cells
 from wargame_rl.wargame.envs.domain.placement import place_for_episode
 from wargame_rl.wargame.envs.domain.shooting import (
+    ENGAGEMENT_RANGE,
     DefenderStats,
     PairedShootingResult,
     ShootingResult,
@@ -40,6 +41,10 @@ from wargame_rl.wargame.envs.env_components import (
     compute_distances,
 )
 from wargame_rl.wargame.envs.env_components.actions import ActionSlice
+from wargame_rl.wargame.envs.env_components.shooting_masks import (
+    compute_shooting_masks,
+    max_weapon_ranges,
+)
 from wargame_rl.wargame.envs.mission import build_vp_calculator
 from wargame_rl.wargame.envs.opponent.policy import OpponentPolicy
 from wargame_rl.wargame.envs.opponent.registry import (
@@ -213,9 +218,24 @@ class WargameEnv(gym.Env):
         return self._action_handler
 
     @property
+    def opponent_action_handler(self) -> ActionHandler:
+        """Action handler for the opponent's models (used by opponent policies)."""
+        return self._opponent_action_handler
+
+    @property
     def state_exporters(self) -> list[StateExporter]:
         """Exporters recording this env's steps (empty when not recording)."""
         return list(self._state_exporters)
+
+    @property
+    def last_player_shooting_results(self) -> list[PairedShootingResult]:
+        """Shots the player resolved during the most recent step."""
+        return list(self._last_player_shooting_results)
+
+    @property
+    def last_opponent_shooting_results(self) -> list[PairedShootingResult]:
+        """Shots the opponent resolved during the most recent step."""
+        return list(self._last_opponent_shooting_results)
 
     @property
     def opponent_action_space(self) -> spaces.Tuple:
@@ -469,14 +489,51 @@ class WargameEnv(gym.Env):
                 phase=phase,
             )
 
+    def _opponent_action_mask(
+        self, phase: BattlePhase, opp_alive: np.ndarray
+    ) -> np.ndarray:
+        """Legal actions per opponent model, shooting targets included.
+
+        Mirrors the player's mask in `build_observation`, with the sides
+        swapped: the opponent's shots are held to the same range, line-of-sight
+        and engagement-range rules the player's are. Without this the opponent's
+        mask is phase-and-alive only, and any shooting action it emits is
+        applied unchecked by `_resolve_shooting_action`.
+        """
+        handler = self._opponent_action_handler
+        mask = handler.registry.get_model_action_masks(
+            phase, len(self.opponent_models), alive_mask=opp_alive
+        )
+        shooting_slice = handler.shooting_slice
+        if (
+            phase != BattlePhase.shooting
+            or shooting_slice is None
+            or not self.wargame_models
+            or self._opponent_policy is None
+            or not self._opponent_policy.shoots
+        ):
+            return mask
+
+        mask[:, shooting_slice.start : shooting_slice.end] &= compute_shooting_masks(
+            np.array([m.location for m in self.opponent_models]),
+            np.array([m.location for m in self.wargame_models]),
+            opp_alive,
+            alive_mask_for(self.wargame_models),
+            max_weapon_ranges(self.config.opponent_models, len(self.opponent_models)),
+            self.has_line_of_sight_between_cells,
+            player_advanced=np.array(
+                [m.advanced_this_turn for m in self.opponent_models]
+            ),
+            engagement_range=float(ENGAGEMENT_RANGE),
+        )
+        return mask
+
     def _apply_opponent_action(self) -> None:
         if self._opponent_policy is None or not self.opponent_models:
             return
         phase = self._game_clock.state.phase or BattlePhase.movement
         opp_alive = alive_mask_for(self.opponent_models)
-        opp_mask = self._opponent_action_handler.registry.get_model_action_masks(
-            phase, len(self.opponent_models), alive_mask=opp_alive
-        )
+        opp_mask = self._opponent_action_mask(phase, opp_alive)
         opp_action = self._opponent_policy.select_action(
             self.opponent_models, self, action_mask=opp_mask
         )


### PR DESCRIPTION
ScriptedAdvanceAndShootPolicy moves exactly as scripted_advance_to_objective
and fires at a uniformly random valid target each shooting phase. Every
other opponent policy is movement-only, so opponent models carried weapons
they never fired -- which is why squad_march_shoot scored 1.00 on 25v25,
a bar set against an enemy that could not answer.

Shooting legality was only ever enforced in the player's observation
builder. The opponent's mask is now refined the same way in
WargameEnv._opponent_action_mask, gated on a new OpponentPolicy.shoots
flag so movement-only policies do not pay for the LOS walks. This also
stops a random opponent shooting through terrain from across the board.

No config changes: adopting the new opponent invalidates every baseline
measured on that config. Measured on 25 seeds of 25v25_single_phase,
switching opponents drops squad_march 0.80 -> 0.24 win and
squad_march_shoot 1.00 -> 0.60.
