### PR TITLE
fix: pin float32 precision per test, so TF32 cannot leak between them

### DIFF
--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -7,6 +7,7 @@ Applies to everything under `tests/`. General testing philosophy lives in the ro
 
 - Pytest + shared fixtures in `conftest.py`; run via `just test`; coverage → `coverage.xml`
 - Fixtures: `n_steps`, `env`, `experiences`, `policy_net` (a bare `TransformerNetwork`), `transformer_net`, `ppo_net`, `ppo_transformer_net`
+- **`full_float32_precision` is autouse and pins `set_float32_matmul_precision("highest")` before every test.** That setting is process-wide and sticky, so one test enabling TF32 changes the arithmetic of everything after it in the same worker — which surfaced as a once-per-16-runs "flake" in `test_transformer_shooting_policy` that is actually a deterministic 25/25 failure under TF32. A test needing another mode sets it itself; the fixture only decides the starting point
 
 ## Rules
 
@@ -16,6 +17,8 @@ Applies to everything under `tests/`. General testing philosophy lives in the ro
 - Type-annotate fixtures and test functions
 - `wargame_rl/wargame/envs/interactive_demo.py` is NOT a test
 - When env default config changes stepping (e.g. `skip_phases`), tests that rely on per-phase or all-phase behaviour must set config explicitly (e.g. `skip_phases=[]` in a shared `_make_env` or in the test)
+- **A randomly-initialised network counts as randomness.** `TransformerNetwork.policy_from_env` seeds nothing, so a test asserting on its outputs needs `torch.manual_seed` — otherwise a failure arrives with weights nobody can reproduce
+- **Before calling a test flaky, check what global state ran before it.** Process-wide torch settings survive across tests in a worker, so an intermittent *numerical* failure is more often a leak than noise. Rank hypotheses by what you can make fail on demand: thread oversubscription was the intuitive answer to the one flake seen here and gave 0 failures in 960 executions, while TF32 reproduced 25/25
 
 ## Test Files
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,42 @@
+from collections.abc import Iterator
 from functools import lru_cache
 from typing import cast
 
 import pytest
+import torch
 
 from wargame_rl.wargame.envs.types import WargameEnvAction, WargameEnvConfig
 from wargame_rl.wargame.envs.wargame import WargameEnv
 from wargame_rl.wargame.model.net import RL_Network, TransformerNetwork
 from wargame_rl.wargame.model.ppo.ppo import PPO_Transformer
 from wargame_rl.wargame.types import Experience
+
+
+@pytest.fixture(autouse=True)
+def full_float32_precision() -> Iterator[None]:
+    """Run every test at full float32 precision, whatever ran before it.
+
+    `torch.set_float32_matmul_precision` is *process-wide* and sticky, so one
+    test enabling TF32 silently changes the arithmetic of every test that
+    follows it in the same worker. That is not hypothetical: with TF32 on,
+    `test_transformer_shooting_policy.py::test_transformer_policy_batched_matches_single_obs`
+    fails **25 times out of 25** — it compares a batched forward against single
+    forwards at `atol=1e-5`, and TF32's 11 mantissa bits cannot hold that. It
+    presented as a once-per-16-runs flake, which reads like numerical noise and
+    is not.
+
+    Pinned per test rather than per session so that a test which changes the
+    setting deliberately -- `test_precision.py` does, and restores it -- cannot
+    leave the rest of the suite running under different arithmetic if its own
+    restore ever regresses.
+
+    Tests that need another mode set it themselves; this only decides the
+    starting point. TF32 is off in training too, and for the same reason it
+    matters here: it costs ~8.5 vp_margin. See
+    reports/2026-08-09-tf32-costs-eight-vp.md.
+    """
+    torch.set_float32_matmul_precision("highest")
+    yield
 
 
 @pytest.fixture

--- a/tests/test_transformer_shooting_policy.py
+++ b/tests/test_transformer_shooting_policy.py
@@ -122,7 +122,15 @@ def test_transformer_shooting_scores_land_in_correct_opponent_columns() -> None:
 
 
 def test_transformer_policy_batched_matches_single_obs() -> None:
-    """Batched forward (variable alive counts) equals stacked single forwards."""
+    """Batched forward (variable alive counts) equals stacked single forwards.
+
+    Seeded because the network is otherwise randomly initialised, and a failure
+    from weights nobody can reproduce is a failure nobody can diagnose. The
+    tolerance has ~40x of headroom at full float32 precision -- the measured
+    batched-vs-single difference is around 1.3e-7 against an `atol` of 1e-5 --
+    so a failure here means something real changed, not that the bound is tight.
+    """
+    torch.manual_seed(0)
     env = WargameEnv(config=_shooting_env_config())
     net = TransformerNetwork.policy_from_env(env)
     net.eval()


### PR DESCRIPTION
`test_transformer_policy_batched_matches_single_obs` failed once in sixteen full-suite runs and never reproduced in isolation. It looked like numerical noise. It is not.

## What it actually is

`torch.set_float32_matmul_precision` is **process-wide and sticky**. With TF32 on, that test fails **25 times out of 25** — deterministically. It compares a batched forward against single forwards at `atol=1e-5`, and TF32's 11 mantissa bits cannot hold that.

| `float32_matmul_precision` | failures / 25 |
|---|---|
| `highest` | 0 |
| `high` (TF32) | **25** |
| `medium` | **25** |

So one test enabling TF32 changes the arithmetic of everything after it in the same xdist worker. An intermittent numerical failure was a **leak**, not noise.

## The fix

An autouse fixture in `conftest.py` sets `"highest"` before every test. Per test rather than per session, so a test that changes the setting deliberately — `test_precision.py` does, and restores it — cannot leave the suite under different arithmetic if its restore ever regresses. Tests needing another mode still set it themselves; this only decides the starting point.

The test is also seeded. Its network was randomly initialised, and a failure from weights nobody can reproduce is a failure nobody can diagnose.

## Verification

- **Verified sensitive**: with `"high"` set before pytest starts, the test passes with the fixture and fails 25/25 without it.
- 876 tests pass; lint and mypy clean.
- Suite runtime unchanged at ~44 s under `-n auto`.

## Two hypotheses checked and rejected

Recorded in the commit and in `tests/CLAUDE.md` so they are not retried:

- **Thread oversubscription** (torch takes 16 intra-op threads per process, `-n auto` spawns ~22 workers on 24 cores). The intuitive answer, and wrong: **0 failures in 960 executions**, including 24 concurrent processes at 16 threads each.
- **Too-tight tolerance.** Also wrong: the measured batched-vs-single difference at full float32 is ~1.3e-7 median, 2.7e-7 max across 30 networks, against an `atol` of 1e-5 — about **40x of headroom**. Loosening it would have hidden the real signal.

The general rule this earns, now in `tests/CLAUDE.md`: rank hypotheses by what you can make fail *on demand*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)