### PR TITLE
feat: record terrain geometry in game-state snapshots (schema 2.1)

### DIFF
--- a/docs/game-state-io.md
+++ b/docs/game-state-io.md
@@ -201,7 +201,7 @@ class RewardSnapshot(BaseModel):
 | Group | Fields | Purpose |
 |-------|--------|---------|
 | **Timing** | `step`, `max_steps`, `clock`, `action_phase`, `n_rounds` | Where in the episode and game clock |
-| **Board** | `board_width`, `board_height`, `deployment_zone`, `opponent_deployment_zone` | Static geometry |
+| **Board** | `board_width`, `board_height`, `deployment_zone`, `opponent_deployment_zone`, `terrain_footprints` | Static geometry (terrain footprints recorded on the reset + anchors only, not deltas) |
 | **Units** | `player_models`, `opponent_models` | Full per-model state inc. weapons, wounds, distances |
 | **Objectives** | `objectives`, `objective_control` | Positions, radii, ownership |
 | **Actions** | `player_actions`, `opponent_actions`, `player_action_descriptions` | Raw + decoded actions taken |

--- a/docs/game-state-io.md
+++ b/docs/game-state-io.md
@@ -99,7 +99,7 @@ A complete, serialisable Pydantic model of the game at one point in time. This i
 
 ```python
 class GameStateSnapshot(BaseModel):
-    schema_version: str = "2.0"
+    schema_version: str = "2.1"
     step: int
     max_steps: int
     clock: ClockSnapshot
@@ -112,6 +112,7 @@ class GameStateSnapshot(BaseModel):
     objectives: list[ObjectiveSnapshot]
     deployment_zone: list[int]
     opponent_deployment_zone: list[int]
+    terrain_footprints: list[list[list[float]]] | None = None  # 2.1: outline per ruin
     player_vp: int
     opponent_vp: int
     player_vp_delta: int

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -12,6 +12,7 @@ from wargame_rl.wargame.envs.types import TurnOrder, WargameEnvAction, WargameEn
 from wargame_rl.wargame.envs.types.config import (
     ModelConfig,
     OpponentPolicyConfig,
+    TerrainPieceConfig,
     WeaponProfile,
 )
 from wargame_rl.wargame.envs.types.game_timing import BattlePhase
@@ -209,7 +210,7 @@ class TestSchemaVersion:
     def test_schema_version(self, shooting_env: WargameEnv) -> None:
         shooting_env.reset(seed=42)
         snap = shooting_env.to_snapshot()
-        assert snap.schema_version == "2.0"
+        assert snap.schema_version == "2.1"
 
 
 class TestEncoder:
@@ -322,3 +323,52 @@ class TestMissionContext:
 
         assert isinstance(snap.mission_type, str)
         assert isinstance(snap.mission_params, dict)
+
+
+class TestTerrainFootprints:
+    """Schema 2.1: static terrain geometry rides on the full snapshot."""
+
+    @staticmethod
+    def _terrain_env() -> WargameEnv:
+        cfg = WargameEnvConfig(
+            board_width=20,
+            board_height=20,
+            number_of_wargame_models=2,
+            number_of_objectives=1,
+            terrain=[
+                TerrainPieceConfig(footprint=(5, 5, 8, 8)),
+                TerrainPieceConfig(footprint=(12, 12, 15, 16)),
+            ],
+        )
+        return WargameEnv(config=cfg)
+
+    def test_footprints_match_env_terrain(self) -> None:
+        env = self._terrain_env()
+        env.reset(seed=1)
+        snap = env.to_snapshot()
+
+        assert snap.schema_version == "2.1"
+        assert snap.terrain_footprints is not None
+        assert len(snap.terrain_footprints) == len(env.terrain.footprints)
+        for recorded, footprint in zip(snap.terrain_footprints, env.terrain.footprints):
+            assert recorded == footprint.polygon.vertices.tolist()
+
+    def test_footprints_survive_json(self) -> None:
+        env = self._terrain_env()
+        env.reset(seed=1)
+        snap = env.to_snapshot()
+
+        restored = GameStateSnapshot.model_validate(json.loads(snap.model_dump_json()))
+        assert restored.terrain_footprints == snap.terrain_footprints
+
+    def test_none_without_terrain(self) -> None:
+        cfg = WargameEnvConfig(
+            board_width=20,
+            board_height=20,
+            number_of_wargame_models=2,
+            number_of_objectives=1,
+        )
+        env = WargameEnv(config=cfg)
+        env.reset(seed=1)
+
+        assert env.to_snapshot().terrain_footprints is None

--- a/tests/test_snapshot_round_trip.py
+++ b/tests/test_snapshot_round_trip.py
@@ -17,9 +17,15 @@ chance, so the states that expose it are reached every run.
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
+from wargame_rl.wargame.envs.state.codecs import JsonMatchCodec
+from wargame_rl.wargame.envs.state.event_log import EventLog
+from wargame_rl.wargame.envs.state.replay import ReplayController
 from wargame_rl.wargame.envs.types import WargameEnvAction, WargameEnvConfig
+from wargame_rl.wargame.envs.types.config import TerrainPieceConfig
 from wargame_rl.wargame.envs.wargame import WargameEnv
 
 LAYOUT_SEED = 42
@@ -88,3 +94,99 @@ def test_the_vp_deltas_specifically_survive_the_round_trip() -> None:
         restored = env.to_snapshot()
         assert restored.player_vp_delta == snapshot.player_vp_delta
         assert restored.opponent_vp_delta == snapshot.opponent_vp_delta
+
+
+# ---------------------------------------------------------------------------
+# Terrain in recordings (schema 2.1): static terrain is stored on the reset and
+# every anchor, never in a delta, so a replay reconstructs it at any step.
+# ---------------------------------------------------------------------------
+
+_ANCHOR_INTERVAL = 3
+
+
+def _terrain_recording() -> tuple[EventLog, list[list[list[float]]]]:
+    """A short recorded episode on a fixed-terrain config, plus its footprints."""
+    env = WargameEnv(
+        config=WargameEnvConfig(
+            board_width=20,
+            board_height=20,
+            number_of_wargame_models=2,
+            number_of_objectives=1,
+            number_of_battle_rounds=8,
+            terrain=[
+                TerrainPieceConfig(footprint=(5, 5, 8, 8)),
+                TerrainPieceConfig(footprint=(12, 12, 15, 16)),
+            ],
+        )
+    )
+    env.reset(seed=LAYOUT_SEED)
+    env.action_space.seed(0)
+    expected = env.to_snapshot().terrain_footprints
+    assert expected is not None
+
+    log = EventLog(anchor_interval=_ANCHOR_INTERVAL)
+    log.record_reset(env.to_snapshot())
+    for _ in range(9):
+        env.step(WargameEnvAction(actions=env.action_space.sample()))
+        log.record_step(env.to_snapshot())
+    return log, expected
+
+
+def test_terrain_survives_encode_decode() -> None:
+    """Every reconstructed frame carries the recorded terrain outlines."""
+    log, expected = _terrain_recording()
+
+    decoded = JsonMatchCodec().decode(JsonMatchCodec().encode(log))
+    snapshots = ReplayController(decoded).iter_snapshots()
+
+    assert len(snapshots) > _ANCHOR_INTERVAL  # crosses at least one anchor
+    for snapshot in snapshots:
+        assert snapshot.terrain_footprints == expected
+
+
+def test_terrain_survives_a_mid_anchor_seek() -> None:
+    """A seek that resumes from a mid-episode anchor still has terrain.
+
+    Terrain lives on anchors, not deltas, so a `seek` that rebuilds from the
+    nearest anchor forward would drop it if anchors did not carry it.
+    """
+    log, expected = _terrain_recording()
+    controller = ReplayController(JsonMatchCodec().decode(JsonMatchCodec().encode(log)))
+
+    past_first_anchor = _ANCHOR_INTERVAL + 2
+    snapshot = controller.seek(past_first_anchor)
+
+    assert snapshot.step == past_first_anchor
+    assert snapshot.terrain_footprints == expected
+
+
+def test_pre_2_1_recording_decodes_without_terrain() -> None:
+    """A recording written before schema 2.1 loads with terrain_footprints=None."""
+    log, _ = _terrain_recording()
+    data = JsonMatchCodec().encode(log)
+
+    # Simulate an old recording: drop the field and revert the version everywhere.
+    def _scrub(value: object) -> None:
+        if isinstance(value, dict):
+            value.pop("terrain_footprints", None)
+            if value.get("schema_version") == "2.1":
+                value["schema_version"] = "2.0"
+            for child in value.values():
+                _scrub(child)
+        elif isinstance(value, list):
+            for child in value:
+                _scrub(child)
+
+    lines = data.decode().splitlines()
+    rewritten = [lines[0]]
+    for line in lines[1:]:
+        obj = json.loads(line)
+        _scrub(obj)
+        rewritten.append(json.dumps(obj))
+    old_data = "\n".join(rewritten).encode()
+
+    snapshots = ReplayController(JsonMatchCodec().decode(old_data)).iter_snapshots()
+
+    assert snapshots  # decoded without raising
+    assert all(s.schema_version == "2.0" for s in snapshots)
+    assert all(s.terrain_footprints is None for s in snapshots)

--- a/tests/test_v9_milestone_validation.py
+++ b/tests/test_v9_milestone_validation.py
@@ -333,7 +333,7 @@ class TestRequirementSpotChecks:
         env.reset(seed=1)
         env.action_space.seed(1)
         snap = env.to_snapshot()
-        assert snap.schema_version == "2.0"
+        assert snap.schema_version == "2.1"
         schema = GameStateSnapshot.model_json_schema()
         assert "properties" in schema
 

--- a/wargame_rl/wargame/envs/state/events.py
+++ b/wargame_rl/wargame/envs/state/events.py
@@ -45,6 +45,9 @@ class StateDelta(BaseModel):
     step: int
     clock: ClockSnapshot | None = None
     action_phase: str | None = None
+    # No terrain field, deliberately: terrain is static for the episode and rides
+    # on the reset/anchor snapshots, so apply_delta preserves it via model_copy.
+    # Adding it here would bloat every step with an unchanging outline set.
     objectives: list[ObjectiveSnapshot] | None = None
     player_model_deltas: list[ModelDelta] = Field(default_factory=list)
     opponent_model_deltas: list[ModelDelta] = Field(default_factory=list)
@@ -223,6 +226,8 @@ def apply_delta(
             o_models[md.idx] = _apply_model_delta(o_models[md.idx], md)
         updates["opponent_models"] = o_models
 
+    # `terrain_footprints` is intentionally absent from `updates`, so it carries
+    # through unchanged from the base snapshot (the anchor) across every delta.
     result: GameStateSnapshot = snapshot.model_copy(update=updates)
     return result
 

--- a/wargame_rl/wargame/envs/state/snapshot.py
+++ b/wargame_rl/wargame/envs/state/snapshot.py
@@ -27,6 +27,7 @@ from wargame_rl.wargame.envs.types.game_timing import BattlePhase, GameState
 
 if TYPE_CHECKING:
     from wargame_rl.wargame.envs.domain.entities import WargameModel, WargameObjective
+    from wargame_rl.wargame.envs.domain.terrain import Terrain
     from wargame_rl.wargame.envs.types.config import ModelConfig
 
 
@@ -125,7 +126,7 @@ class GameStateSnapshot(BaseModel):
     attributing ``player_actions`` to a phase.
     """
 
-    schema_version: str = "2.0"
+    schema_version: str = "2.1"
     step: int
     max_steps: int
     clock: ClockSnapshot
@@ -138,6 +139,13 @@ class GameStateSnapshot(BaseModel):
     objectives: list[ObjectiveSnapshot]
     deployment_zone: list[int]
     opponent_deployment_zone: list[int]
+    terrain_footprints: list[list[list[float]]] | None = None
+    """Outline vertices of each terrain piece, one ``[[x, y], ...]`` per footprint.
+
+    Static per episode, so it is recorded on the reset snapshot and every anchor
+    (never in a delta — see ``build_snapshot``). ``None`` on pre-2.1 recordings,
+    which carried no terrain; a replay of those draws no ruins.
+    """
     player_vp: int
     opponent_vp: int
     player_vp_delta: int
@@ -455,10 +463,20 @@ def build_snapshot(
     shooting_slice_start: int | None = None,
     shooting_slice_end: int | None = None,
     action_phase: str | None = None,
+    terrain: "Terrain | None" = None,
 ) -> GameStateSnapshot:
     """Build a complete game-state snapshot from env internals."""
     player_configs = config.models
     opponent_configs = config.opponent_models
+
+    # Terrain is static for the episode, so it rides on every full snapshot
+    # (reset + anchors) and is intentionally left out of deltas — apply_delta
+    # preserves it from the anchor. Do NOT move this into StateDelta.
+    terrain_footprints: list[list[list[float]]] | None = (
+        [fp.polygon.vertices.tolist() for fp in terrain.footprints]
+        if terrain is not None and terrain.footprints
+        else None
+    )
 
     spatial = _compute_spatial_data(player_models, opponent_models, objectives)
 
@@ -550,6 +568,7 @@ def build_snapshot(
         objectives=obj_snaps,
         deployment_zone=dz,
         opponent_deployment_zone=odz,
+        terrain_footprints=terrain_footprints,
         player_vp=player_vp,
         opponent_vp=opponent_vp,
         player_vp_delta=player_vp_delta,

--- a/wargame_rl/wargame/envs/wargame.py
+++ b/wargame_rl/wargame/envs/wargame.py
@@ -992,6 +992,7 @@ class WargameEnv(gym.Env):
             action_phase=(
                 self._last_action_phase.value if self._last_action_phase else None
             ),
+            terrain=self.terrain,
         )
 
     def load_state(


### PR DESCRIPTION
## Summary

Store terrain geometry in game-state recordings so a match can be replayed faithfully. Recordings carried dynamic state (models, objectives, VP, combat, reward) but not the terrain, so a replay had no ruins unless it re-created an env from a matching fixed-terrain config — and random terrain, which regenerates every reset with no stored seed, could never be reproduced.

This is the first, standalone PR of the renderer-v2 work: it's self-contained, backward-compatible, and useful on its own to anything that consumes recordings (analysis, replay, external tooling). The upcoming replay renderer depends on it.

## Change

Terrain is static per episode, so it rides on the **full** snapshots (reset + every anchor) and is deliberately kept **out of** `StateDelta` — `apply_delta` preserves it from the anchor via `model_copy`, so a mid-episode `seek` stays faithful without bloating every step with an unchanging outline set.

- `envs/state/snapshot.py` — add optional `terrain_footprints: list[list[list[float]]] | None` (one outline per footprint, mirroring `ObjectiveSnapshot.area`); bump `schema_version` to `2.1`; `build_snapshot` gains a `terrain: Terrain | None` param filled from `fp.polygon.vertices`.
- `envs/wargame.py` — `to_snapshot()` passes `terrain=self.terrain` (the single capture site; the `EventLogExporter` records reset + anchors through it).
- `envs/state/events.py` — no delta field; comments at `StateDelta` and `apply_delta` so nobody adds terrain to the delta.
- `docs/game-state-io.md` — schema block updated (version + field).

## Backward compatibility

The field is optional and `GameStateSnapshot` has no `extra="forbid"`, so **pre-2.1 recordings decode with `terrain_footprints=None`** and old readers ignore the new field. The codec header `version` ("1.0", log format) is left distinct from `schema_version` ("2.1").

## Tests

- `test_snapshot.py::TestTerrainFootprints` — footprints match the env's terrain, survive JSON, and are `None` without terrain.
- `test_snapshot_round_trip.py` — terrain survives encode→decode; a **mid-anchor `seek`** still carries it; a **pre-2.1 recording** (field stripped, version reverted) decodes with `None` and does not raise.
- Verified end-to-end: a recorded episode's reset line carries `terrain_footprints`; `just replay-summary` parses it.

Golden gates (`test_reward_golden`, `test_observation_golden`) and the full state-I/O suite pass — the change is additive and off the reward/observation path.
