### PR TITLE
refactor: prepare the env for continuous space

### DIFF
--- a/docs/ddd-envs.md
+++ b/docs/ddd-envs.md
@@ -40,7 +40,8 @@ wargame_rl/wargame/envs/
 ├── state/                     # Snapshots, event log, replay, narration, analysis
 ├── reward/                    # Reward phases, calculators, criteria (use BattleView)
 ├── renders/                   # Pygame etc. (use BattleView)
-├── types/                     # Config, observation/info types, game timing types
+├── types/                     # Shared kernel: config, observation/info types,
+│                              #   game timing, and geometry (see below)
 └── wargame.py                 # WargameEnv: facade that implements BattleView
 ```
 
@@ -76,7 +77,7 @@ The env calls these; it does not reimplement their logic.
 ### Adding a new entity type
 
 1. **Define the entity** in `domain/entities.py` (or a new file under `domain/` if you prefer). Follow the same pattern as `WargameModel` / `WargameObjective`: attributes, `reset_for_episode` if it has episode state, and optionally a `to_space()` for the Gym observation space if the env needs it.
-2. **Add config** in `types/config.py` (e.g. number of X, list of X configs, deployment). Keep new fields optional or default so existing YAML stays valid.
+2. **Add config** in `types/config/` — `entities.py` for a per-entity model, `terrain.py` for terrain, `battle.py` for turn order / opponent / mission, `env.py` for a scenario-level field. Keep new fields optional or default so existing YAML stays valid. `__init__.py` re-exports everything, so importers use `types.config` either way.
 3. **Wire the factory**: in `domain/battle_factory.py`, create instances from config and attach them to the `Battle` (e.g. new list + property). If the aggregate must expose them for observation or rules, add them to `Battle` and to `BattleView`.
 4. **Observation**: if the new entity appears in the Gym observation, extend the observation types in `types/`, then in `env_components/observation_builder.py` add the mapping from `view` to that part of the observation (using `BattleView` so the builder stays view-based).
 5. **Backward compatibility**: if something used to live at envs root, keep a thin re-export from there that imports from `domain`.
@@ -113,8 +114,34 @@ Action space and phase-aware masking live in `env_components/actions.py` (Action
 
 ## Dependency direction
 
-- **Domain** → types (config, game timing). Domain does not import env_components, reward, or renders.
+- **Domain** → types (config, game timing, geometry). Domain does not import env_components, reward, or renders.
 - **Env** → domain, env_components, reward, renders, types. The env is the only place that ties them together.
 - **Reward / Renders** → `BattleView`, types. They do not import the env class or the aggregate; they receive a view.
 
 This keeps the domain stable and testable in isolation, and makes it clear where to add new behaviour (domain vs adapters vs env wiring).
+
+### `types/` is the shared kernel, not just a bag of DTOs
+
+The name undersells it. `types/` is the one package everything else may depend
+on, and it holds value objects with real behaviour, not only data shapes.
+
+**Geometry belongs in `types/`, as `types/geometry.py`.** This is forced rather
+than chosen: `config` has to *validate* shapes — that a polygon is well formed,
+that a terrain piece is not thinner than the line-of-sight sample step — so it
+needs the geometry type, and `types/` cannot import `domain/` without inverting
+the direction above. Putting `Polygon` in `domain/` and importing it from config
+would invert it; a prototype tried exactly that and had to move the module.
+
+The alternative considered was a standalone dependency-free `geometry/` package
+that both `types/` and `domain/` import. It states the intent more clearly and
+costs one directory. It was not taken because `types/` already plays this role —
+`game_timing` exports `BattlePhase` and phase-ordering constants that the domain
+depends on for correctness, not merely for typing — so a second shared-kernel
+package would split the same concept in two. Revisit if `types/` grows a
+dependency that geometry should not inherit.
+
+Positions are the counter-example worth knowing: `Position`, `POSITION_DTYPE`
+and the constructors live in `domain/value_objects.py`, not in `types/`, because
+nothing in `config` builds one. Config carries plain `x`/`y` integers and
+placement turns them into positions. Keep it that way — the whole point of the
+single dtype declaration is that it has one home.

--- a/docs/ddd-envs.md
+++ b/docs/ddd-envs.md
@@ -27,7 +27,8 @@ wargame_rl/wargame/envs/
 │   ├── game_clock.py          # Turn/phase/round logic
 │   ├── placement.py           # place_for_episode, placement helpers
 │   ├── termination.py         # is_battle_over, check_max_turns_reached
-│   ├── los.py                 # Grid Bresenham LOS, injectable blocking (terrain)
+│   ├── los.py                 # Grid Bresenham ray + injectable blocking predicate
+│   ├── sight.py               # "Can A see B?": los + terrain + blocking_mask
 │   ├── terrain.py             # Footprint, Terrain (LOS-blocking geometry)
 │   ├── terrain_placement.py   # generate_terrain: random per-episode layouts
 │   ├── shooting.py            # Attack sequence: hit → wound → save → damage
@@ -64,7 +65,8 @@ wargame_rl/wargame/envs/
 - **GameClock**: advance setup/battle phases, rounds, turns; `is_game_over`.
 - **termination**: `is_battle_over(clock, current_turn, max_turns, success_flag, all_eliminated=False)`.
 - **los / terrain**: Bresenham LOS with an injectable blocking predicate; `Terrain` supplies the footprints that block a given query.
-- **shooting**: `resolve_shooting(weapon, defender, rng)` and `expected_damage`, plus `wound_roll_threshold`.
+- **sight**: `has_line_of_sight_between_cells` composes the two — the Bresenham ray, the terrain footprints that contain neither endpoint (the see-out rule), and the static `blocking_mask`. Kept apart from `los.py` so the geometry primitive stays free of game rules, and so the question "can A see B?" has one home when it gains continuous coordinates and a three-state answer for cover.
+- **shooting**: `resolve_shooting(weapon, defender, rng)` and `expected_damage`, plus `wound_roll_threshold`. `resolve_shooting_phase` resolves a whole phase from already-decoded `(attacker_idx, target_idx)` shots — decoding the action tuple is the adapter's job (`ActionHandler.decode_shooting_targets`), because the action-space slice lives in `env_components/`.
 - **turn_execution**: `run_until_player_phase`, `run_after_player_action` (skip phases, run opponent turn, advance clock).
 
 The env calls these; it does not reimplement their logic.

--- a/docs/game-state-io.md
+++ b/docs/game-state-io.md
@@ -32,6 +32,7 @@ reward/     renders/     state/         env_components/
 wargame_rl/wargame/envs/state/
 ├── __init__.py         # Public API re-exports
 ├── snapshot.py         # GameStateSnapshot model, build_snapshot(), validation, SnapshotEncoder
+├── restore.py          # The read direction: rebuild clock, models, objectives, combat results
 ├── events.py           # StateDelta, ResetEvent, StepEvent, compute_delta(), apply_delta()
 ├── event_log.py        # EventLog: append-only accumulator with anchor snapshots
 ├── exporter.py         # StateExporter protocol, EventLogExporter

--- a/docs/opponent-policies.md
+++ b/docs/opponent-policies.md
@@ -204,7 +204,7 @@ The `select_action` method receives the list of opponent `WargameModel` instance
 
 ### Policies that shoot
 
-Set the class attribute `shoots = True` on any policy that emits shooting-slice actions. The env only refines that policy's action mask with range, line-of-sight and engagement-range validity when the flag is set, because doing so costs up to `n_opponent × n_player` line-of-sight walks per shooting phase and most policies never fire. Without the flag the mask allows any target and `_resolve_shooting_action` applies the shot unchecked — a policy could shoot through terrain from across the board.
+Set the class attribute `shoots = True` on any policy that emits shooting-slice actions. The env only refines that policy's action mask with range, line-of-sight and engagement-range validity when the flag is set, because doing so costs up to `n_opponent × n_player` line-of-sight walks per shooting phase and most policies never fire. Without the flag the mask allows any target and `domain.shooting.resolve_shooting_phase` applies the shot unchecked — a policy could shoot through terrain from across the board.
 
 Given the flag, honouring `action_mask` is all a policy needs to do to play by the same rules the player does.
 

--- a/docs/shooting.md
+++ b/docs/shooting.md
@@ -72,7 +72,7 @@ The player's overlay is applied in `build_observation` (`env_components/observat
 
 The opponent's overlay is built **only for policies that declare `shoots = True`** (see [opponent-policies.md](opponent-policies.md#policies-that-shoot)). It costs up to `n_opponent × n_player` line-of-sight walks per shooting phase, which is not worth paying for the movement-only policies that most configs run.
 
-This masking is the *only* enforcement of shooting legality. `_resolve_shooting_action` re-checks nothing beyond attacker-alive, target-alive, the attacker carrying at least one weapon, and the action falling inside the shooting slice — it trusts the mask for both sides.
+This masking is the *only* enforcement of shooting legality. Resolution re-checks nothing beyond the action falling inside the shooting slice (`ActionHandler.decode_shooting_targets`) and then attacker-alive, target-alive and the attacker carrying at least one weapon (`domain.shooting.resolve_shooting_phase`) — it trusts the mask for both sides.
 
 ### Range Calculation
 
@@ -84,7 +84,7 @@ max_range = max(w.range for w in model_config.weapons)
 
 Models with no weapons (`weapons: []`) have max range 0 and cannot shoot anyone.
 
-Note the asymmetry with resolution: masking uses the *longest*-ranged weapon, while `_resolve_shooting_action` always fires `weapons[0]`. For a multi-weapon model that makes targets between the first weapon's range and the longest weapon's range selectable but resolved with the wrong profile. Single-weapon models — every current config — are unaffected. Multi-weapon targeting is listed under Future Extensions below.
+Note the asymmetry with resolution: masking uses the *longest*-ranged weapon, while `resolve_shooting_phase` always fires `weapons[0]`. For a multi-weapon model that makes targets between the first weapon's range and the longest weapon's range selectable but resolved with the wrong profile. Single-weapon models — every current config — are unaffected. Multi-weapon targeting is listed under Future Extensions below.
 
 ### Line of Sight
 
@@ -131,7 +131,9 @@ else:
 
 ## Shooting Resolution
 
-`_resolve_shooting_action` runs the full attack sequence per firing model via `resolve_shooting(weapon, defender, rng)` in `domain/shooting.py`:
+`_resolve_shooting_action` is a two-line composition: `ActionHandler.decode_shooting_targets` reads the action tuple into `(attacker_idx, target_idx)` pairs, then `domain.shooting.resolve_shooting_phase` filters and resolves them. The decode is action-space knowledge and the filtering is a rule, which is why they sit either side of the domain boundary.
+
+`resolve_shooting_phase` runs the full attack sequence per firing model via `resolve_shooting(weapon, defender, rng)` in the same module:
 
 1. **Hit** — roll `attacks` D6; a roll ≥ `ballistic_skill` hits, unmodified 6 always hits, unmodified 1 always misses.
 2. **Wound** — one D6 per hit against `wound_roll_threshold(strength, toughness)` (same 1-always-fails / 6-always-succeeds rule).

--- a/docs/terrain.md
+++ b/docs/terrain.md
@@ -242,7 +242,7 @@ For a query from cell `(x0, y0)` to cell `(x1, y1)`:
    - The cell is contained by any active footprint.
 3. Endpoint order is canonicalised (`sorted([(x0,y0),(x1,y1)])`) before the call to `has_line_of_sight`, guaranteeing **symmetry**: `has_los(A, B) == has_los(B, A)`.
 
-The Bresenham core in `domain/los.py` is **untouched** — all terrain logic lives in the seam layer (`wargame.py`) and the domain model (`terrain.py`).
+The Bresenham core in `domain/los.py` is **untouched** — it takes an injectable predicate and knows nothing about terrain. Steps 1–3 above are `domain/sight.py`, which composes that primitive with the domain model (`terrain.py`) and the static mask. `WargameEnv.has_line_of_sight_between_cells` is a one-line delegation to it.
 
 ### See-Into / See-Out Rules
 

--- a/scripts/measure_throughput.py
+++ b/scripts/measure_throughput.py
@@ -32,6 +32,7 @@ from typing import Any
 import numpy as np
 from pydantic_yaml import parse_yaml_raw_as
 
+from wargame_rl.wargame.envs.domain import sight
 from wargame_rl.wargame.envs.types import WargameEnvAction, WargameEnvConfig
 from wargame_rl.wargame.envs.wargame import WargameEnv
 
@@ -62,16 +63,19 @@ class _Timings:
         setattr(owner, method, timed)
 
 
-def _instrument_line_of_sight(env: WargameEnv, timings: _Timings) -> None:
+def _instrument_line_of_sight(timings: _Timings) -> None:
     """Time whole LOS queries, not just the predicate's construction.
 
-    `_make_is_blocking` returns a closure that is then called once per cell along
-    the Bresenham line, so timing the factory alone would miss almost all of the
-    cost. Wrapping the returned closure as well makes "line of sight" the real
-    per-query total, and its call count is `los_queries_per_step` — the number
-    that says whether the quadratic LOS scan is worth optimising yet.
+    `blocking_predicate_for_query` returns a closure that is then called once per
+    cell along the Bresenham line, so timing the factory alone would miss almost
+    all of the cost. Wrapping the returned closure as well makes "line of sight"
+    the real per-query total, and its call count is `los_queries_per_step` — the
+    number that says whether the quadratic LOS scan is worth optimising yet.
+
+    Patched on the `sight` module rather than on the env, because the resolver
+    looks the factory up by module-global name at call time.
     """
-    original = env._make_is_blocking
+    original = sight.blocking_predicate_for_query
 
     def timed_factory(*args: Any, **kwargs: Any) -> Any:
         start = time.perf_counter()
@@ -88,7 +92,7 @@ def _instrument_line_of_sight(env: WargameEnv, timings: _Timings) -> None:
 
         return timed_predicate
 
-    env._make_is_blocking = timed_factory  # type: ignore[method-assign]
+    sight.blocking_predicate_for_query = timed_factory  # type: ignore[assignment]
 
 
 def _instrument(env: WargameEnv, timings: _Timings) -> None:
@@ -100,7 +104,7 @@ def _instrument(env: WargameEnv, timings: _Timings) -> None:
     timings.wrap(env.phase_manager, "calculate_reward", "reward")
     timings.wrap(env, "_get_obs", "observation build")
     timings.wrap(env, "_apply_opponent_action", "opponent turn")
-    _instrument_line_of_sight(env, timings)
+    _instrument_line_of_sight(timings)
 
     for phase in env.phase_manager.phases:
         calculators = list(phase.per_model_calculators) + list(phase.global_calculators)

--- a/tests/test_shooting_resolution.py
+++ b/tests/test_shooting_resolution.py
@@ -18,6 +18,7 @@ from wargame_rl.wargame.envs.domain.shooting import (
     expected_damage,
     expected_damage_matrix,
     resolve_shooting,
+    resolve_shooting_phase,
     wound_roll_threshold,
 )
 from wargame_rl.wargame.envs.env_components.actions import STAY_ACTION
@@ -255,6 +256,100 @@ class TestResolveShooting:
 
     def test_engagement_range_constant(self) -> None:
         assert ENGAGEMENT_RANGE == 1
+
+
+# ---------------------------------------------------------------------------
+# Whole-phase resolution
+# ---------------------------------------------------------------------------
+
+
+class TestResolveShootingPhase:
+    """The phase-level service, exercised without building a Gym env.
+
+    That it can be tested this way at all is the point of it living in the
+    domain: the attack sequence used to be a private method on `WargameEnv`,
+    so reaching it meant constructing a board, a clock and an action space.
+    """
+
+    def _weapons(self, count: int) -> list[list[_TestWeapon]]:
+        return [[_TestWeapon()] for _ in range(count)]
+
+    def test_a_dead_attacker_does_not_fire(self) -> None:
+        attackers = [_make_model(), _make_model()]
+        targets = [_make_model(max_wounds=10)]
+        attackers[0].take_damage(1)
+
+        results = resolve_shooting_phase(
+            shots=[(0, 0), (1, 0)],
+            attackers=attackers,
+            targets=targets,
+            attacker_weapons=self._weapons(2),
+            rng=np.random.default_rng(0),
+        )
+
+        assert [r.attacker_idx for r in results] == [1]
+
+    def test_a_dead_target_cannot_be_fired_at(self) -> None:
+        attackers = [_make_model()]
+        targets = [_make_model()]
+        targets[0].take_damage(1)
+
+        results = resolve_shooting_phase(
+            shots=[(0, 0)],
+            attackers=attackers,
+            targets=targets,
+            attacker_weapons=self._weapons(1),
+            rng=np.random.default_rng(0),
+        )
+
+        assert results == []
+
+    def test_an_unarmed_attacker_does_not_consume_dice(self) -> None:
+        """No weapon means no roll, so the next shooter gets the first dice.
+
+        Order of RNG consumption is the property that makes a refactor of this
+        function safe to compare bit-for-bit against the previous one.
+        """
+        attackers = [_make_model(), _make_model()]
+        targets = [_make_model(max_wounds=10)]
+
+        armed_second = resolve_shooting_phase(
+            shots=[(0, 0), (1, 0)],
+            attackers=attackers,
+            targets=targets,
+            attacker_weapons=[[], [_TestWeapon()]],
+            rng=np.random.default_rng(7),
+        )
+
+        targets = [_make_model(max_wounds=10)]
+        alone = resolve_shooting_phase(
+            shots=[(1, 0)],
+            attackers=attackers,
+            targets=targets,
+            attacker_weapons=[[], [_TestWeapon()]],
+            rng=np.random.default_rng(7),
+        )
+
+        assert [r.result for r in armed_second] == [r.result for r in alone]
+
+    def test_kill_is_attributed_to_the_shot_that_landed_it(self) -> None:
+        """`killed` cannot be recovered afterwards when several shots share a target."""
+        attackers = [_make_model() for _ in range(6)]
+        targets = [_make_model(max_wounds=1, save=7)]
+
+        results = resolve_shooting_phase(
+            shots=[(i, 0) for i in range(6)],
+            attackers=attackers,
+            targets=targets,
+            attacker_weapons=self._weapons(6),
+            rng=np.random.default_rng(3),
+        )
+
+        assert not targets[0].is_alive
+        # Exactly one shot may claim the kill, and it is the last one resolved:
+        # every later shot is filtered out by the dead-target check.
+        assert sum(r.killed for r in results) == 1
+        assert results[-1].killed
 
 
 # ---------------------------------------------------------------------------

--- a/wargame_rl/wargame/envs/CLAUDE.md
+++ b/wargame_rl/wargame/envs/CLAUDE.md
@@ -58,7 +58,7 @@ Applies to everything under `wargame_rl/wargame/envs/`.
 
 ## Adding Features
 
-1. Config → `WargameEnvConfig` in `types/`
+1. Config → `types/config/` (`entities.py` per-entity, `terrain.py` terrain, `battle.py` turn order/opponent/mission, `env.py` scenario-level). `__init__.py` re-exports, so importers still use `types.config`
 2. Logic → `env_components/`
 3. Obs → `env_observation.py`/`env_info.py` + obs builder
 4. Tensor → `model/common/observation.py`
@@ -67,7 +67,8 @@ Applies to everything under `wargame_rl/wargame/envs/`.
 
 ## Design
 
-- Integer locations; pre-compute expensive ops at `__init__` (numpy vectorized)
+- Integer locations, built through `position()` / `zero_position()` from `domain/value_objects.py` — never a literal `dtype=np.int32`. `POSITION_DTYPE` is the single declaration, so making the board continuous is one edit rather than a hunt; a missed site would truncate silently with no exception and no failing test. (Known drift documented there: a position is int32 from placement and int64 once it has moved, because the displacement table is int64 and numpy promotes.)
+- Pre-compute expensive ops at `__init__` (numpy vectorized)
 - Track rendering state (e.g. `previous_location`) in same change
 - New entities mirror existing patterns; always backward compatible
 - Follow [docs/ddd-envs.md](../../../docs/ddd-envs.md): keep domain logic in `domain/`, use `BattleView` for read-only state, and preserve dependency direction (domain → types only; reward/renders → BattleView)

--- a/wargame_rl/wargame/envs/domain/__init__.py
+++ b/wargame_rl/wargame/envs/domain/__init__.py
@@ -19,6 +19,7 @@ from wargame_rl.wargame.envs.domain.shooting import (
     WeaponStats,
     expected_damage,
     resolve_shooting,
+    resolve_shooting_phase,
     wound_roll_threshold,
 )
 from wargame_rl.wargame.envs.domain.termination import (
@@ -57,5 +58,6 @@ __all__ = [
     "WeaponStats",
     "expected_damage",
     "resolve_shooting",
+    "resolve_shooting_phase",
     "wound_roll_threshold",
 ]

--- a/wargame_rl/wargame/envs/domain/__init__.py
+++ b/wargame_rl/wargame/envs/domain/__init__.py
@@ -22,6 +22,10 @@ from wargame_rl.wargame.envs.domain.shooting import (
     resolve_shooting_phase,
     wound_roll_threshold,
 )
+from wargame_rl.wargame.envs.domain.sight import (
+    blocking_predicate_for_query,
+    has_line_of_sight_between_cells,
+)
 from wargame_rl.wargame.envs.domain.termination import (
     check_max_turns_reached,
     is_battle_over,
@@ -37,6 +41,8 @@ __all__ = [
     "BoardDimensions",
     "BattleView",
     "has_line_of_sight",
+    "blocking_predicate_for_query",
+    "has_line_of_sight_between_cells",
     "iter_los_cells",
     "WargameModel",
     "WargameObjective",

--- a/wargame_rl/wargame/envs/domain/battle.py
+++ b/wargame_rl/wargame/envs/domain/battle.py
@@ -112,6 +112,31 @@ class Battle:
         self._player_vp_delta = 0
         self._opponent_vp_delta = 0
 
+    def restore_victory_points(
+        self,
+        *,
+        player_vp: int,
+        opponent_vp: int,
+        player_vp_delta: int,
+        opponent_vp_delta: int,
+    ) -> None:
+        """Set victory points outright, for restoring a snapshot.
+
+        Distinct from `add_player_vp` because loading a state is not scoring:
+        the totals are known and must land exactly, not accumulate onto
+        whatever the aggregate happened to hold.
+
+        The deltas are restored rather than zeroed. `player_vp_delta` is a
+        feature of the observation the policy acts on, so zeroing it would make
+        a loaded state disagree with the live state it was captured from and
+        round-trip to a different snapshot. Both are always in the snapshot, so
+        there is nothing to reconstruct.
+        """
+        self._player_vp = player_vp
+        self._opponent_vp = opponent_vp
+        self._player_vp_delta = player_vp_delta
+        self._opponent_vp_delta = opponent_vp_delta
+
     def reset_for_episode(self) -> None:
         """Clear episode state on all models before new placement."""
         self._player_vp = 0

--- a/wargame_rl/wargame/envs/domain/battle_factory.py
+++ b/wargame_rl/wargame/envs/domain/battle_factory.py
@@ -11,7 +11,7 @@ from wargame_rl.wargame.envs.types import WargameEnvConfig
 from .battle import Battle
 from .entities import WargameModel, WargameObjective
 from .terrain import Footprint, Terrain
-from .value_objects import BoardDimensions, DeploymentZone
+from .value_objects import BoardDimensions, DeploymentZone, zero_position
 
 
 def _build_models(
@@ -37,7 +37,7 @@ def _build_models(
             save = 4
         result.append(
             WargameModel(
-                location=np.zeros(2, dtype=int),
+                location=zero_position(),
                 stats={
                     "max_wounds": max_wounds,
                     "current_wounds": max_wounds,
@@ -65,7 +65,7 @@ def _build_objectives(config: WargameEnvConfig) -> list[WargameObjective]:
 
         result.append(
             WargameObjective(
-                location=np.zeros(2, dtype=int),
+                location=zero_position(),
                 radius_size=radius,  # type: ignore[arg-type]
             )
         )

--- a/wargame_rl/wargame/envs/domain/entities.py
+++ b/wargame_rl/wargame/envs/domain/entities.py
@@ -7,6 +7,13 @@ from typing import TYPE_CHECKING
 import numpy as np
 from gymnasium import spaces
 
+from wargame_rl.wargame.envs.domain.value_objects import (
+    POSITION_DTYPE,
+    Position,
+    position,
+    zero_position,
+)
+
 if TYPE_CHECKING:
     from wargame_rl.wargame.envs.reward.types.model_rewards import ModelRewards
 
@@ -25,7 +32,7 @@ class WargameModel:
 
     def __init__(
         self,
-        location: np.ndarray,
+        location: Position,
         stats: dict[str, int],
         distances_to_objectives: np.ndarray,
         group_id: int,
@@ -33,7 +40,7 @@ class WargameModel:
         best_closest_objective_distance: float | None = None,
     ):
         self.location = location
-        self.previous_location: np.ndarray | None = None
+        self.previous_location: Position | None = None
         self.stats = stats
         self.distances_to_objectives = distances_to_objectives
         self.group_id = group_id
@@ -81,10 +88,10 @@ class WargameModel:
     ) -> spaces.Dict:
         """Gymnasium observation space for one model (used by the env facade)."""
         location_space = spaces.Box(
-            low=np.array([0, 0], dtype=np.int32),
-            high=np.array([board_width - 1, board_height - 1], dtype=np.int32),
+            low=zero_position(),
+            high=position(board_width - 1, board_height - 1),
             shape=(2,),
-            dtype=np.int32,
+            dtype=POSITION_DTYPE,
         )
         max_dx = max(board_width, board_height) - 1
         distances_to_objectives_space = spaces.Box(
@@ -127,8 +134,8 @@ def alive_mask_for(models: list[WargameModel]) -> np.ndarray:
 class WargameObjective:
     """Objective (capture target) on the board."""
 
-    def __init__(self, location: np.ndarray, radius_size: int):
-        self.location = location  # numpy array of shape (2,)
+    def __init__(self, location: Position, radius_size: int):
+        self.location = location
         self.radius_size = radius_size  # Radius of the objective in the environment
 
     def __repr__(self) -> str:
@@ -140,10 +147,10 @@ class WargameObjective:
         return spaces.Dict(
             {
                 "location": spaces.Box(
-                    low=np.array([0, 0], dtype=np.int32),
-                    high=np.array([board_width - 1, board_height - 1], dtype=np.int32),
+                    low=zero_position(),
+                    high=position(board_width - 1, board_height - 1),
                     shape=(2,),
-                    dtype=np.int32,
+                    dtype=POSITION_DTYPE,
                 )
             }
         )

--- a/wargame_rl/wargame/envs/domain/placement.py
+++ b/wargame_rl/wargame/envs/domain/placement.py
@@ -10,7 +10,12 @@ from wargame_rl.wargame.envs.domain.battle import Battle
 from wargame_rl.wargame.envs.domain.entities import WargameModel, WargameObjective
 from wargame_rl.wargame.envs.domain.terrain import Terrain
 from wargame_rl.wargame.envs.domain.terrain_placement import generate_terrain
-from wargame_rl.wargame.envs.domain.value_objects import BoardDimensions
+from wargame_rl.wargame.envs.domain.value_objects import (
+    BoardDimensions,
+    Position,
+    position,
+    zero_position,
+)
 from wargame_rl.wargame.envs.types.config import (
     ModelConfig,
     ObjectiveConfig,
@@ -122,7 +127,7 @@ def wargame_model_placement(
                     rng,
                 )
 
-            model.location = np.array(loc, dtype=np.int32)
+            model.location = position(*loc)
             model.reset_for_episode()
             occupied.add(loc)
             placed.append(model)
@@ -156,7 +161,7 @@ def objective_placement(
         if opponent_deployment_zone is not None
         else board_width
     )
-    placed: list[np.ndarray] = []
+    placed: list[Position] = []
     for objective in objectives:
         location = _sample_objective_location(
             x_min,
@@ -177,20 +182,19 @@ def _sample_objective_location(
     x_max: int,
     board_height: int,
     rng: Generator,
-    placed: list[np.ndarray],
+    placed: list[Position],
     min_separation: int | None,
     terrain: Terrain | None,
     terrain_clearance: int | None,
-) -> np.ndarray:
+) -> Position:
     """Draw one objective location satisfying the separation constraints."""
-    candidate = np.zeros(2, dtype=np.int32)
+    candidate = zero_position()
     for _ in range(_MAX_PLACEMENT_RETRIES):
-        candidate = np.array(
-            [
-                rng.integers(x_min, x_max, dtype=np.int32),
-                rng.integers(0, board_height, dtype=np.int32),
-            ],
-            dtype=np.int32,
+        # Each draw's dtype is part of the random stream rather than the storage
+        # format, so changing it changes which layouts a given seed produces.
+        candidate = position(
+            rng.integers(x_min, x_max, dtype=np.int32),
+            rng.integers(0, board_height, dtype=np.int32),
         )
         if min_separation is not None and any(
             float(np.linalg.norm(candidate - other)) < min_separation
@@ -230,7 +234,7 @@ def fixed_wargame_model_placement(
     """Place models at the exact positions specified in *model_configs*."""
     for model, cfg in zip(wargame_models, model_configs):
         assert cfg.x is not None and cfg.y is not None
-        model.location = np.array([cfg.x, cfg.y], dtype=np.int32)
+        model.location = position(cfg.x, cfg.y)
         model.reset_for_episode()
 
 
@@ -241,7 +245,7 @@ def fixed_objective_placement(
     """Place objectives at the exact positions specified in *objective_configs*."""
     for objective, cfg in zip(objectives, objective_configs):
         assert cfg.x is not None and cfg.y is not None
-        objective.location = np.array([cfg.x, cfg.y], dtype=np.int32)
+        objective.location = position(cfg.x, cfg.y)
 
 
 def place_for_episode(

--- a/wargame_rl/wargame/envs/domain/shooting.py
+++ b/wargame_rl/wargame/envs/domain/shooting.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 
 import numpy as np
+
+from wargame_rl.wargame.envs.domain.entities import WargameModel
 
 ENGAGEMENT_RANGE = 1  # grid-cell distance for engagement (v3.0 stub)
 
@@ -121,6 +124,69 @@ def resolve_shooting(
     return ShootingResult(
         hits=hits, wounds=wounds, unsaved=unsaved, damage_dealt=damage_dealt
     )
+
+
+def resolve_shooting_phase(
+    shots: Sequence[tuple[int, int]],
+    attackers: Sequence[WargameModel],
+    targets: Sequence[WargameModel],
+    attacker_weapons: Sequence[Sequence[WeaponStats]],
+    rng: np.random.Generator,
+) -> list[PairedShootingResult]:
+    """Resolve every shot declared this phase, applying damage to the targets.
+
+    Args:
+        shots: ``(attacker_idx, target_idx)`` pairs already decoded from the
+            action space. Decoding is the adapter's job; this function only
+            knows the rules.
+        attackers: Models on the firing side, indexed by ``attacker_idx``.
+        targets: Models on the receiving side, indexed by ``target_idx``.
+        attacker_weapons: Weapon list per attacker, positionally aligned with
+            *attackers*. A shorter sequence, or an empty entry, means that
+            attacker cannot fire.
+        rng: Dice source. Consumed only for shots that pass every check, so the
+            random stream depends on how many shots resolve.
+
+    Returns:
+        One result per shot that actually resolved, in *shots* order.
+
+    A dead attacker does not fire and a dead target cannot be fired at, so both
+    are filtered here rather than by the caller — they are rules, not encoding.
+    """
+    results: list[PairedShootingResult] = []
+    for attacker_idx, target_idx in shots:
+        if not attackers[attacker_idx].is_alive:
+            continue
+        if target_idx >= len(targets) or not targets[target_idx].is_alive:
+            continue
+        weapons = (
+            attacker_weapons[attacker_idx]
+            if attacker_idx < len(attacker_weapons)
+            else ()
+        )
+        if not weapons:
+            continue
+        target = targets[target_idx]
+        defender = DefenderStats(
+            toughness=target.stats["toughness"],
+            save=target.stats["save"],
+        )
+        result = resolve_shooting(weapons[0], defender, rng)
+        killed = False
+        if result.damage_dealt > 0:
+            target.take_damage(result.damage_dealt)
+            # The target was alive at the check above, so a dead target here
+            # means this shot made the kill.
+            killed = not target.is_alive
+        results.append(
+            PairedShootingResult(
+                attacker_idx=attacker_idx,
+                target_idx=target_idx,
+                result=result,
+                killed=killed,
+            )
+        )
+    return results
 
 
 def expected_damage(

--- a/wargame_rl/wargame/envs/domain/sight.py
+++ b/wargame_rl/wargame/envs/domain/sight.py
@@ -1,0 +1,83 @@
+"""Whether one cell can see another: what blocks sight, composed with how it is traced.
+
+This is deliberately separate from `los.py`. That module is the geometry
+primitive — a Bresenham ray and an injectable predicate — and knows nothing
+about terrain or the game's blocking rules. This module is the *answer*, built
+by handing that primitive the two things that actually block a shot: the static
+`blocking_mask` from config, and the terrain footprints that do not contain
+either endpoint.
+
+Keeping the composition here rather than on the env facade gives the question
+"can A see B?" a single home in the domain. It is also the seam that changes
+most when the board stops being a grid: continuous coordinates, a three-state
+answer for cover, and endpoints that carry a base radius all land on these two
+functions rather than on every caller.
+
+Terrain is read at call time, never cached. `Battle.set_terrain` replaces the
+layout between episodes and a cache here would need invalidating; the footprint
+scan is cheap next to the ray.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from wargame_rl.wargame.envs.domain.los import has_line_of_sight
+from wargame_rl.wargame.envs.domain.terrain import Terrain
+
+BlockingMask = list[list[bool]]
+
+
+def blocking_predicate_for_query(
+    x0: int,
+    y0: int,
+    x1: int,
+    y1: int,
+    terrain: Terrain,
+    blocking_mask: BlockingMask | None,
+) -> Callable[[int, int], bool]:
+    """Build the per-query predicate: is this cell opaque for *this* sight line?
+
+    Terrain is filtered per query rather than globally, because a piece
+    containing either endpoint does not block — a model can see out of the ruin
+    it stands in, and can be seen when standing in one. The static
+    `blocking_mask` is opaque matter and gets no such exemption.
+    """
+    active = terrain.blocking_footprints_for_endpoints(x0, y0, x1, y1)
+
+    def is_blocking(x: int, y: int) -> bool:
+        if blocking_mask is not None and blocking_mask[y][x]:
+            return True
+        return any(footprint.contains(x, y) for footprint in active)
+
+    return is_blocking
+
+
+def has_line_of_sight_between_cells(
+    x0: int,
+    y0: int,
+    x1: int,
+    y1: int,
+    board_width: int,
+    board_height: int,
+    terrain: Terrain,
+    blocking_mask: BlockingMask | None,
+) -> bool:
+    """True when sight is clear between two cells.
+
+    Endpoints are sorted into a canonical order first, which makes the answer
+    exactly symmetric: A sees B if and only if B sees A. Several metrics depend
+    on that — `firepower_ratio` reads an exposed model as one that can also
+    fire — and a Bresenham ray is not otherwise guaranteed to trace the same
+    cells in both directions.
+    """
+    (ax, ay), (bx, by) = sorted([(x0, y0), (x1, y1)])
+    return has_line_of_sight(
+        ax,
+        ay,
+        bx,
+        by,
+        board_width,
+        board_height,
+        blocking_predicate_for_query(ax, ay, bx, by, terrain, blocking_mask),
+    )

--- a/wargame_rl/wargame/envs/domain/value_objects.py
+++ b/wargame_rl/wargame/envs/domain/value_objects.py
@@ -3,8 +3,38 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Final, SupportsFloat, TypeAlias
 
 import numpy as np
+import numpy.typing as npt
+
+# The one place the coordinate type is declared. Board coordinates are whole
+# cells, matching the dtype the Gym observation space advertises in
+# `entities.to_space`. Every position is built through `position` or
+# `zero_position` so that making the board continuous is a change to this
+# constant rather than a hunt through the codebase -- assigning a float array
+# into an int one truncates *silently*, with no exception and no failing test,
+# so a missed site would be invisible.
+#
+# Known drift, deliberately left alone: a position is int32 when placement
+# builds it and int64 once it has moved, because the displacement table in
+# `env_components/actions.py` is int64 and numpy promotes. Values are
+# unaffected (coordinates are small) and the observation is float downstream.
+# Fixing it belongs with the change that makes displacements exact, not here.
+POSITION_DTYPE: Final = np.int32
+
+# A board coordinate pair, shape (2,).
+Position: TypeAlias = npt.NDArray[np.int32]
+
+
+def position(x: SupportsFloat, y: SupportsFloat) -> Position:
+    """Build a board coordinate from an x and a y."""
+    return np.array([x, y], dtype=POSITION_DTYPE)
+
+
+def zero_position() -> Position:
+    """Build the origin coordinate, for entities not yet placed."""
+    return np.zeros(2, dtype=POSITION_DTYPE)
 
 
 @dataclass(frozen=True, slots=True)

--- a/wargame_rl/wargame/envs/env_components/actions.py
+++ b/wargame_rl/wargame/envs/env_components/actions.py
@@ -185,6 +185,28 @@ class ActionHandler:
         """Shooting action slice, or None when no shoot targets are registered."""
         return self._shooting_slice
 
+    def decode_shooting_targets(
+        self, action: WargameEnvAction, n_attackers: int
+    ) -> list[tuple[int, int]]:
+        """Read the action tuple as ``(attacker_idx, target_idx)`` shot declarations.
+
+        Only the action *encoding* is interpreted here: entries outside the
+        shooting slice are not shots, and entries past the end of the army have
+        no attacker. Whether a declared shot can actually resolve — the attacker
+        is alive, the target is alive, the model carries a weapon — is a rule,
+        and belongs to `domain.shooting.resolve_shooting_phase`.
+
+        Returns an empty list when this handler registered no shooting slice.
+        """
+        if self._shooting_slice is None:
+            return []
+        start, end = self._shooting_slice.start, self._shooting_slice.end
+        return [
+            (i, act - start)
+            for i, act in enumerate(action.actions)
+            if i < n_attackers and start <= act < end
+        ]
+
     @property
     def registry(self) -> ActionRegistry:
         return self._registry

--- a/wargame_rl/wargame/envs/env_components/exposure.py
+++ b/wargame_rl/wargame/envs/env_components/exposure.py
@@ -8,9 +8,13 @@ can see you, and in how far the army stays from the nearest ruin.
 
 from __future__ import annotations
 
+from collections.abc import Callable, Sequence
+
 import numpy as np
 
+from wargame_rl.wargame.envs.domain.entities import WargameModel, alive_mask_for
 from wargame_rl.wargame.envs.domain.terrain import Footprint
+from wargame_rl.wargame.envs.env_components.shooting_masks import compute_threat_counts
 
 
 def distances_to_nearest_footprint(
@@ -143,3 +147,46 @@ class ExposureTracker:
         if self._their_shooters == 0:
             return None
         return self._our_shooters / self._their_shooters
+
+
+def record_shooting_phase(
+    tracker: ExposureTracker,
+    player_models: Sequence[WargameModel],
+    opponent_models: Sequence[WargameModel],
+    opponent_alive: np.ndarray,
+    player_max_ranges: np.ndarray,
+    opponent_max_ranges: np.ndarray,
+    footprints: list[Footprint],
+    has_los_fn: Callable[[int, int, int, int], bool],
+) -> None:
+    """Sample both sides of the shooting exchange and feed *tracker*.
+
+    Deliberately ignores the engagement-range and advanced gating that the
+    opponent's action mask applies. A shooter in base contact cannot fire at
+    all, so counting that as safety would score a headlong charge as if it were
+    cover -- and cover is the thing being measured.
+
+    One scan yields every direction, so `firepower_ratio` costs nothing on top
+    of `exposure_rate`. Does nothing when either side has no one left alive:
+    there is no exchange to sample, and an empty one would drag the averages.
+    """
+    player_alive = alive_mask_for(list(player_models))
+    if not player_alive.any() or not opponent_alive.any():
+        return
+    player_positions = np.array([m.location for m in player_models])
+    threats = compute_threat_counts(
+        player_positions,
+        np.array([m.location for m in opponent_models]),
+        player_alive,
+        opponent_alive,
+        player_max_ranges,
+        opponent_max_ranges,
+        has_los_fn,
+    )
+    tracker.record(
+        exposed=threats.threat_to_player > 0,
+        alive=player_alive,
+        terrain_distances=distances_to_nearest_footprint(player_positions, footprints),
+        our_shooters=int((threats.player_can_shoot & player_alive).sum()),
+        their_shooters=int((threats.opponent_can_shoot & opponent_alive).sum()),
+    )

--- a/wargame_rl/wargame/envs/state/restore.py
+++ b/wargame_rl/wargame/envs/state/restore.py
@@ -1,0 +1,98 @@
+"""Rebuild live state from a snapshot: the read direction of `snapshot.py`.
+
+`build_snapshot` turns the board into a `GameStateSnapshot`; these functions
+turn one back. They are kept together with the schema rather than on the env
+because they are the half that changes whenever the schema does -- coordinates
+becoming floats, a base radius appearing on every model, a version bump -- and
+a schema change should be one module's problem.
+
+Everything here mutates the objects it is handed. Restoring is not building:
+the entities already exist with their configured stats, and only the parts a
+snapshot actually carries are overwritten.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from wargame_rl.wargame.envs.domain.entities import WargameModel, WargameObjective
+from wargame_rl.wargame.envs.domain.game_clock import GameClock
+from wargame_rl.wargame.envs.domain.shooting import PairedShootingResult, ShootingResult
+from wargame_rl.wargame.envs.domain.value_objects import position
+from wargame_rl.wargame.envs.state.snapshot import (
+    ClockSnapshot,
+    CombatResultSnapshot,
+    ModelSnapshot,
+    ObjectiveSnapshot,
+)
+from wargame_rl.wargame.envs.types.game_timing import BattlePhase, GamePhase, PlayerSide
+
+
+def restore_clock(clock: GameClock, snapshot: ClockSnapshot, total_steps: int) -> None:
+    """Move *clock* to the timing position the snapshot recorded."""
+    clock.set_state(
+        GamePhase(snapshot.game_phase),
+        battle_round=snapshot.battle_round,
+        active_player=(
+            PlayerSide(snapshot.active_player) if snapshot.active_player else None
+        ),
+        phase=BattlePhase(snapshot.battle_phase) if snapshot.battle_phase else None,
+        total_steps=total_steps,
+    )
+
+
+def restore_models(
+    models: Sequence[WargameModel], snapshots: Sequence[ModelSnapshot]
+) -> None:
+    """Restore position, wounds and turn flags for each model.
+
+    Reward-shaping memory (previous/best objective distance, the per-model
+    reward history) is *cleared* rather than restored: none of it is in the
+    snapshot, and carrying stale values over would shape the next step against
+    distances from a different episode.
+    """
+    for model, snapshot in zip(models, snapshots):
+        model.location = position(*snapshot.location)
+        model.previous_location = (
+            position(*snapshot.previous_location)
+            if snapshot.previous_location is not None
+            else None
+        )
+        model.stats["current_wounds"] = snapshot.current_wounds
+        model.advanced_this_turn = snapshot.advanced_this_turn
+        model.previous_closest_objective_distance = None
+        model.best_closest_objective_distance = None
+        model.model_rewards_history.clear()
+
+
+def restore_objectives(
+    objectives: Sequence[WargameObjective], snapshots: Sequence[ObjectiveSnapshot]
+) -> None:
+    """Restore each objective's position. Radius is configuration, not state."""
+    for objective, snapshot in zip(objectives, snapshots):
+        objective.location = position(*snapshot.location)
+
+
+def restore_shooting_results(
+    snapshots: Sequence[CombatResultSnapshot],
+) -> list[PairedShootingResult]:
+    """Rebuild the last phase's shooting results from the snapshot.
+
+    `killed` is not carried by the schema and defaults to False, so these are
+    stubs: they replay what was rolled, not who died of it. Nothing downstream
+    of a restore reads the flag -- it is consumed by the reward calculators in
+    the step that produced it.
+    """
+    return [
+        PairedShootingResult(
+            attacker_idx=snapshot.attacker_idx,
+            target_idx=snapshot.target_idx,
+            result=ShootingResult(
+                hits=snapshot.hits,
+                wounds=snapshot.wounds,
+                unsaved=snapshot.unsaved,
+                damage_dealt=snapshot.damage_dealt,
+            ),
+        )
+        for snapshot in snapshots
+    ]

--- a/wargame_rl/wargame/envs/types/config/__init__.py
+++ b/wargame_rl/wargame/envs/types/config/__init__.py
@@ -1,0 +1,45 @@
+"""Environment configuration models.
+
+Split into modules by what they configure, but re-exported here in full: this
+was one 667-line module and roughly 30 call sites import from
+`...envs.types.config` directly, so the package boundary is deliberately
+invisible to them.
+
+- `battle`    — turn order, opponent policy, mission
+- `entities`  — weapon profiles, models, objectives
+- `terrain`   — fixed pieces, named maps, the random generator
+- `env`       — `WargameEnvConfig`, which composes all of the above
+- `_validation` — the checks the models share
+
+The dependency runs one way: `env` imports the rest, and nothing imports `env`.
+"""
+
+from wargame_rl.wargame.envs.types.config.battle import (
+    MissionConfig,
+    OpponentPolicyConfig,
+    TurnOrder,
+)
+from wargame_rl.wargame.envs.types.config.entities import (
+    ModelConfig,
+    ObjectiveConfig,
+    WeaponProfile,
+)
+from wargame_rl.wargame.envs.types.config.env import WargameEnvConfig
+from wargame_rl.wargame.envs.types.config.terrain import (
+    RandomTerrainConfig,
+    TerrainMapConfig,
+    TerrainPieceConfig,
+)
+
+__all__ = [
+    "MissionConfig",
+    "ModelConfig",
+    "ObjectiveConfig",
+    "OpponentPolicyConfig",
+    "RandomTerrainConfig",
+    "TerrainMapConfig",
+    "TerrainPieceConfig",
+    "TurnOrder",
+    "WargameEnvConfig",
+    "WeaponProfile",
+]

--- a/wargame_rl/wargame/envs/types/config/_validation.py
+++ b/wargame_rl/wargame/envs/types/config/_validation.py
@@ -1,0 +1,68 @@
+"""Shared validation helpers for the config models.
+
+Private to `types.config`: these are the checks the models reuse, kept out of
+the model modules so that none of them has to import another for a helper.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, TypeVar
+
+
+class _HasCoords(Protocol):
+    x: int | None
+    y: int | None
+
+
+_CoordsT = TypeVar("_CoordsT", bound=_HasCoords)
+
+
+def _validate_coords_both_or_neither(x: int | None, y: int | None) -> None:
+    """Raise if exactly one of x, y is None."""
+    if (x is None) != (y is None):
+        raise ValueError("x and y must both be set or both be None")
+
+
+def _validate_entity_configs(
+    count: int,
+    configs: list[_CoordsT] | None,
+    board_width: int,
+    board_height: int,
+    entity_name: str,
+) -> None:
+    """Validate entity list length, all-or-none coords, and in-bounds for fixed positions."""
+    if configs is None:
+        return
+    if len(configs) != count:
+        raise ValueError(
+            f"{entity_name} has {len(configs)} entries but expected {count}"
+        )
+    has_coords = [c.x is not None for c in configs]
+    if any(has_coords) and not all(has_coords):
+        raise ValueError(f"Either all {entity_name} must have x/y coordinates or none")
+    for i, c in enumerate(configs):
+        if (
+            c.x is not None
+            and c.y is not None
+            and (c.x >= board_width or c.y >= board_height)
+        ):
+            raise ValueError(
+                f"{entity_name}[{i}] ({c.x}, {c.y}) is outside "
+                f"the board ({board_width}x{board_height})"
+            )
+
+
+def _normalise_rect(r: tuple[int, int, int, int]) -> tuple[int, int, int, int]:
+    x0, y0, x1, y1 = r
+    return (min(x0, x1), min(y0, y1), max(x0, x1), max(y0, y1))
+
+
+# Rejection sampling for random terrain slows sharply as the board fills, so
+# layouts are rejected at config load well before that point.
+_MAX_TERRAIN_PACKING_FRACTION = 0.5
+
+
+def _rects_overlap(a: tuple[int, int, int, int], b: tuple[int, int, int, int]) -> bool:
+    ax0, ay0, ax1, ay1 = a
+    bx0, by0, bx1, by1 = b
+    return ax0 <= bx1 and bx0 <= ax1 and ay0 <= by1 and by0 <= ay1

--- a/wargame_rl/wargame/envs/types/config/battle.py
+++ b/wargame_rl/wargame/envs/types/config/battle.py
@@ -1,0 +1,41 @@
+"""Turn order, opponent policy and mission selection."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class TurnOrder(str, Enum):
+    """Who moves first each turn."""
+
+    player = "player"
+    opponent = "opponent"
+    random = "random"
+
+
+class OpponentPolicyConfig(BaseModel):
+    """Configuration for the opponent policy engine."""
+
+    type: str = Field(
+        description="Policy engine identifier, e.g. 'random', 'scripted_advance_to_objective'."
+    )
+    params: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Policy-specific parameters forwarded to the policy constructor.",
+    )
+
+
+class MissionConfig(BaseModel):
+    """Configuration for the mission (victory point scoring rules)."""
+
+    type: str = Field(
+        default="default",
+        description="Mission type identifier; selects the VP calculator (e.g. 'default', 'none').",
+    )
+    params: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Mission-specific parameters (e.g. vp_per_objective, cap_per_turn, min_round).",
+    )

--- a/wargame_rl/wargame/envs/types/config/entities.py
+++ b/wargame_rl/wargame/envs/types/config/entities.py
@@ -1,0 +1,96 @@
+"""Per-entity configuration: weapon profiles, models and objectives."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, model_validator
+
+from wargame_rl.wargame.envs.types.config._validation import (
+    _validate_coords_both_or_neither,
+)
+
+
+class WeaponProfile(BaseModel):
+    """Weapon stat block with range and resolution stats."""
+
+    range: int = Field(gt=0, description="Maximum range in grid cells")
+    attacks: int = Field(
+        default=2, gt=0, description="Number of hit rolls per shooting action"
+    )
+    ballistic_skill: int = Field(
+        default=3, ge=2, le=6, description="D6 roll needed to hit (e.g. 3 means 3+)"
+    )
+    strength: int = Field(
+        default=4, gt=0, description="For wound roll comparison vs target toughness"
+    )
+    ap: int = Field(
+        default=1,
+        ge=0,
+        description="Armour penetration (worsens target save by this amount)",
+    )
+    damage: int = Field(default=1, gt=0, description="Wounds inflicted per failed save")
+
+
+class ModelConfig(BaseModel):
+    """Per-model configuration (position, group, stats, etc.).
+
+    When *x* and *y* are provided the model is placed at that exact cell;
+    otherwise it is placed randomly in the deployment zone.
+    """
+
+    x: int | None = Field(
+        default=None,
+        ge=0,
+        description="X coordinate on the board. If None, placed randomly.",
+    )
+    y: int | None = Field(
+        default=None,
+        ge=0,
+        description="Y coordinate on the board. If None, placed randomly.",
+    )
+    group_id: int = Field(default=0, ge=0, description="Group this model belongs to")
+    max_wounds: int = Field(default=1, gt=0)
+    toughness: int = Field(default=3, gt=0, description="Wound roll comparison stat")
+    save: int = Field(
+        default=4,
+        ge=2,
+        le=7,
+        description="Base armour save (e.g. 4 means 4+, 7 means no armour)",
+    )
+    weapons: list[WeaponProfile] = Field(
+        default_factory=list,
+        description="Weapon profiles. Empty = cannot shoot.",
+    )
+
+    @model_validator(mode="after")
+    def coords_both_or_neither(self) -> "ModelConfig":
+        _validate_coords_both_or_neither(self.x, self.y)
+        return self
+
+
+class ObjectiveConfig(BaseModel):
+    """Per-objective configuration (position, radius, etc.).
+
+    When *x* and *y* are provided the objective is placed at that exact cell;
+    otherwise it is placed randomly outside the deployment zone.
+    """
+
+    x: int | None = Field(
+        default=None,
+        ge=0,
+        description="X coordinate on the board. If None, placed randomly.",
+    )
+    y: int | None = Field(
+        default=None,
+        ge=0,
+        description="Y coordinate on the board. If None, placed randomly.",
+    )
+    radius_size: int | None = Field(
+        default=None,
+        gt=0,
+        description="Override the global objective_radius_size for this objective",
+    )
+
+    @model_validator(mode="after")
+    def coords_both_or_neither(self) -> "ObjectiveConfig":
+        _validate_coords_both_or_neither(self.x, self.y)
+        return self

--- a/wargame_rl/wargame/envs/types/config/env.py
+++ b/wargame_rl/wargame/envs/types/config/env.py
@@ -1,7 +1,6 @@
-from __future__ import annotations
+"""The environment configuration: the whole scenario in one model."""
 
-from enum import Enum
-from typing import Any, Protocol, TypeVar
+from __future__ import annotations
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -10,260 +9,23 @@ from wargame_rl.wargame.envs.reward.phase import (
     RewardPhaseConfig,
     SuccessCriteriaConfig,
 )
+from wargame_rl.wargame.envs.types.config._validation import (
+    _MAX_TERRAIN_PACKING_FRACTION,
+    _normalise_rect,
+    _rects_overlap,
+    _validate_entity_configs,
+)
+from wargame_rl.wargame.envs.types.config.battle import (
+    MissionConfig,
+    OpponentPolicyConfig,
+    TurnOrder,
+)
+from wargame_rl.wargame.envs.types.config.entities import ModelConfig, ObjectiveConfig
+from wargame_rl.wargame.envs.types.config.terrain import (
+    RandomTerrainConfig,
+    TerrainPieceConfig,
+)
 from wargame_rl.wargame.envs.types.game_timing import NON_MOVEMENT_PHASES, BattlePhase
-
-
-class _HasCoords(Protocol):
-    x: int | None
-    y: int | None
-
-
-_CoordsT = TypeVar("_CoordsT", bound=_HasCoords)
-
-
-def _validate_coords_both_or_neither(x: int | None, y: int | None) -> None:
-    """Raise if exactly one of x, y is None."""
-    if (x is None) != (y is None):
-        raise ValueError("x and y must both be set or both be None")
-
-
-def _validate_entity_configs(
-    count: int,
-    configs: list[_CoordsT] | None,
-    board_width: int,
-    board_height: int,
-    entity_name: str,
-) -> None:
-    """Validate entity list length, all-or-none coords, and in-bounds for fixed positions."""
-    if configs is None:
-        return
-    if len(configs) != count:
-        raise ValueError(
-            f"{entity_name} has {len(configs)} entries but expected {count}"
-        )
-    has_coords = [c.x is not None for c in configs]
-    if any(has_coords) and not all(has_coords):
-        raise ValueError(f"Either all {entity_name} must have x/y coordinates or none")
-    for i, c in enumerate(configs):
-        if (
-            c.x is not None
-            and c.y is not None
-            and (c.x >= board_width or c.y >= board_height)
-        ):
-            raise ValueError(
-                f"{entity_name}[{i}] ({c.x}, {c.y}) is outside "
-                f"the board ({board_width}x{board_height})"
-            )
-
-
-def _normalise_rect(r: tuple[int, int, int, int]) -> tuple[int, int, int, int]:
-    x0, y0, x1, y1 = r
-    return (min(x0, x1), min(y0, y1), max(x0, x1), max(y0, y1))
-
-
-# Rejection sampling for random terrain slows sharply as the board fills, so
-# layouts are rejected at config load well before that point.
-_MAX_TERRAIN_PACKING_FRACTION = 0.5
-
-
-def _rects_overlap(a: tuple[int, int, int, int], b: tuple[int, int, int, int]) -> bool:
-    ax0, ay0, ax1, ay1 = a
-    bx0, by0, bx1, by1 = b
-    return ax0 <= bx1 and bx0 <= ax1 and ay0 <= by1 and by0 <= ay1
-
-
-class TurnOrder(str, Enum):
-    """Who moves first each turn."""
-
-    player = "player"
-    opponent = "opponent"
-    random = "random"
-
-
-class OpponentPolicyConfig(BaseModel):
-    """Configuration for the opponent policy engine."""
-
-    type: str = Field(
-        description="Policy engine identifier, e.g. 'random', 'scripted_advance_to_objective'."
-    )
-    params: dict[str, Any] = Field(
-        default_factory=dict,
-        description="Policy-specific parameters forwarded to the policy constructor.",
-    )
-
-
-class MissionConfig(BaseModel):
-    """Configuration for the mission (victory point scoring rules)."""
-
-    type: str = Field(
-        default="default",
-        description="Mission type identifier; selects the VP calculator (e.g. 'default', 'none').",
-    )
-    params: dict[str, Any] = Field(
-        default_factory=dict,
-        description="Mission-specific parameters (e.g. vp_per_objective, cap_per_turn, min_round).",
-    )
-
-
-class WeaponProfile(BaseModel):
-    """Weapon stat block with range and resolution stats."""
-
-    range: int = Field(gt=0, description="Maximum range in grid cells")
-    attacks: int = Field(
-        default=2, gt=0, description="Number of hit rolls per shooting action"
-    )
-    ballistic_skill: int = Field(
-        default=3, ge=2, le=6, description="D6 roll needed to hit (e.g. 3 means 3+)"
-    )
-    strength: int = Field(
-        default=4, gt=0, description="For wound roll comparison vs target toughness"
-    )
-    ap: int = Field(
-        default=1,
-        ge=0,
-        description="Armour penetration (worsens target save by this amount)",
-    )
-    damage: int = Field(default=1, gt=0, description="Wounds inflicted per failed save")
-
-
-class ModelConfig(BaseModel):
-    """Per-model configuration (position, group, stats, etc.).
-
-    When *x* and *y* are provided the model is placed at that exact cell;
-    otherwise it is placed randomly in the deployment zone.
-    """
-
-    x: int | None = Field(
-        default=None,
-        ge=0,
-        description="X coordinate on the board. If None, placed randomly.",
-    )
-    y: int | None = Field(
-        default=None,
-        ge=0,
-        description="Y coordinate on the board. If None, placed randomly.",
-    )
-    group_id: int = Field(default=0, ge=0, description="Group this model belongs to")
-    max_wounds: int = Field(default=1, gt=0)
-    toughness: int = Field(default=3, gt=0, description="Wound roll comparison stat")
-    save: int = Field(
-        default=4,
-        ge=2,
-        le=7,
-        description="Base armour save (e.g. 4 means 4+, 7 means no armour)",
-    )
-    weapons: list[WeaponProfile] = Field(
-        default_factory=list,
-        description="Weapon profiles. Empty = cannot shoot.",
-    )
-
-    @model_validator(mode="after")
-    def coords_both_or_neither(self) -> "ModelConfig":
-        _validate_coords_both_or_neither(self.x, self.y)
-        return self
-
-
-class TerrainPieceConfig(BaseModel):
-    """Configuration for a single terrain piece (axis-aligned rectangle)."""
-
-    footprint: tuple[int, int, int, int] = Field(
-        description="Bounding rectangle (x0, y0, x1, y1) in grid cells."
-    )
-
-
-class TerrainMapConfig(BaseModel):
-    """A named fixed terrain layout, stored on its own in `configs/evaluation/maps/`.
-
-    Kept out of `WargameEnvConfig` deliberately. A map is meant to be swapped
-    onto an *existing* scenario — `just measure-maps` overrides `terrain` on the
-    golden config once per map — so that final evaluation runs the same reward,
-    opponent and force composition the agent was trained under. A config per map
-    would duplicate a 13 KB scenario N times and let evaluation drift from
-    training the first time a reward term changed.
-    """
-
-    name: str = Field(description="Map identifier, used as the row label.")
-    terrain: list[TerrainPieceConfig] = Field(
-        description="The layout's pieces. Replaces the scenario's own terrain."
-    )
-
-
-class RandomTerrainConfig(BaseModel):
-    """Regenerate terrain footprints randomly at the start of every episode.
-
-    The piece *count* is fixed while size and position vary. This is a hard
-    constraint, not a simplification: `observations_to_tensor_batch` stacks the
-    terrain arrays of a whole batch with `np.stack`, so a batch containing
-    episodes with different piece counts cannot be collated.
-
-    Randomising terrain is what makes a cover result falsifiable. With a fixed
-    layout a policy can memorise a handful of rectangles; with a fresh layout
-    every episode it has to read the terrain tokens in the observation.
-    """
-
-    count: int = Field(
-        gt=0,
-        default=7,
-        description="Number of terrain pieces. Constant across episodes.",
-    )
-    min_size: int = Field(
-        gt=0, default=5, description="Minimum footprint side length in cells."
-    )
-    max_size: int = Field(
-        gt=0, default=7, description="Maximum footprint side length in cells."
-    )
-    mirror: bool = Field(
-        default=True,
-        description="Mirror the layout across the vertical centre line. Deployment "
-        "zones are fixed to the left and right of the board, so an asymmetric "
-        "random layout would systematically favour one side.",
-    )
-    edge_margin: int = Field(
-        ge=0, default=2, description="Keep footprints this far from the board edge."
-    )
-    min_gap: int = Field(
-        ge=0,
-        default=1,
-        description="Minimum clear cells between two footprints. 0 lets them touch.",
-    )
-
-    @model_validator(mode="after")
-    def sizes_ordered(self) -> "RandomTerrainConfig":
-        """Reject an inverted size range."""
-        if self.min_size > self.max_size:
-            raise ValueError(
-                f"min_size ({self.min_size}) must not exceed max_size ({self.max_size})"
-            )
-        return self
-
-
-class ObjectiveConfig(BaseModel):
-    """Per-objective configuration (position, radius, etc.).
-
-    When *x* and *y* are provided the objective is placed at that exact cell;
-    otherwise it is placed randomly outside the deployment zone.
-    """
-
-    x: int | None = Field(
-        default=None,
-        ge=0,
-        description="X coordinate on the board. If None, placed randomly.",
-    )
-    y: int | None = Field(
-        default=None,
-        ge=0,
-        description="Y coordinate on the board. If None, placed randomly.",
-    )
-    radius_size: int | None = Field(
-        default=None,
-        gt=0,
-        description="Override the global objective_radius_size for this objective",
-    )
-
-    @model_validator(mode="after")
-    def coords_both_or_neither(self) -> "ObjectiveConfig":
-        _validate_coords_both_or_neither(self.x, self.y)
-        return self
 
 
 def _default_reward_phases() -> list[RewardPhaseConfig]:

--- a/wargame_rl/wargame/envs/types/config/terrain.py
+++ b/wargame_rl/wargame/envs/types/config/terrain.py
@@ -1,0 +1,79 @@
+"""Terrain configuration: fixed pieces, named maps and the random generator."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class TerrainPieceConfig(BaseModel):
+    """Configuration for a single terrain piece (axis-aligned rectangle)."""
+
+    footprint: tuple[int, int, int, int] = Field(
+        description="Bounding rectangle (x0, y0, x1, y1) in grid cells."
+    )
+
+
+class TerrainMapConfig(BaseModel):
+    """A named fixed terrain layout, stored on its own in `configs/evaluation/maps/`.
+
+    Kept out of `WargameEnvConfig` deliberately. A map is meant to be swapped
+    onto an *existing* scenario — `just measure-maps` overrides `terrain` on the
+    golden config once per map — so that final evaluation runs the same reward,
+    opponent and force composition the agent was trained under. A config per map
+    would duplicate a 13 KB scenario N times and let evaluation drift from
+    training the first time a reward term changed.
+    """
+
+    name: str = Field(description="Map identifier, used as the row label.")
+    terrain: list[TerrainPieceConfig] = Field(
+        description="The layout's pieces. Replaces the scenario's own terrain."
+    )
+
+
+class RandomTerrainConfig(BaseModel):
+    """Regenerate terrain footprints randomly at the start of every episode.
+
+    The piece *count* is fixed while size and position vary. This is a hard
+    constraint, not a simplification: `observations_to_tensor_batch` stacks the
+    terrain arrays of a whole batch with `np.stack`, so a batch containing
+    episodes with different piece counts cannot be collated.
+
+    Randomising terrain is what makes a cover result falsifiable. With a fixed
+    layout a policy can memorise a handful of rectangles; with a fresh layout
+    every episode it has to read the terrain tokens in the observation.
+    """
+
+    count: int = Field(
+        gt=0,
+        default=7,
+        description="Number of terrain pieces. Constant across episodes.",
+    )
+    min_size: int = Field(
+        gt=0, default=5, description="Minimum footprint side length in cells."
+    )
+    max_size: int = Field(
+        gt=0, default=7, description="Maximum footprint side length in cells."
+    )
+    mirror: bool = Field(
+        default=True,
+        description="Mirror the layout across the vertical centre line. Deployment "
+        "zones are fixed to the left and right of the board, so an asymmetric "
+        "random layout would systematically favour one side.",
+    )
+    edge_margin: int = Field(
+        ge=0, default=2, description="Keep footprints this far from the board edge."
+    )
+    min_gap: int = Field(
+        ge=0,
+        default=1,
+        description="Minimum clear cells between two footprints. 0 lets them touch.",
+    )
+
+    @model_validator(mode="after")
+    def sizes_ordered(self) -> "RandomTerrainConfig":
+        """Reject an inverted size range."""
+        if self.min_size > self.max_size:
+            raise ValueError(
+                f"min_size ({self.min_size}) must not exceed max_size ({self.max_size})"
+            )
+        return self

--- a/wargame_rl/wargame/envs/wargame.py
+++ b/wargame_rl/wargame/envs/wargame.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import Any
 
 import gymnasium as gym
@@ -18,13 +17,16 @@ from wargame_rl.wargame.envs.domain.battle_factory import (
 )
 from wargame_rl.wargame.envs.domain.entities import alive_mask_for
 from wargame_rl.wargame.envs.domain.game_clock import GameClock
-from wargame_rl.wargame.envs.domain.los import has_line_of_sight, iter_los_cells
+from wargame_rl.wargame.envs.domain.los import iter_los_cells
 from wargame_rl.wargame.envs.domain.placement import place_for_episode
 from wargame_rl.wargame.envs.domain.shooting import (
     ENGAGEMENT_RANGE,
     PairedShootingResult,
     ShootingResult,
     resolve_shooting_phase,
+)
+from wargame_rl.wargame.envs.domain.sight import (
+    has_line_of_sight_between_cells as resolve_line_of_sight,
 )
 from wargame_rl.wargame.envs.domain.termination import is_battle_over
 from wargame_rl.wargame.envs.domain.terrain import Terrain
@@ -327,34 +329,19 @@ class WargameEnv(gym.Env):
         """
         return self._exposure_tracker.firepower_ratio
 
-    def _make_is_blocking(
-        self, x0: int, y0: int, x1: int, y1: int
-    ) -> Callable[[int, int], bool]:
-        """Per-query blocking predicate: static blocking_mask OR membership of any
-        footprint that contains NEITHER endpoint (10e see-out / see-into rule)."""
-        mask = self.config.blocking_mask
-        active = self._battle.terrain.blocking_footprints_for_endpoints(x0, y0, x1, y1)
-
-        def is_blocking(x: int, y: int) -> bool:
-            if mask is not None and mask[y][x]:
-                return True
-            return any(fp.contains(x, y) for fp in active)
-
-        return is_blocking
-
     def has_line_of_sight_between_cells(
         self, x0: int, y0: int, x1: int, y1: int
     ) -> bool:
         """True if LOS is clear between two cells (symmetric: canonical ordering)."""
-        (ax, ay), (bx, by) = sorted([(x0, y0), (x1, y1)])
-        return has_line_of_sight(
-            ax,
-            ay,
-            bx,
-            by,
+        return resolve_line_of_sight(
+            x0,
+            y0,
+            x1,
+            y1,
             self.board_width,
             self.board_height,
-            self._make_is_blocking(ax, ay, bx, by),
+            self._battle.terrain,
+            self.config.blocking_mask,
         )
 
     def iter_los_cells_between_cells(

--- a/wargame_rl/wargame/envs/wargame.py
+++ b/wargame_rl/wargame/envs/wargame.py
@@ -44,11 +44,10 @@ from wargame_rl.wargame.envs.env_components import (
 )
 from wargame_rl.wargame.envs.env_components.exposure import (
     ExposureTracker,
-    distances_to_nearest_footprint,
+    record_shooting_phase,
 )
 from wargame_rl.wargame.envs.env_components.shooting_masks import (
     compute_shooting_masks,
-    compute_threat_counts,
     max_weapon_ranges,
 )
 from wargame_rl.wargame.envs.mission import build_vp_calculator
@@ -595,37 +594,16 @@ class WargameEnv(gym.Env):
         return mask
 
     def _record_exposure(self, opp_alive: np.ndarray) -> None:
-        """Sample both sides of the shooting exchange right now.
-
-        Deliberately ignores the engagement-range and advanced gating that
-        `_opponent_action_mask` applies. A shooter in base contact cannot fire at
-        all, so counting that as safety would score a headlong charge as if it
-        were cover — and cover is the thing being measured.
-
-        One scan yields every direction, so `firepower_ratio` costs nothing on
-        top of `exposure_rate`.
-        """
-        player_alive = alive_mask_for(self.wargame_models)
-        if not player_alive.any() or not opp_alive.any():
-            return
-        player_positions = np.array([m.location for m in self.wargame_models])
-        threats = compute_threat_counts(
-            player_positions,
-            np.array([m.location for m in self.opponent_models]),
-            player_alive,
+        """Sample both sides of the shooting exchange into the exposure tracker."""
+        record_shooting_phase(
+            self._exposure_tracker,
+            self.wargame_models,
+            self.opponent_models,
             opp_alive,
             self._player_max_ranges,
             self._opponent_max_ranges,
+            self.terrain.footprints,
             self.has_line_of_sight_between_cells,
-        )
-        self._exposure_tracker.record(
-            exposed=threats.threat_to_player > 0,
-            alive=player_alive,
-            terrain_distances=distances_to_nearest_footprint(
-                player_positions, self.terrain.footprints
-            ),
-            our_shooters=int((threats.player_can_shoot & player_alive).sum()),
-            their_shooters=int((threats.opponent_can_shoot & opp_alive).sum()),
         )
 
     def _apply_opponent_action(self) -> None:

--- a/wargame_rl/wargame/envs/wargame.py
+++ b/wargame_rl/wargame/envs/wargame.py
@@ -22,10 +22,9 @@ from wargame_rl.wargame.envs.domain.los import has_line_of_sight, iter_los_cells
 from wargame_rl.wargame.envs.domain.placement import place_for_episode
 from wargame_rl.wargame.envs.domain.shooting import (
     ENGAGEMENT_RANGE,
-    DefenderStats,
     PairedShootingResult,
     ShootingResult,
-    resolve_shooting,
+    resolve_shooting_phase,
 )
 from wargame_rl.wargame.envs.domain.termination import is_battle_over
 from wargame_rl.wargame.envs.domain.terrain import Terrain
@@ -42,7 +41,6 @@ from wargame_rl.wargame.envs.env_components import (
     build_observation,
     compute_distances,
 )
-from wargame_rl.wargame.envs.env_components.actions import ActionSlice
 from wargame_rl.wargame.envs.env_components.exposure import (
     ExposureTracker,
     distances_to_nearest_footprint,
@@ -531,56 +529,20 @@ class WargameEnv(gym.Env):
         action: WargameEnvAction,
         attackers: list[WargameModel],
         targets: list[WargameModel],
-        shooting_slice: ActionSlice | None,
+        action_handler: ActionHandler,
         attacker_configs: list[ModelConfig] | None,
     ) -> list[PairedShootingResult]:
-        """Resolve shooting for each model in the action against targets.
+        """Decode the action into shots, then let the domain resolve them.
 
         Returns one PairedShootingResult per model that actually fired.
         """
-        results: list[PairedShootingResult] = []
-        if shooting_slice is None:
-            return results
-        for i, act in enumerate(action.actions):
-            if i >= len(attackers):
-                continue
-            attacker = attackers[i]
-            if not attacker.is_alive:
-                continue
-            if not (shooting_slice.start <= act < shooting_slice.end):
-                continue
-            target_idx = act - shooting_slice.start
-            if target_idx >= len(targets) or not targets[target_idx].is_alive:
-                continue
-            weapons = (
-                attacker_configs[i].weapons
-                if attacker_configs and i < len(attacker_configs)
-                else []
-            )
-            if not weapons:
-                continue
-            w = weapons[0]
-            target = targets[target_idx]
-            defender = DefenderStats(
-                toughness=target.stats["toughness"],
-                save=target.stats["save"],
-            )
-            result = resolve_shooting(w, defender, self._combat_rng)
-            killed = False
-            if result.damage_dealt > 0:
-                targets[target_idx].take_damage(result.damage_dealt)
-                # The target was alive at the range check above, so a dead
-                # target here means this shot made the kill.
-                killed = not targets[target_idx].is_alive
-            results.append(
-                PairedShootingResult(
-                    attacker_idx=i,
-                    target_idx=target_idx,
-                    result=result,
-                    killed=killed,
-                )
-            )
-        return results
+        return resolve_shooting_phase(
+            shots=action_handler.decode_shooting_targets(action, len(attackers)),
+            attackers=attackers,
+            targets=targets,
+            attacker_weapons=[cfg.weapons for cfg in attacker_configs or []],
+            rng=self._combat_rng,
+        )
 
     def _apply_player_action(self, action: WargameEnvAction) -> None:
         phase = self._game_clock.state.phase or BattlePhase.movement
@@ -592,7 +554,7 @@ class WargameEnv(gym.Env):
                 action,
                 self.wargame_models,
                 self.opponent_models,
-                self._action_handler.shooting_slice,
+                self._action_handler,
                 self.config.models,
             )
         else:
@@ -695,7 +657,7 @@ class WargameEnv(gym.Env):
                 opp_action,
                 self.opponent_models,
                 self.wargame_models,
-                self._opponent_action_handler.shooting_slice,
+                self._opponent_action_handler,
                 self.config.opponent_models,
             )
         else:

--- a/wargame_rl/wargame/envs/wargame.py
+++ b/wargame_rl/wargame/envs/wargame.py
@@ -22,7 +22,6 @@ from wargame_rl.wargame.envs.domain.placement import place_for_episode
 from wargame_rl.wargame.envs.domain.shooting import (
     ENGAGEMENT_RANGE,
     PairedShootingResult,
-    ShootingResult,
     resolve_shooting_phase,
 )
 from wargame_rl.wargame.envs.domain.sight import (
@@ -65,6 +64,12 @@ from wargame_rl.wargame.envs.reward.phase_manager import (
 )
 from wargame_rl.wargame.envs.reward.step_context import StepContext
 from wargame_rl.wargame.envs.state.exporter import StateExporter
+from wargame_rl.wargame.envs.state.restore import (
+    restore_clock,
+    restore_models,
+    restore_objectives,
+    restore_shooting_results,
+)
 from wargame_rl.wargame.envs.state.snapshot import (
     GameStateSnapshot,
     build_snapshot,
@@ -80,11 +85,7 @@ from wargame_rl.wargame.envs.types import (
     WargameEnvObservation,
 )
 from wargame_rl.wargame.envs.types.config import ModelConfig
-from wargame_rl.wargame.envs.types.game_timing import (
-    BATTLE_PHASE_ORDER,
-    GamePhase,
-    GameState,
-)
+from wargame_rl.wargame.envs.types.game_timing import BATTLE_PHASE_ORDER, GameState
 from wargame_rl.wargame.envs.wargame_model import WargameModel
 from wargame_rl.wargame.envs.wargame_objective import WargameObjective
 
@@ -851,62 +852,16 @@ class WargameEnv(gym.Env):
                 "Invalid snapshot:\n" + "\n".join(f"  - {e}" for e in errors)
             )
 
-        # Clock
-        clock = snapshot.clock
-        self._game_clock.set_state(
-            GamePhase(clock.game_phase),
-            battle_round=clock.battle_round,
-            active_player=(
-                PlayerSide(clock.active_player) if clock.active_player else None
-            ),
-            phase=BattlePhase(clock.battle_phase) if clock.battle_phase else None,
-            total_steps=snapshot.step,
+        restore_clock(self._game_clock, snapshot.clock, snapshot.step)
+        restore_models(self.wargame_models, snapshot.player_models)
+        restore_models(self.opponent_models, snapshot.opponent_models)
+        restore_objectives(self.objectives, snapshot.objectives)
+        self._battle.restore_victory_points(
+            player_vp=snapshot.player_vp,
+            opponent_vp=snapshot.opponent_vp,
+            player_vp_delta=snapshot.player_vp_delta,
+            opponent_vp_delta=snapshot.opponent_vp_delta,
         )
-
-        # Player models
-        for i, ms in enumerate(snapshot.player_models):
-            m = self.wargame_models[i]
-            m.location = np.array(ms.location, dtype=np.int32)
-            m.previous_location = (
-                np.array(ms.previous_location, dtype=np.int32)
-                if ms.previous_location is not None
-                else None
-            )
-            m.stats["current_wounds"] = ms.current_wounds
-            m.advanced_this_turn = ms.advanced_this_turn
-            m.previous_closest_objective_distance = None
-            m.best_closest_objective_distance = None
-            m.model_rewards_history.clear()
-
-        # Opponent models
-        for i, ms in enumerate(snapshot.opponent_models):
-            m = self.opponent_models[i]
-            m.location = np.array(ms.location, dtype=np.int32)
-            m.previous_location = (
-                np.array(ms.previous_location, dtype=np.int32)
-                if ms.previous_location is not None
-                else None
-            )
-            m.stats["current_wounds"] = ms.current_wounds
-            m.advanced_this_turn = ms.advanced_this_turn
-            m.previous_closest_objective_distance = None
-            m.best_closest_objective_distance = None
-            m.model_rewards_history.clear()
-
-        # Objectives
-        for i, os_ in enumerate(snapshot.objectives):
-            self.objectives[i].location = np.array(os_.location, dtype=np.int32)
-
-        # VP. The deltas are restored, not zeroed: `player_vp_delta` is a
-        # feature of the observation the policy acts on (game features, index
-        # 5), so zeroing it here made a loaded state disagree with the live
-        # state it was captured from, and `to_snapshot` round-tripped it to a
-        # different snapshot. Every snapshot carries both, so there is nothing
-        # to reconstruct.
-        self._battle._player_vp = snapshot.player_vp
-        self._battle._opponent_vp = snapshot.opponent_vp
-        self._battle._player_vp_delta = snapshot.player_vp_delta
-        self._battle._opponent_vp_delta = snapshot.opponent_vp_delta
 
         # Env counters
         self.current_turn = snapshot.step
@@ -930,33 +885,12 @@ class WargameEnv(gym.Env):
         else:
             self._last_opponent_action = None
 
-        # Reconstruct combat results as PairedShootingResult stubs
-        self._last_player_shooting_results = [
-            PairedShootingResult(
-                attacker_idx=cr.attacker_idx,
-                target_idx=cr.target_idx,
-                result=ShootingResult(
-                    hits=cr.hits,
-                    wounds=cr.wounds,
-                    unsaved=cr.unsaved,
-                    damage_dealt=cr.damage_dealt,
-                ),
-            )
-            for cr in snapshot.player_combat_results
-        ]
-        self._last_opponent_shooting_results = [
-            PairedShootingResult(
-                attacker_idx=cr.attacker_idx,
-                target_idx=cr.target_idx,
-                result=ShootingResult(
-                    hits=cr.hits,
-                    wounds=cr.wounds,
-                    unsaved=cr.unsaved,
-                    damage_dealt=cr.damage_dealt,
-                ),
-            )
-            for cr in snapshot.opponent_combat_results
-        ]
+        self._last_player_shooting_results = restore_shooting_results(
+            snapshot.player_combat_results
+        )
+        self._last_opponent_shooting_results = restore_shooting_results(
+            snapshot.opponent_combat_results
+        )
 
         # Reward
         self.last_reward = snapshot.reward.total


### PR DESCRIPTION
Six behaviour-preserving refactors that move the code [phase 03](https://github.com/sashman/wargame_rl/pull/137) will rewrite into places where rewriting it is a local change instead of surgery.

**No behaviour changes.** No reward, no observation, no trained result moves. Nothing from PR #137 is implemented here.

## Why

An audit of the env against `docs/ddd-envs.md` found the dependency direction is genuinely clean — `domain/` never imports upward, `types/` never imports `domain/`, and no calculator or renderer reaches for the env class or the aggregate, all verified mechanically. The problem was the distribution of code inside the boundaries: `wargame.py` was **1030 lines** against a `Battle` aggregate of **124**, owning four things the DDD doc says a facade must not — the attack sequence, the see-out rule, exposure metrics and ~170 lines of serialisation. Phase 03 lands on all four.

The facade is now **891 lines**.

## The commits

| | |
|---|---|
| `078a1b7` | `POSITION_DTYPE` / `position()` / `zero_position()` in `domain/value_objects.py`. The coordinate type was re-asserted at ~12 literal sites; a missed one when the board goes continuous truncates **silently**, with no exception and no failing test. |
| `930f2f5` | Attack sequence → `domain.shooting.resolve_shooting_phase`; action decoding → `ActionHandler.decode_shooting_targets`. Cover can now enter resolution as a *parameter* rather than a facade lookup. |
| `f2e6270` | "Can A see B?" → `domain/sight.py`, kept apart from `los.py` so the geometry primitive stays free of game rules. `BattleView`'s signature is untouched. |
| `1be2db7` | Snapshot read path → `state/restore.py`; VP restore → `Battle.restore_victory_points`. |
| `67e367c` | Exposure gathering → `exposure.py`, beside the tracker it feeds. |
| `9d4ac0d` | `config.py` → `types/config/` package. **All 72 importing files untouched.** |
| `70e4b8a` | Records the geometry-home decision and `types/` as a shared kernel; fixes doc drift. |

## Verification

The golden gates (`test_reward_golden`, `test_observation_golden`) pass **unmodified** — if either needed editing, the refactor changed behaviour and was wrong.

They only cover states their recorded trajectories reach, so each commit was also checked against a digest of **every shooting outcome across 8 seeded episodes** on `25v25_shooting_opponent.yaml` — both sides' attacker/target/hits/wounds/unsaved/damage/kill flag, per-step reward, final VP, and every model's end position — run against a worktree of `main`:

```
squad_march_shoot   1197 records   sha256=73a6671…   identical, all 7 commits
squad_march         1008 records   sha256=f97f45c…   identical
random (seed 0)      685 records   sha256=9419416…   identical
```

- **876 tests pass**, `just lint` and mypy clean.
- Throughput flat: 0.987 vs 0.973 ms/step, line of sight 0.057 vs 0.058 ms, 2.6 s per 2048-step epoch either way.
- `9d4ac0d` verified rather than assumed: `git diff --name-only` shows changes under `types/config/` and nowhere else.

## Two things reviewers should know

**`to_snapshot` is deliberately left on the facade.** It is already a thin adapter over `build_snapshot`, and most of what it gathers is not on `BattleView` — last actions, shooting results, action phase, shooting slice, phase-manager position. Moving it meant either a 25-parameter function or a `state` → env import cycle.

**A dtype drift is documented but not fixed.** A position is int32 from placement and **int64 once it has moved**, because the displacement table is int64 and numpy promotes. Values are unaffected and the observation is float downstream. Fixing it is a behaviour change and belongs with the change that makes displacements exact.

Separately: `tests/test_transformer_shooting_policy.py::test_transformer_policy_batched_matches_single_obs` flaked once in 16 full-suite runs here (`main` clean 4/4). It compares a batched forward against single forwards of the same **unseeded** random network at `atol=1e-5`, on observations the golden gate proves identical to `main` — neither operand is reachable from these changes. A `torch.manual_seed` in that test would settle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)