### PR TITLE
fix: keep board positions int32 end to end, as the observation space says

### DIFF
--- a/docs/ddd-envs.md
+++ b/docs/ddd-envs.md
@@ -23,7 +23,8 @@ wargame_rl/wargame/envs/
 │   ├── battle_view.py         # Protocol: read-only battle state
 │   ├── battle_factory.py      # Builds Battle from config
 │   ├── entities.py            # WargameModel, WargameObjective
-│   ├── value_objects.py       # BoardDimensions, DeploymentZone
+│   ├── value_objects.py       # Position + POSITION_DTYPE, BoardDimensions,
+│   │                          #   DeploymentZone
 │   ├── game_clock.py          # Turn/phase/round logic
 │   ├── placement.py           # place_for_episode, placement helpers
 │   ├── termination.py         # is_battle_over, check_max_turns_reached

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from wargame_rl.wargame.envs.domain.value_objects import POSITION_DTYPE
+from wargame_rl.wargame.envs.env_components.actions import STAY_ACTION
 from wargame_rl.wargame.envs.reward.phase import (
     RewardCalculatorConfig,
     RewardPhaseConfig,
@@ -359,3 +361,42 @@ def test_terrain_movement_through_footprint() -> None:
             break
     # Verify env didn't crash — terrain does not block movement
     assert env.current_turn >= 1
+
+
+def test_positions_keep_the_declared_dtype_through_a_whole_episode() -> None:
+    """A location must stay `POSITION_DTYPE` from placement to the last move.
+
+    This is the invariant that makes the board's coordinate type editable in one
+    place, and it is invisible when broken: numpy silently widens on
+    `location + displacement`, so a location was int32 from placement and int64
+    from its first move onward while the observation space still advertised
+    int32. Nothing raised, no test failed, and every value was correct — which
+    is exactly why it survived.
+
+    Three sources conspire and all three are checked: the displacement table,
+    the STAY displacement, and `np.clip`'s bounds (python-list bounds become
+    int64 arrays and widen the result regardless of the inputs).
+    """
+    env = WargameEnv(config=WargameEnvConfig(number_of_battle_rounds=100))
+    n_models = env.config.number_of_wargame_models
+
+    env.reset(seed=0)
+    assert env.wargame_models[0].location.dtype == POSITION_DTYPE
+    assert env.objectives[0].location.dtype == POSITION_DTYPE
+
+    # Movement actions: exercises the displacement table and the clip bounds.
+    for step in range(6):
+        env.step(WargameEnvAction(actions=[step + 1] * n_models))
+    moved = env.wargame_models[0]
+    assert moved.location.dtype == POSITION_DTYPE
+    assert moved.previous_location is not None
+    assert moved.previous_location.dtype == POSITION_DTYPE
+
+    # STAY takes a different branch and had its own literal dtype.
+    env.reset(seed=1)
+    for _ in range(3):
+        env.step(WargameEnvAction(actions=[STAY_ACTION] * n_models))
+    assert env.wargame_models[0].location.dtype == POSITION_DTYPE
+
+    space = env.observation_space["wargame_models"][0]["location"]  # type: ignore[index]
+    assert space.dtype == POSITION_DTYPE

--- a/wargame_rl/wargame/envs/CLAUDE.md
+++ b/wargame_rl/wargame/envs/CLAUDE.md
@@ -67,7 +67,7 @@ Applies to everything under `wargame_rl/wargame/envs/`.
 
 ## Design
 
-- Integer locations, built through `position()` / `zero_position()` from `domain/value_objects.py` — never a literal `dtype=np.int32`. `POSITION_DTYPE` is the single declaration, so making the board continuous is one edit rather than a hunt; a missed site would truncate silently with no exception and no failing test. (Known drift documented there: a position is int32 from placement and int64 once it has moved, because the displacement table is int64 and numpy promotes.)
+- Integer locations, built through `position()` / `zero_position()` from `domain/value_objects.py` — never a literal `dtype=np.int32`. `POSITION_DTYPE` is the single declaration, so making the board continuous is one edit rather than a hunt; a missed site would truncate silently with no exception and no failing test. **Arithmetic widens too** — anything added to or clipped against a position must carry `POSITION_DTYPE`. A location used to become int64 on its first move via three separate int64 sources in `actions.py` (displacement table, STAY displacement, python-list `np.clip` bounds); `test_positions_keep_the_declared_dtype_through_a_whole_episode` now pins it
 - Pre-compute expensive ops at `__init__` (numpy vectorized)
 - Track rendering state (e.g. `previous_location`) in same change
 - New entities mirror existing patterns; always backward compatible

--- a/wargame_rl/wargame/envs/domain/value_objects.py
+++ b/wargame_rl/wargame/envs/domain/value_objects.py
@@ -16,11 +16,13 @@ import numpy.typing as npt
 # into an int one truncates *silently*, with no exception and no failing test,
 # so a missed site would be invisible.
 #
-# Known drift, deliberately left alone: a position is int32 when placement
-# builds it and int64 once it has moved, because the displacement table in
-# `env_components/actions.py` is int64 and numpy promotes. Values are
-# unaffected (coordinates are small) and the observation is float downstream.
-# Fixing it belongs with the change that makes displacements exact, not here.
+# Construction is not the only way to get the dtype wrong -- *arithmetic* is.
+# A position was int32 from placement and int64 from its first move onward,
+# because three things in `env_components/actions.py` widened it: an int64
+# displacement table, an int64 STAY displacement, and `np.clip` bounds passed
+# as python lists. Anything combined with a position has to carry this dtype
+# too, and `test_positions_keep_the_declared_dtype_through_a_whole_episode`
+# pins the result across a whole episode.
 POSITION_DTYPE: Final = np.int32
 
 # A board coordinate pair, shape (2,).

--- a/wargame_rl/wargame/envs/env_components/actions.py
+++ b/wargame_rl/wargame/envs/env_components/actions.py
@@ -1,7 +1,7 @@
 """Action space and application for the wargame environment.
 
 Polar coordinate movement: each model picks an (angle, speed) pair or stays
-still.  The continuous displacement is rounded to the nearest integer cell so
+still. The continuous displacement is rounded to the nearest integer cell so
 that locations remain on the discrete grid.
 
 The ``ActionRegistry`` partitions the flat action space into contiguous slices
@@ -17,6 +17,11 @@ from typing import Any
 import numpy as np
 from gymnasium import spaces
 
+from wargame_rl.wargame.envs.domain.value_objects import (
+    POSITION_DTYPE,
+    position,
+    zero_position,
+)
 from wargame_rl.wargame.envs.types import WargameEnvAction, WargameEnvConfig
 from wargame_rl.wargame.envs.types.game_timing import BattlePhase
 
@@ -149,12 +154,18 @@ class ActionHandler:
         self._speeds = speeds  # (n_speeds,)
 
         # Pre-compute the integer displacement for every (angle, speed) pair.
-        # _displacements[angle_idx, speed_idx] -> (dx, dy) as int
+        # _displacements[angle_idx, speed_idx] -> (dx, dy) as POSITION_DTYPE.
+        #
+        # The dtype matters as much as the rounding. A displacement is added to
+        # a location, so a wider one silently widens every location on the
+        # board: this was `dtype=int` (int64), which made a model's position
+        # int32 from placement and int64 from its first move onward, disagreeing
+        # with the int32 the observation space advertises.
         raw = (
             self._unit_directions[:, np.newaxis, :]
             * self._speeds[np.newaxis, :, np.newaxis]
         )  # (n_angles, n_speeds, 2)
-        self._displacements: np.ndarray = np.rint(raw).astype(int)
+        self._displacements: np.ndarray = np.rint(raw).astype(POSITION_DTYPE)
 
         self._n_move_actions = n_angles * n_speeds
         self._n_speed_bins = n_speeds
@@ -241,7 +252,7 @@ class ActionHandler:
     def _decode_action(self, action: int) -> np.ndarray:
         """Return the integer (dx, dy) displacement for *action*."""
         if action == STAY_ACTION:
-            return np.array([0, 0], dtype=int)
+            return zero_position()
         move_idx = action - 1
         angle_idx = move_idx // self._n_speed_bins
         speed_idx = move_idx % self._n_speed_bins
@@ -304,6 +315,10 @@ class ActionHandler:
         enforces that for a learned policy, but scripted policies bypass the
         mask, so honouring `phase` here keeps them on the same footing.
         """
+        # Hoisted, and typed: python-list bounds become int64 arrays, so passing
+        # them to `np.clip` would widen the result whatever the inputs are.
+        lower = zero_position()
+        upper = position(board_width - 1, board_height - 1)
         for i, act in enumerate(action.actions):
             model = wargame_models[i]
             if not model.is_alive:
@@ -321,8 +336,4 @@ class ActionHandler:
                 continue
             model.previous_location = model.location.copy()
             displacement = self._decode_action(act)
-            model.location = np.clip(
-                model.location + displacement,
-                [0, 0],
-                [board_width - 1, board_height - 1],
-            )
+            model.location = np.clip(model.location + displacement, lower, upper)


### PR DESCRIPTION
A model's location was `int32` when placement built it and `int64` from its first move onward. Nothing raised, no test failed, and every value was correct — the observation space just advertised a dtype the env stopped producing one step in.

This is the drift `domain/value_objects.py` documented and deliberately left alone during #149.

## Three sites conspired

Fixing any one alone does nothing:

| site | why it widens |
|---|---|
| displacement table | was `dtype=int` (int64), and a displacement is **added** to a location |
| STAY branch | built its own `np.array([0, 0], dtype=int)` |
| `np.clip` bounds | passed as python lists, which become int64 arrays and widen the output regardless of the inputs |

The clip bounds are now typed and hoisted out of the per-model loop, which also drops two allocations per model per step.

## Not a behaviour change

The 8-episode digest over `configs/golden/25v25_shooting_opponent.yaml` matches `main` exactly on all three baselines — 1197 / 1008 / 685 records, same hashes. Throughput is unchanged to marginally better (0.966 vs 0.973 ms/step).

`test_positions_keep_the_declared_dtype_through_a_whole_episode` pins the invariant, and is **verified sensitive**: reverting any one of the three sites fails it.

877 tests pass, lint and mypy clean.

## This is not WP-0

Worth stating, because they touch the same line. Deleting the `np.rint` rounding — WP-0 in the phase 03 plan — makes positions **float**, which is a much wider change: I measured it and `to_snapshot` raises a `ValidationError` immediately (`ModelSnapshot.location` is `list[int]`), the Gym `Box` still declares int32, and the LOS seam takes `int` arguments so coordinates would be silently truncated back to the grid on every sight query.

This PR keeps the rounding and only corrects the dtype.

🤖 Generated with [Claude Code](https://claude.com/claude-code)