### PR TITLE
fix: reject config keys the model does not define

### DIFF
--- a/docs/reward-phases.md
+++ b/docs/reward-phases.md
@@ -76,6 +76,13 @@ reward_phases:
 | `type` | string | *required* | Registry key identifying the criteria class |
 | `params` | dict | `{}` | Keyword arguments forwarded to the criteria constructor |
 
+> **A misspelled field is an error, not a default.** Every config model sets
+> `extra="forbid"`, so `wieght: 1.0` fails to load rather than quietly leaving the
+> weight at 1.0 — which is how an arm ends up not measuring what its config says.
+> The strictness stops at `params`: its contents are free-form by design, because
+> each registry entry defines its own keys, and they are validated by the
+> calculator that receives them.
+
 ## Available Reward Calculators
 
 | Type key | Scope | Parameters | Description |

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -42,6 +42,8 @@ Applies to everything under `tests/`. General testing philosophy lives in the ro
 
 **Rules spec** — `test_scale_and_rules_quantities` (the inches↔units `Scale`, and that resolving at the default 1.0 reproduces the exact numbers the code used before the scale existed — that assertion is the no-op guarantee, so a failure means every baseline was measured under a different env; also pins that `RulesQuantities` holds only fields something reads, since a settable-but-inert config field is how a lever silently does nothing) · `test_rules_constants` (pins the domain against `docs/rules/constants.yaml` wherever the env claims fidelity; everywhere else the divergence is recorded in `implementation-status.md` rather than asserted, so a failure here means the code moved away from the spec, not that the spec is aspirational) · `test_no_ip_references` (denylist over tracked **and untracked** files — untracked matters, because a scratch file is exactly how a product reference gets reintroduced)
 
+**Config validation** — `test_config_rejects_unknown_keys` (every config model forbids extras, enumerated so a newly added model fails rather than silently swallowing typos; also pins that the legacy `size`/`width`/`height` aliases are *consumed* by the before-validator rather than left in the dict, and that free-form `params` dicts stay open)
+
 **Cross-cutting** — `test_checkpoint_module_alias` (a moved module silently un-loads every existing checkpoint — Lightning pickles `PPO_Transformer` into `hyper_parameters`, so checkpoints carry import *paths*; verified sensitive by deleting the alias) · `test_integration` (backward compat) · `test_v9_milestone_validation` · `test_imports` · `test_interactive_demo`
 
 ## New Features

--- a/tests/test_config_rejects_unknown_keys.py
+++ b/tests/test_config_rejects_unknown_keys.py
@@ -1,0 +1,114 @@
+"""Every config model rejects keys it does not define.
+
+Pydantic's default is to *ignore* an unknown key. For a config that selects a
+scenario, that turns a typo into a silent no-op: the run starts, trains, and
+reports a number for an environment nobody asked for. This project has already
+spent GPU-hours on arms that were not measuring what their config claimed, so
+the failure mode is not hypothetical.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from wargame_rl.wargame.envs.reward.phase import (
+    RewardCalculatorConfig,
+    RewardPhaseConfig,
+    SuccessCriteriaConfig,
+)
+from wargame_rl.wargame.envs.types.config import (
+    MissionConfig,
+    ModelConfig,
+    ObjectiveConfig,
+    OpponentPolicyConfig,
+    RandomTerrainConfig,
+    TerrainMapConfig,
+    TerrainPieceConfig,
+    WargameEnvConfig,
+    WeaponProfile,
+)
+
+# Every config model a YAML file can reach. A new one added without a
+# `model_config` entry fails here rather than silently swallowing typos.
+CONFIG_MODELS: list[type[BaseModel]] = [
+    WargameEnvConfig,
+    ModelConfig,
+    ObjectiveConfig,
+    WeaponProfile,
+    TerrainPieceConfig,
+    TerrainMapConfig,
+    RandomTerrainConfig,
+    MissionConfig,
+    OpponentPolicyConfig,
+    RewardPhaseConfig,
+    RewardCalculatorConfig,
+    SuccessCriteriaConfig,
+]
+
+
+@pytest.mark.parametrize("model", CONFIG_MODELS, ids=lambda m: m.__name__)
+def test_model_forbids_unknown_keys(model: type[BaseModel]) -> None:
+    """Declared on the class, so it survives someone adding fields later."""
+    assert model.model_config.get("extra") == "forbid"
+
+
+def test_a_misspelled_field_is_an_error_not_a_default() -> None:
+    """The case that motivated this.
+
+    `objective_radius_sze=99` used to give you an objective of radius 1 and no
+    warning at all -- a config that looks like it is testing something and is
+    not. The error names the offending key so the fix is obvious.
+    """
+    with pytest.raises(ValidationError, match="objective_radius_sze"):
+        WargameEnvConfig(objective_radius_sze=99)  # type: ignore[call-arg]
+
+
+def test_a_misspelled_key_inside_a_nested_model_is_caught_too() -> None:
+    """Nested models are where the interesting settings live.
+
+    A weapon profile or a reward calculator is exactly the kind of thing an
+    experiment arm edits, and a typo there is the most expensive place to be
+    silently ignored.
+    """
+    with pytest.raises(ValidationError, match="rnge"):
+        WeaponProfile(rnge=24)  # type: ignore[call-arg]
+
+    with pytest.raises(ValidationError, match="wieght"):
+        RewardCalculatorConfig(type="vp_gain", wieght=1.0)  # type: ignore[call-arg]
+
+
+@pytest.mark.parametrize(
+    "legacy, expected_width, expected_height",
+    [
+        ({"size": 30}, 30, 30),
+        ({"width": 25, "height": 40}, 25, 40),
+    ],
+)
+def test_legacy_board_size_aliases_still_load(
+    legacy: dict[str, int], expected_width: int, expected_height: int
+) -> None:
+    """`size` / `width` / `height` are aliases, and must be consumed not copied.
+
+    They are translated by a `mode="before"` validator. It used to leave the
+    original key in the dict, which was harmless only because unknown keys were
+    ignored -- the very behaviour this module removes.
+    """
+    config = WargameEnvConfig.model_validate(legacy)
+
+    assert config.board_width == expected_width
+    assert config.board_height == expected_height
+
+
+def test_free_form_params_dicts_are_still_open() -> None:
+    """Forbidding extras must not reach *inside* a params dict.
+
+    Calculator and policy parameters are `dict[str, Any]` on purpose -- each
+    registry entry defines its own -- so the strictness stops at the model
+    boundary. Their contents are validated by the calculator that reads them.
+    """
+    calculator = RewardCalculatorConfig(
+        type="objective_hold", params={"crowding_exponent": 1.0, "weight_hint": "any"}
+    )
+
+    assert calculator.params["crowding_exponent"] == 1.0

--- a/wargame_rl/wargame/envs/CLAUDE.md
+++ b/wargame_rl/wargame/envs/CLAUDE.md
@@ -58,7 +58,7 @@ Applies to everything under `wargame_rl/wargame/envs/`.
 
 ## Adding Features
 
-1. Config → `types/config/` (`entities.py` per-entity, `terrain.py` terrain, `battle.py` turn order/opponent/mission, `env.py` scenario-level). `__init__.py` re-exports, so importers still use `types.config`
+1. Config → `types/config/` (`entities.py` per-entity, `terrain.py` terrain, `battle.py` turn order/opponent/mission, `env.py` scenario-level). `__init__.py` re-exports, so importers still use `types.config`. **Every config model sets `model_config = ConfigDict(extra="forbid")`** — a new one must too, and `tests/test_config_rejects_unknown_keys.py` enumerates them so it fails if you forget. Pydantic's default *ignores* an unknown key, which turns a typo into a silent no-op: `objective_radius_sze=99` used to give you radius 1 and no warning, i.e. an arm not measuring what its config claims. Strictness stops at the model boundary — `params` dicts on calculators and policies stay free-form, since each registry entry defines its own
 2. Logic → `env_components/`
 3. Obs → `env_observation.py`/`env_info.py` + obs builder
 4. Tensor → `model/common/observation.py`

--- a/wargame_rl/wargame/envs/reward/phase.py
+++ b/wargame_rl/wargame/envs/reward/phase.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class SuccessCriteriaConfig(BaseModel):
     """YAML-serialisable description of a success criteria."""
+
+    model_config = ConfigDict(extra="forbid")
 
     type: str = Field(
         description="Registry key, e.g. 'all_at_objectives', 'all_models_grouped'"
@@ -19,6 +21,8 @@ class SuccessCriteriaConfig(BaseModel):
 
 class RewardCalculatorConfig(BaseModel):
     """YAML-serialisable description of a single reward calculator."""
+
+    model_config = ConfigDict(extra="forbid")
 
     type: str = Field(
         description="Registry key, e.g. 'closest_objective', 'group_cohesion'"
@@ -34,6 +38,8 @@ class RewardCalculatorConfig(BaseModel):
 
 class RewardPhaseConfig(BaseModel):
     """Configuration for a single reward phase in the curriculum."""
+
+    model_config = ConfigDict(extra="forbid")
 
     name: str = Field(description="Human-readable phase name")
     reward_calculators: list[RewardCalculatorConfig] = Field(

--- a/wargame_rl/wargame/envs/types/config/battle.py
+++ b/wargame_rl/wargame/envs/types/config/battle.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class TurnOrder(str, Enum):
@@ -19,6 +19,8 @@ class TurnOrder(str, Enum):
 class OpponentPolicyConfig(BaseModel):
     """Configuration for the opponent policy engine."""
 
+    model_config = ConfigDict(extra="forbid")
+
     type: str = Field(
         description="Policy engine identifier, e.g. 'random', 'scripted_advance_to_objective'."
     )
@@ -30,6 +32,8 @@ class OpponentPolicyConfig(BaseModel):
 
 class MissionConfig(BaseModel):
     """Configuration for the mission (victory point scoring rules)."""
+
+    model_config = ConfigDict(extra="forbid")
 
     type: str = Field(
         default="default",

--- a/wargame_rl/wargame/envs/types/config/entities.py
+++ b/wargame_rl/wargame/envs/types/config/entities.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from wargame_rl.wargame.envs.types.config._validation import (
     _validate_coords_both_or_neither,
@@ -11,6 +11,8 @@ from wargame_rl.wargame.envs.types.config._validation import (
 
 class WeaponProfile(BaseModel):
     """Weapon stat block with range and resolution stats."""
+
+    model_config = ConfigDict(extra="forbid")
 
     range: int = Field(gt=0, description="Maximum range in grid cells")
     attacks: int = Field(
@@ -36,6 +38,8 @@ class ModelConfig(BaseModel):
     When *x* and *y* are provided the model is placed at that exact cell;
     otherwise it is placed randomly in the deployment zone.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     x: int | None = Field(
         default=None,
@@ -73,6 +77,8 @@ class ObjectiveConfig(BaseModel):
     When *x* and *y* are provided the objective is placed at that exact cell;
     otherwise it is placed randomly outside the deployment zone.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     x: int | None = Field(
         default=None,

--- a/wargame_rl/wargame/envs/types/config/env.py
+++ b/wargame_rl/wargame/envs/types/config/env.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from wargame_rl.wargame.envs.reward.phase import (
     RewardCalculatorConfig,
@@ -45,6 +45,8 @@ class WargameEnvConfig(BaseModel):
     """
     Configuration for the Wargame environment.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     config_name: str | None = Field(
         default=None, description="Name of the environment config"
@@ -275,16 +277,30 @@ class WargameEnvConfig(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def size_to_width_height(cls, data: object) -> object:
-        """Backward compatibility: accept 'size' or 'width'/'height' in YAML/dict."""
+        """Backward compatibility: accept 'size' or 'width'/'height' in YAML/dict.
+
+        The legacy keys are *consumed*, not just copied. They are aliases rather
+        than fields, so leaving them behind would trip `extra="forbid"` — and
+        before that existed they were simply ignored, which is the failure this
+        model now rejects. Works on a copy; the caller's dict is not touched.
+        """
         if not isinstance(data, dict):
             return data
-        if "size" in data and "board_width" not in data and "board_height" not in data:
-            s = data["size"]
-            data = {**data, "board_width": s, "board_height": s}
-        if "width" in data and "board_width" not in data:
-            data = {**data, "board_width": data["width"]}
-        if "height" in data and "board_height" not in data:
-            data = {**data, "board_height": data["height"]}
+        data = dict(data)
+        size = data.pop("size", None)
+        width = data.pop("width", None)
+        height = data.pop("height", None)
+        if (
+            size is not None
+            and "board_width" not in data
+            and "board_height" not in data
+        ):
+            data["board_width"] = size
+            data["board_height"] = size
+        if width is not None and "board_width" not in data:
+            data["board_width"] = width
+        if height is not None and "board_height" not in data:
+            data["board_height"] = height
         return data
 
     @property

--- a/wargame_rl/wargame/envs/types/config/terrain.py
+++ b/wargame_rl/wargame/envs/types/config/terrain.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class TerrainPieceConfig(BaseModel):
     """Configuration for a single terrain piece (axis-aligned rectangle)."""
+
+    model_config = ConfigDict(extra="forbid")
 
     footprint: tuple[int, int, int, int] = Field(
         description="Bounding rectangle (x0, y0, x1, y1) in grid cells."
@@ -23,6 +25,8 @@ class TerrainMapConfig(BaseModel):
     would duplicate a 13 KB scenario N times and let evaluation drift from
     training the first time a reward term changed.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     name: str = Field(description="Map identifier, used as the row label.")
     terrain: list[TerrainPieceConfig] = Field(
@@ -42,6 +46,8 @@ class RandomTerrainConfig(BaseModel):
     layout a policy can memorise a handful of rectangles; with a fresh layout
     every episode it has to read the terrain tokens in the observation.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     count: int = Field(
         gt=0,


### PR DESCRIPTION
Pydantic ignores an unknown key by default. On a config that selects a scenario, that turns a typo into a silent no-op:

```python
WargameEnvConfig(objective_radius_sze=99)   # → objective_radius_size == 1, no warning
```

The run starts, trains, and reports a number for an environment nobody asked for. Given the history of arms that turned out not to be measuring what their config claimed, this is worth closing — and it's cheap.

## What changes

Every config model a YAML file can reach sets `extra="forbid"`: the nine under `types/config/` plus the three reward-phase models.

Declared **per class rather than through a shared base**, because `reward/phase.py` is imported *by* `types/config/env.py` and a common base would invert that dependency. `tests/test_config_rejects_unknown_keys.py` enumerates all twelve instead — which is stronger than inheritance anyway, since it also catches a model added later or an override.

Strictness stops at the model boundary. `params` dicts on calculators and opponent policies stay free-form, since each registry entry defines its own keys; there's a test pinning that too.

## One real bug fell out

`size_to_width_height` translated the legacy `size` / `width` / `height` aliases into `board_width` / `board_height` but **left the originals in the dict**. That was harmless only because unknown keys were being ignored — the exact behaviour this PR removes. They're now consumed, on a copy so the caller's dict is untouched.

## Verification

- **All 8 shipped configs parse unchanged** (checked directly, not assumed).
- The 8-episode digest over `configs/golden/25v25_shooting_opponent.yaml` is unchanged — this is validation only, no behaviour.
- **894 tests pass** (877 + 17 new), lint and mypy clean.

## Scope

This is the first of the three things worth doing about config drift. Deliberately **not** included:

- A `config_version` field. Worth adding when WP-2b or WP-3 actually reinterprets an existing field's meaning — and only together with loader logic that acts on it. A version nothing validates against is the same settable-but-inert trap.
- A resolved-config fingerprint for answering "are these two results comparable?". That question needs `config × code × precision flag`, not the config alone — TF32 cost 8.5 vp_margin with an identical config and seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)