### PR TITLE
feat: add renderer v2 core (scene/backend/presenter) alongside legacy

### DIFF
--- a/simulate.py
+++ b/simulate.py
@@ -14,7 +14,8 @@ from pathlib import Path
 import typer
 from pydantic_yaml import parse_yaml_raw_as
 
-from wargame_rl.wargame.envs.renders.human import HumanRender, QuitRequested
+from wargame_rl.wargame.envs.renders.human import QuitRequested
+from wargame_rl.wargame.envs.renders.v2 import build_renderer
 from wargame_rl.wargame.envs.state import EventLogExporter, JsonMatchCodec
 from wargame_rl.wargame.envs.types import WargameEnvConfig
 from wargame_rl.wargame.model.common.argmax_agent import ArgmaxAgent
@@ -46,6 +47,8 @@ def simulate(
     render: bool = True,
     env_config_path: str | None = None,
     record_events: bool = False,
+    renderer_name: str = "legacy",
+    backend: str = "pygame",
 ) -> None:
     """Run simulation with trained agent.
 
@@ -54,6 +57,8 @@ def simulate(
         num_episodes: Number of episodes to run
         render: Whether to render the environment
         record_events: Whether to record the last episode as a JSON event log
+        renderer_name: ``legacy`` (HumanRender) or ``v2`` (the new renderer)
+        backend: v2 drawing backend (``pygame``)
     """
 
     if not os.path.exists(checkpoint_path):
@@ -62,7 +67,11 @@ def simulate(
     logging.info(f"Loading model from checkpoint: {checkpoint_path}")
 
     env_config = get_env_config(env_config_path, render)
-    renderer = HumanRender()
+    renderer = (
+        build_renderer(renderer_name, "interactive", backend=backend)
+        if render
+        else None
+    )
 
     event_exporter: EventLogExporter | None = None
     if record_events:
@@ -208,6 +217,12 @@ def main(
         False,
         help="Record the last episode as a JSON event log (written to recordings/)",
     ),
+    renderer: str = typer.Option(
+        "legacy", help="Renderer to use: 'legacy' (HumanRender) or 'v2'"
+    ),
+    backend: str = typer.Option(
+        "pygame", help="v2 drawing backend (only 'pygame' in Phase 1)"
+    ),
 ) -> None:
     # Handle dynamic defaults inside the function
     if checkpoint_path is None:
@@ -222,6 +237,8 @@ def main(
         render,
         env_config_path,
         record_events=record_events,
+        renderer_name=renderer,
+        backend=backend,
     )
 
 

--- a/tests/test_renderer_v2.py
+++ b/tests/test_renderer_v2.py
@@ -1,0 +1,170 @@
+"""Renderer v2: Scene purity, control extraction, FrameSource, and A/B vs legacy.
+
+The Scene tests need no pygame — they pin the board-coordinate conventions (no
+`+0.5`, the base-radius rule) that only the renderer can get wrong, now that
+those live in `build_scene` rather than in a draw method. The pixel tests render
+v2 and the untouched legacy renderer headlessly and check they agree.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import numpy as np
+import pytest
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+from wargame_rl.wargame.envs.renders.human import HumanRender  # noqa: E402
+from wargame_rl.wargame.envs.renders.renderer import FrameSource  # noqa: E402
+from wargame_rl.wargame.envs.renders.v2 import build_renderer  # noqa: E402
+from wargame_rl.wargame.envs.renders.v2.control import (  # noqa: E402
+    compute_objective_control,
+)
+from wargame_rl.wargame.envs.renders.v2.scene import (  # noqa: E402
+    Control,
+    Disc,
+    build_scene,
+)
+from wargame_rl.wargame.envs.renders.v2.theme import DEFAULT_THEME  # noqa: E402
+from wargame_rl.wargame.envs.types import WargameEnvConfig  # noqa: E402
+from wargame_rl.wargame.envs.types.config import (  # noqa: E402
+    ModelConfig,
+    ObjectiveConfig,
+    TerrainPieceConfig,
+)
+from wargame_rl.wargame.envs.wargame import WargameEnv  # noqa: E402
+
+
+def _env(**overrides: Any) -> WargameEnv:
+    base: dict[str, Any] = dict(
+        board_width=20,
+        board_height=20,
+        number_of_wargame_models=1,
+        number_of_objectives=1,
+        number_of_battle_rounds=3,
+        render_mode=None,
+    )
+    base.update(overrides)
+    env = WargameEnv(config=WargameEnvConfig(**base))
+    env.reset(seed=0)
+    return env
+
+
+# --- Scene purity (no pygame) ----------------------------------------------
+
+
+def test_build_scene_draws_player_at_its_board_location() -> None:
+    env = _env(models=[ModelConfig(x=7, y=5)])
+    scene = build_scene(env, compute_objective_control(env), scale=10.0)
+
+    model = env.player_models[0]
+    discs = [
+        p for p in scene.primitives if isinstance(p, Disc) and p.center == (7.0, 5.0)
+    ]
+    assert discs, "expected a player disc at the model's exact board coordinate"
+    assert discs[0].fill is not None
+    assert discs[0].fill[:3] == DEFAULT_THEME.player_color(model.group_id)
+
+
+def test_build_scene_uses_the_real_base_radius() -> None:
+    env = _env(models=[ModelConfig(x=7, y=5)], base_radius=2.0)
+    scene = build_scene(env, compute_objective_control(env), scale=10.0)
+
+    resolved = env.player_models[0].base_radius
+    assert resolved > 0.0  # config base_radius resolves onto the model
+    disc = next(
+        p for p in scene.primitives if isinstance(p, Disc) and p.center == (7.0, 5.0)
+    )
+    assert disc.radius == pytest.approx(resolved)  # board units, not the 1/3 token
+
+
+def test_build_scene_grid_toggles() -> None:
+    env = _env()
+    with_grid = build_scene(
+        env, compute_objective_control(env), scale=10.0, show_grid=True
+    )
+    without = build_scene(
+        env, compute_objective_control(env), scale=10.0, show_grid=False
+    )
+    assert len(with_grid.primitives) > len(without.primitives)
+
+
+# --- Control extraction (behaviour) ----------------------------------------
+
+
+def test_uncontested_objective_is_player_held() -> None:
+    env = _env(
+        number_of_objectives=1,
+        objectives=[ObjectiveConfig(x=5, y=5)],
+        models=[ModelConfig(x=5, y=5)],
+    )
+    assert compute_objective_control(env) == (Control.PLAYER,)
+
+
+def test_control_length_matches_objectives() -> None:
+    env = _env(number_of_objectives=3)
+    control = compute_objective_control(env)
+    assert len(control) == 3
+    assert all(isinstance(c, Control) for c in control)
+
+
+# --- FrameSource ------------------------------------------------------------
+
+
+def test_recording_presenter_and_legacy_are_frame_sources() -> None:
+    assert isinstance(build_renderer("v2", "recording"), FrameSource)
+    assert isinstance(HumanRender(), FrameSource)
+
+
+# --- A/B pixel parity vs the untouched legacy renderer ---------------------
+
+
+def _frame(renderer_name: str, config: WargameEnvConfig, seed: int = 0) -> np.ndarray:
+    renderer = build_renderer(renderer_name, "recording")
+    env = WargameEnv(config=config, renderer=renderer)
+    env.reset(seed=seed)
+    env.render()
+    assert isinstance(renderer, FrameSource)
+    return renderer.get_frame_array()
+
+
+def _ab_config() -> WargameEnvConfig:
+    return WargameEnvConfig(
+        board_width=20,
+        board_height=20,
+        number_of_wargame_models=1,
+        number_of_objectives=1,
+        number_of_battle_rounds=3,
+        render_mode=None,
+        models=[ModelConfig(x=5, y=5)],
+        terrain=[TerrainPieceConfig(footprint=(10, 10, 14, 14))],
+    )
+
+
+def test_v2_frame_matches_legacy_shape_and_coverage() -> None:
+    config = _ab_config()
+    legacy = _frame("legacy", config)
+    v2 = _frame("v2", config)
+
+    assert v2.shape == legacy.shape
+    legacy_nonwhite = int((legacy != 255).any(axis=2).sum())
+    v2_nonwhite = int((v2 != 255).any(axis=2).sum())
+    # Same board, same primitives: coverage should be within a couple of percent
+    # (fonts and alpha compositing differ by a hair, so not exact).
+    assert abs(v2_nonwhite - legacy_nonwhite) < 0.02 * legacy_nonwhite
+
+
+def test_v2_draws_the_player_in_its_group_colour() -> None:
+    config = _ab_config()
+    v2 = _frame("v2", config)
+
+    # Board is 20x20 fit to 1024; the board sits below the 36px north panel.
+    scale = 1024 / 20
+    north = 36
+    px = int(5 * scale)
+    py = int(5 * scale) + north
+    patch = v2[py - 3 : py + 3, px - 3 : px + 3].reshape(-1, 3).mean(axis=0)
+    # Group 0 is blue (0, 0, 255): blue channel dominates.
+    assert patch[2] > patch[0] and patch[2] > patch[1]

--- a/wargame_rl/wargame/envs/CLAUDE.md
+++ b/wargame_rl/wargame/envs/CLAUDE.md
@@ -58,6 +58,7 @@ Applies to everything under `wargame_rl/wargame/envs/`.
 - `"human"` (Pygame) / `"rgb_array"` (video); renderer injected via constructor
 - Player: blue/green circles · Opponents: red/warm triangles
 - Use a single FPS cap for human rendering; avoid phase-conditional throttle — it breaks when default stepping changes (e.g. skip_phases)
+- **Two renderers**: legacy `renders/human.py` (`HumanRender`, the default) and `renders/v2/` — a `Scene`→`Backend`→`Presenter` split (`build_scene` is domain-free, `control.py` isolates the ownership/LOS domain reads, `PygameBackend` draws, interactive/recording presenters). Pick via `renders.v2.build_renderer(name, mode, backend=...)` (`name="legacy"|"v2"`); `simulate.py` exposes `--renderer/--mode/--backend`, the record callback takes `renderer_name`/`backend`. Both default to `legacy`, so v2 is opt-in and A/B-able. Recording depends on the `FrameSource` protocol (in `renders/renderer.py`), which both satisfy — do **not** add abstract methods to the `Renderer` ABC. Legacy `human.py` is frozen as the A/B baseline (`tests/test_terrain_render.py` depends on it)
 
 ## Adding Features
 

--- a/wargame_rl/wargame/envs/renders/renderer.py
+++ b/wargame_rl/wargame/envs/renders/renderer.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import Protocol, runtime_checkable
+
+import numpy as np
 
 from wargame_rl.wargame.envs.domain.battle_view import BattleView
 
@@ -17,3 +20,21 @@ class Renderer(ABC):
     @abstractmethod
     def close(self) -> None:
         pass
+
+
+@runtime_checkable
+class FrameSource(Protocol):
+    """A renderer that can hand back the last frame as an RGB array.
+
+    Not on the `Renderer` ABC on purpose: only the recording path needs frames,
+    and making it abstract would force it onto every renderer. The recording
+    callback depends on this protocol instead of a concrete class, so both the
+    legacy `HumanRender` (which already has `epoch` and `get_frame_array`) and the
+    v2 recording presenter satisfy it structurally.
+    """
+
+    epoch: int | None
+
+    def get_frame_array(self) -> np.ndarray:
+        """The most recently rendered frame as ``(H, W, 3)`` uint8."""
+        ...

--- a/wargame_rl/wargame/envs/renders/v2/__init__.py
+++ b/wargame_rl/wargame/envs/renders/v2/__init__.py
@@ -1,0 +1,20 @@
+"""Renderer v2: a Scene → Backend → Presenter subsystem.
+
+Public surface is the factory plus the presenters; the legacy `HumanRender` at
+`renders/human.py` stays the default and is untouched.
+"""
+
+from wargame_rl.wargame.envs.renders.v2.factory import build_renderer
+from wargame_rl.wargame.envs.renders.v2.presenters.interactive import (
+    InteractiveRenderer,
+)
+from wargame_rl.wargame.envs.renders.v2.presenters.recording import RecordingRenderer
+from wargame_rl.wargame.envs.renders.v2.theme import DEFAULT_THEME, Theme
+
+__all__ = [
+    "build_renderer",
+    "InteractiveRenderer",
+    "RecordingRenderer",
+    "DEFAULT_THEME",
+    "Theme",
+]

--- a/wargame_rl/wargame/envs/renders/v2/backend.py
+++ b/wargame_rl/wargame/envs/renders/v2/backend.py
@@ -1,0 +1,125 @@
+"""The swappable drawing seam.
+
+A `RenderBackend` implements a handful of primitive draws against its own canvas
+type (pygame Surface, PIL Image, ...). `rasterize` walks a `Scene`'s primitives,
+applies the `Camera`, and dispatches to those draws, so every backend renders the
+identical primitives — which is what makes the Phase 2 bake-off apples-to-apples.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+import numpy as np
+
+from wargame_rl.wargame.envs.renders.v2.camera import Camera
+from wargame_rl.wargame.envs.renders.v2.scene import Disc, Label, Poly, Scene, Seg
+from wargame_rl.wargame.envs.renders.v2.theme import RGB, RGBA
+
+# The canvas is the backend's own surface type; callers pass it back opaquely.
+Canvas = Any
+Point = tuple[float, float]
+
+
+class RenderBackend(Protocol):
+    """Minimal primitive set every backend implements."""
+
+    def new_canvas(self, width_px: int, height_px: int, bg: RGB) -> Canvas:
+        """A fresh canvas filled with ``bg``."""
+        ...
+
+    def fill_rect(
+        self, canvas: Canvas, rect: tuple[int, int, int, int], color: RGB
+    ) -> None:
+        """Fill an ``(x, y, w, h)`` rectangle."""
+        ...
+
+    def draw_line(
+        self, canvas: Canvas, a: Point, b: Point, color: RGB, width: int
+    ) -> None:
+        """Stroke a line segment."""
+        ...
+
+    def draw_polygon(
+        self,
+        canvas: Canvas,
+        points: list[Point],
+        fill: RGBA | None,
+        outline: RGB | None,
+        width: int,
+    ) -> None:
+        """Fill (honouring alpha) and/or outline a polygon."""
+        ...
+
+    def draw_disc(
+        self,
+        canvas: Canvas,
+        center: Point,
+        radius_px: float,
+        fill: RGBA | None,
+        outline: RGB | None,
+        width: int,
+    ) -> None:
+        """Fill (honouring alpha) and/or outline a circle."""
+        ...
+
+    def draw_text(
+        self,
+        canvas: Canvas,
+        text: str,
+        anchor: Point,
+        size_px: int,
+        color: RGB,
+        align: str = "center",
+    ) -> None:
+        """Draw text anchored ``center`` / ``midleft`` / ``midright``."""
+        ...
+
+    def text_size(self, text: str, size_px: int) -> tuple[int, int]:
+        """Rendered ``(width, height)`` of text at a size — for panel layout."""
+        ...
+
+    def blit(self, canvas: Canvas, src: Canvas, pos: Point) -> None:
+        """Composite one canvas onto another."""
+        ...
+
+    def to_rgb_array(self, canvas: Canvas) -> np.ndarray:
+        """Canvas as an ``(H, W, 3)`` uint8 array."""
+        ...
+
+
+def rasterize(
+    backend: RenderBackend, scene: Scene, camera: Camera, canvas: Canvas
+) -> None:
+    """Draw a scene's primitives onto a canvas via a backend and camera."""
+    for primitive in scene.primitives:
+        if isinstance(primitive, Poly):
+            points = [camera.to_px(x, y) for x, y in primitive.points]
+            backend.draw_polygon(
+                canvas, points, primitive.fill, primitive.outline, primitive.outline_w
+            )
+        elif isinstance(primitive, Disc):
+            backend.draw_disc(
+                canvas,
+                camera.to_px(*primitive.center),
+                primitive.radius * camera.scale,
+                primitive.fill,
+                primitive.outline,
+                primitive.outline_w,
+            )
+        elif isinstance(primitive, Seg):
+            backend.draw_line(
+                canvas,
+                camera.to_px(*primitive.a),
+                camera.to_px(*primitive.b),
+                primitive.color,
+                primitive.width,
+            )
+        elif isinstance(primitive, Label):
+            backend.draw_text(
+                canvas,
+                primitive.text,
+                camera.to_px(*primitive.center),
+                primitive.size,
+                primitive.color,
+            )

--- a/wargame_rl/wargame/envs/renders/v2/backends/__init__.py
+++ b/wargame_rl/wargame/envs/renders/v2/backends/__init__.py
@@ -1,0 +1,1 @@
+"""Concrete drawing backends for the v2 renderer."""

--- a/wargame_rl/wargame/envs/renders/v2/backends/pygame_backend.py
+++ b/wargame_rl/wargame/envs/renders/v2/backends/pygame_backend.py
@@ -1,0 +1,108 @@
+"""Pygame drawing backend — the primitive calls the legacy renderer used.
+
+`to_rgb_array` matches `HumanRender.get_frame_array` (transpose pygame's
+`(w, h, 3)` to `(h, w, 3)`) so recorded frames are identical in shape and
+orientation to the legacy path.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pygame
+
+from wargame_rl.wargame.envs.renders.v2.theme import RGB, RGBA
+
+Point = tuple[float, float]
+
+_ALIGNS = {"center", "midleft", "midright", "topleft"}
+
+
+class PygameBackend:
+    """Renders primitives onto `pygame.Surface` canvases."""
+
+    def __init__(self) -> None:
+        if not pygame.get_init():
+            pygame.init()
+        if not pygame.font.get_init():
+            pygame.font.init()
+
+    def new_canvas(self, width_px: int, height_px: int, bg: RGB) -> pygame.Surface:
+        surface = pygame.Surface((max(1, width_px), max(1, height_px)))
+        surface.fill(bg)
+        return surface
+
+    def fill_rect(
+        self, canvas: pygame.Surface, rect: tuple[int, int, int, int], color: RGB
+    ) -> None:
+        pygame.draw.rect(canvas, color, pygame.Rect(*rect))
+
+    def draw_line(
+        self, canvas: pygame.Surface, a: Point, b: Point, color: RGB, width: int
+    ) -> None:
+        pygame.draw.line(canvas, color, a, b, max(1, int(width)))
+
+    def draw_polygon(
+        self,
+        canvas: pygame.Surface,
+        points: list[Point],
+        fill: RGBA | None,
+        outline: RGB | None,
+        width: int,
+    ) -> None:
+        if len(points) >= 3:
+            if fill is not None:
+                if len(fill) == 4 and fill[3] < 255:
+                    layer = pygame.Surface(canvas.get_size(), pygame.SRCALPHA)
+                    pygame.draw.polygon(layer, fill, points)
+                    canvas.blit(layer, (0, 0))
+                else:
+                    pygame.draw.polygon(canvas, fill[:3], points)
+            if outline is not None:
+                pygame.draw.polygon(canvas, outline, points, max(1, int(width)))
+
+    def draw_disc(
+        self,
+        canvas: pygame.Surface,
+        center: Point,
+        radius_px: float,
+        fill: RGBA | None,
+        outline: RGB | None,
+        width: int,
+    ) -> None:
+        radius = max(1, int(round(radius_px)))
+        if fill is not None:
+            if len(fill) == 4 and fill[3] < 255:
+                layer = pygame.Surface(canvas.get_size(), pygame.SRCALPHA)
+                pygame.draw.circle(layer, fill, center, radius)
+                canvas.blit(layer, (0, 0))
+            else:
+                pygame.draw.circle(canvas, fill[:3], center, radius)
+        if outline is not None:
+            pygame.draw.circle(canvas, outline, center, radius, max(1, int(width)))
+
+    def draw_text(
+        self,
+        canvas: pygame.Surface,
+        text: str,
+        anchor: Point,
+        size_px: int,
+        color: RGB,
+        align: str = "center",
+    ) -> None:
+        font = pygame.font.Font(None, max(1, int(size_px)))
+        surface = font.render(text, True, color)
+        anchor_kw = align if align in _ALIGNS else "center"
+        rect = surface.get_rect(**{anchor_kw: (int(anchor[0]), int(anchor[1]))})
+        canvas.blit(surface, rect)
+
+    def text_size(self, text: str, size_px: int) -> tuple[int, int]:
+        width, height = pygame.font.Font(None, max(1, int(size_px))).size(text)
+        return (int(width), int(height))
+
+    def blit(self, canvas: pygame.Surface, src: pygame.Surface, pos: Point) -> None:
+        canvas.blit(src, (int(pos[0]), int(pos[1])))
+
+    def to_rgb_array(self, canvas: pygame.Surface) -> np.ndarray:
+        return np.asarray(
+            np.transpose(pygame.surfarray.array3d(canvas), (1, 0, 2)), dtype=np.uint8
+        )

--- a/wargame_rl/wargame/envs/renders/v2/camera.py
+++ b/wargame_rl/wargame/envs/renders/v2/camera.py
@@ -1,0 +1,41 @@
+"""The board→pixel transform, isolated so pan/zoom has one place to live.
+
+Phase 1 uses only `fit` (the legacy fit-to-`GRID_SIZE` letterbox) with a zero
+offset; `pan`/`zoom_at` are stubbed for Phase 4. Keeping the transform here is
+what lets the interactive presenter gain pan/zoom later without touching the
+scene or any backend.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Camera:
+    """Maps board units to pixels: ``px = unit * scale + offset``."""
+
+    scale: float
+    offset_x: float = 0.0
+    offset_y: float = 0.0
+
+    def to_px(self, x: float, y: float) -> tuple[float, float]:
+        """Board coordinate to pixel coordinate."""
+        return (x * self.scale + self.offset_x, y * self.scale + self.offset_y)
+
+    @classmethod
+    def fit(cls, board_width: float, board_height: float, scale: float) -> "Camera":
+        """A camera at a given board→pixel scale with no pan offset."""
+        return cls(scale=scale)
+
+    def pan(self, dx_px: float, dy_px: float) -> None:
+        """Shift the view (Phase 4)."""
+        self.offset_x += dx_px
+        self.offset_y += dy_px
+
+    def zoom_at(self, cursor_px: tuple[float, float], factor: float) -> None:
+        """Zoom keeping the cursor point fixed (Phase 4)."""
+        cx, cy = cursor_px
+        self.offset_x = cx - (cx - self.offset_x) * factor
+        self.offset_y = cy - (cy - self.offset_y) * factor
+        self.scale *= factor

--- a/wargame_rl/wargame/envs/renders/v2/control.py
+++ b/wargame_rl/wargame/envs/renders/v2/control.py
@@ -1,0 +1,92 @@
+"""Domain reads the v2 renderer needs, returned as plain data.
+
+The legacy renderer computed objective ownership and the debug LOS verdict inside
+its draw methods, mixing domain calls into drawing. v2 keeps drawing
+(`scene`/`backend`) domain-free by doing those reads here and handing the results
+to `build_scene` as data. This is the one place v2 touches the domain, and it
+reuses the exact functions the legacy renderer used so the results match.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from wargame_rl.wargame.envs.domain.battle_view import BattleView
+from wargame_rl.wargame.envs.domain.entities import alive_mask_for
+from wargame_rl.wargame.envs.env_components.distance_cache import (
+    compute_distances,
+    objective_ownership_from_norms_offset,
+)
+from wargame_rl.wargame.envs.renders.v2.scene import Control
+
+
+def compute_objective_control(view: BattleView) -> tuple[Control, ...]:
+    """Ownership per objective, mirroring the legacy ``_draw_target`` body.
+
+    Reproduced exactly, including the empty-opponent branch that feeds a
+    ``(0, n_obj)`` norms array so a board with no opponents still resolves.
+    """
+    objectives = view.objectives
+    if not objectives:
+        return ()
+
+    player_models = view.player_models
+    opponent_models = view.opponent_models
+    n_obj = len(objectives)
+
+    player_alive = alive_mask_for(player_models)
+    player_cache = compute_distances(player_models, objectives, alive_mask=player_alive)
+    if opponent_models:
+        opponent_alive = alive_mask_for(opponent_models)
+        opponent_cache = compute_distances(
+            opponent_models, objectives, alive_mask=opponent_alive
+        )
+        opponent_norms = opponent_cache.model_obj_norms_offset
+    else:
+        opponent_norms = np.zeros((0, n_obj), dtype=np.float64)
+
+    player_controls, opponent_controls = objective_ownership_from_norms_offset(
+        player_cache.model_obj_norms_offset,
+        opponent_norms,
+        player_cache.obj_radii,
+    )
+
+    result: list[Control] = []
+    for i in range(n_obj):
+        if player_controls[i]:
+            result.append(Control.PLAYER)
+        elif opponent_controls[i]:
+            result.append(Control.OPPONENT)
+        else:
+            result.append(Control.NEUTRAL)
+    return tuple(result)
+
+
+@dataclass(frozen=True)
+class LosResult:
+    """The debug sight line and whether it is clear."""
+
+    clear: bool
+    a: tuple[float, float]
+    b: tuple[float, float]
+
+
+def probe_debug_los(view: BattleView) -> LosResult | None:
+    """First alive player to first alive opponent; ``None`` if either is absent."""
+    player_alive = alive_mask_for(view.player_models)
+    p_idx = next((i for i, ok in enumerate(player_alive) if ok), None)
+    if p_idx is None or not view.opponent_models:
+        return None
+    opponent_alive = alive_mask_for(view.opponent_models)
+    o_idx = next((i for i, ok in enumerate(opponent_alive) if ok), None)
+    if o_idx is None:
+        return None
+
+    pm = view.player_models[p_idx]
+    om = view.opponent_models[o_idx]
+    a = (float(pm.location[0]), float(pm.location[1]))
+    b = (float(om.location[0]), float(om.location[1]))
+    clear = view.has_line_of_sight_between_points(a[0], a[1], b[0], b[1])
+    return LosResult(clear=clear, a=a, b=b)

--- a/wargame_rl/wargame/envs/renders/v2/factory.py
+++ b/wargame_rl/wargame/envs/renders/v2/factory.py
@@ -1,0 +1,51 @@
+"""One entry point to pick a renderer, so call sites stay declarative.
+
+`legacy` returns the untouched `HumanRender`, which is the default everywhere, so
+existing behaviour is unchanged until a caller opts into `v2`. Only pygame is
+wired as an interactive backend in Phase 1; the AA and Pillow backends arrive in
+the Phase 2 bake-off.
+"""
+
+from __future__ import annotations
+
+from wargame_rl.wargame.envs.renders.human import HumanRender
+from wargame_rl.wargame.envs.renders.renderer import Renderer
+from wargame_rl.wargame.envs.renders.v2.backend import RenderBackend
+from wargame_rl.wargame.envs.renders.v2.backends.pygame_backend import PygameBackend
+from wargame_rl.wargame.envs.renders.v2.presenters.interactive import (
+    InteractiveRenderer,
+)
+from wargame_rl.wargame.envs.renders.v2.presenters.recording import RecordingRenderer
+from wargame_rl.wargame.envs.renders.v2.theme import DEFAULT_THEME, Theme
+
+
+def _build_backend(name: str) -> RenderBackend:
+    if name == "pygame":
+        return PygameBackend()
+    raise ValueError(f"unknown backend {name!r} (available: pygame)")
+
+
+def build_renderer(
+    name: str = "legacy",
+    mode: str = "interactive",
+    *,
+    backend: str = "pygame",
+    theme: Theme = DEFAULT_THEME,
+) -> Renderer:
+    """Construct a renderer.
+
+    name: ``legacy`` (the current `HumanRender`) or ``v2``.
+    mode: ``interactive`` (window) or ``recording`` (headless frames).
+    backend: v2 drawing backend; only ``pygame`` in Phase 1.
+    """
+    if name == "legacy":
+        return HumanRender()
+    if name != "v2":
+        raise ValueError(f"unknown renderer {name!r} (available: legacy, v2)")
+
+    be = _build_backend(backend)
+    if mode == "interactive":
+        return InteractiveRenderer(be, theme)
+    if mode == "recording":
+        return RecordingRenderer(be, theme)
+    raise ValueError(f"unknown mode {mode!r} (available: interactive, recording)")

--- a/wargame_rl/wargame/envs/renders/v2/presenters/__init__.py
+++ b/wargame_rl/wargame/envs/renders/v2/presenters/__init__.py
@@ -1,0 +1,1 @@
+"""v2 presenters: interactive window and headless recording."""

--- a/wargame_rl/wargame/envs/renders/v2/presenters/base.py
+++ b/wargame_rl/wargame/envs/renders/v2/presenters/base.py
@@ -1,0 +1,189 @@
+"""Shared presenter: build a Scene, rasterise the board, compose the HUD panels.
+
+Subclasses provide only the window/output half (`_present`) and, for interactive
+use, the event loop. The board is drawn to its own canvas at the fit scale and
+composited into a window-sized frame under the north panel; the panels are drawn
+with the same backend primitives so a recording includes them.
+"""
+
+from __future__ import annotations
+
+import math
+
+from wargame_rl.wargame.envs.domain.battle_view import BattleView
+from wargame_rl.wargame.envs.renders.renderer import Renderer
+from wargame_rl.wargame.envs.renders.v2.backend import Canvas, RenderBackend, rasterize
+from wargame_rl.wargame.envs.renders.v2.camera import Camera
+from wargame_rl.wargame.envs.renders.v2.control import (
+    compute_objective_control,
+    probe_debug_los,
+)
+from wargame_rl.wargame.envs.renders.v2.scene import HudData, build_scene
+from wargame_rl.wargame.envs.renders.v2.theme import DEFAULT_THEME, Theme
+
+GRID_SIZE = 1024  # Longest board side, in pixels, at the fit scale.
+
+
+class BasePresenter(Renderer):
+    """Scene→frame pipeline shared by the interactive and recording presenters."""
+
+    def __init__(self, backend: RenderBackend, theme: Theme = DEFAULT_THEME) -> None:
+        self._backend = backend
+        self._theme = theme
+        self.epoch: int | None = None
+        self._debug_los = False
+        # Board fit + window layout, set in `setup`.
+        self._scale = 1.0
+        self._board_w = 1
+        self._board_h = 1
+        self._canvas_w = 1
+        self._canvas_h = 1
+        self._window_w = 1
+        self._window_h = 1
+        self._offset_x = 0
+        self._offset_y = theme.north_panel_h
+
+    def setup(self, view: BattleView) -> None:
+        self._board_w = view.config.board_width
+        self._board_h = view.config.board_height
+        self._scale = min(GRID_SIZE / self._board_w, GRID_SIZE / self._board_h)
+        self._recompute_layout()
+
+    def _recompute_layout(self) -> None:
+        self._canvas_w = math.ceil(self._scale * self._board_w)
+        self._canvas_h = math.ceil(self._scale * self._board_h)
+        north = self._theme.north_panel_h
+        south = self._theme.south_panel_rows * north
+        self._window_w = self._canvas_w
+        self._window_h = self._canvas_h + north + south
+        self._offset_x = 0
+        self._offset_y = north
+
+    def _compose(self, view: BattleView) -> Canvas:
+        """Render the board and panels into one window-sized frame."""
+        control = compute_objective_control(view)
+        los = probe_debug_los(view) if self._debug_los else None
+        scene = build_scene(
+            view,
+            control,
+            scale=self._scale,
+            theme=self._theme,
+            debug_los=los,
+            show_grid=self._theme.show_grid,
+        )
+
+        board = self._backend.new_canvas(self._canvas_w, self._canvas_h, scene.board_bg)
+        rasterize(self._backend, scene, Camera(self._scale), board)
+
+        frame = self._backend.new_canvas(
+            self._window_w, self._window_h, self._theme.palette.window_bg
+        )
+        self._backend.blit(frame, board, (self._offset_x, self._offset_y))
+        self._draw_panels(frame, scene.hud)
+        return frame
+
+    # -- panels --------------------------------------------------------------
+
+    def _draw_panels(self, frame: Canvas, hud: HudData) -> None:
+        pal = self._theme.palette
+        north = self._theme.north_panel_h
+        width = self._window_w
+
+        # North: hotkey bar.
+        self._backend.fill_rect(frame, (0, 0, width, north), pal.panel_bg)
+        self._backend.draw_line(frame, (0, north), (width, north), pal.panel_line, 1)
+        hotkeys = (
+            "PAUSED - Space: Resume | Esc: Quit | L: LOS debug"
+            if self._is_paused()
+            else "Space: Pause | Esc: Quit | L: LOS debug"
+        )
+        self._backend.draw_text(frame, hotkeys, (width // 2, north // 2), 24, pal.text)
+
+        # South: two info rows.
+        south_h = self._theme.south_panel_rows * north
+        panel_y = self._window_h - south_h
+        self._backend.fill_rect(frame, (0, panel_y, width, south_h), pal.panel_bg)
+        self._backend.draw_line(
+            frame, (0, panel_y), (width, panel_y), pal.panel_line, 1
+        )
+
+        row1_y = panel_y + north // 2
+        reward = f"{hud.reward:.3f}" if hud.reward is not None else "—"
+        turn = f"Round: {hud.round} / {hud.n_rounds}  |  {hud.phase}"
+        steps = f"Step: {hud.step}"
+        reward_text = f"Reward: {reward}"
+        if hud.epoch is not None:
+            for text, cx in (
+                (f"Epoch: {hud.epoch}", width // 8),
+                (turn, 3 * width // 8),
+                (steps, 5 * width // 8),
+                (reward_text, 7 * width // 8),
+            ):
+                self._backend.draw_text(frame, text, (cx, row1_y), 24, pal.text)
+        else:
+            for text, cx in (
+                (turn, width // 6),
+                (steps, width // 2),
+                (reward_text, 5 * width // 6),
+            ):
+                self._backend.draw_text(frame, text, (cx, row1_y), 24, pal.text)
+
+        row2_y = panel_y + north + north // 2
+        self._draw_vp(
+            frame, "Player VP:", hud.player_vp, hud.player_vp_delta, width // 4, row2_y
+        )
+        self._draw_vp(
+            frame,
+            "Opponent VP:",
+            hud.opponent_vp,
+            hud.opponent_vp_delta,
+            3 * width // 4,
+            row2_y,
+        )
+
+    def _draw_vp(
+        self,
+        frame: Canvas,
+        label: str,
+        value: int,
+        delta: int,
+        center_x: int,
+        center_y: int,
+    ) -> None:
+        """Fixed-field VP readout so nothing shifts when the delta appears."""
+        pal = self._theme.palette
+        gap = self._backend.text_size(" ", 24)[0]
+        value_field = self._backend.text_size("000", 24)[0]
+        delta_field = self._backend.text_size("(+00)", 24)[0]
+        label_w = self._backend.text_size(label, 24)[0]
+
+        total = label_w + gap + value_field + gap + delta_field
+        left = center_x - total // 2
+        self._backend.draw_text(frame, label, (left, center_y), 24, pal.text, "midleft")
+        value_right = left + label_w + gap + value_field
+        self._backend.draw_text(
+            frame, str(value), (value_right, center_y), 24, pal.text, "midright"
+        )
+        if delta > 0:
+            self._backend.draw_text(
+                frame,
+                f"(+{delta})",
+                (value_right + gap, center_y),
+                24,
+                pal.text,
+                "midleft",
+            )
+
+    # -- hooks ---------------------------------------------------------------
+
+    def _is_paused(self) -> bool:
+        return False
+
+    def _present(self, frame: Canvas) -> None:
+        raise NotImplementedError
+
+    def render(self, view: BattleView) -> None:
+        self._present(self._compose(view))
+
+    def close(self) -> None:
+        pass

--- a/wargame_rl/wargame/envs/renders/v2/presenters/interactive.py
+++ b/wargame_rl/wargame/envs/renders/v2/presenters/interactive.py
@@ -1,0 +1,180 @@
+"""Interactive presenter: a resizable pygame window with the legacy controls.
+
+Space pauses, Esc quits (raising `QuitRequested`, as the legacy renderer did),
+L toggles the debug sight line, a left click pins a model's tooltip, and resizing
+refits the board. Pan/zoom is deliberately absent in Phase 1 — the `Camera` is
+where it will slot in later.
+"""
+
+from __future__ import annotations
+
+import pygame
+
+from wargame_rl.wargame.envs.domain.battle_view import BattleView
+from wargame_rl.wargame.envs.renders.human import QuitRequested
+from wargame_rl.wargame.envs.renders.v2.backend import Canvas, RenderBackend
+from wargame_rl.wargame.envs.renders.v2.presenters.base import BasePresenter
+from wargame_rl.wargame.envs.renders.v2.theme import DEFAULT_THEME, Theme
+
+
+class InteractiveRenderer(BasePresenter):
+    """Drives a live pygame window."""
+
+    def __init__(self, backend: RenderBackend, theme: Theme = DEFAULT_THEME) -> None:
+        super().__init__(backend, theme)
+        self._window: pygame.Surface | None = None
+        self._clock: pygame.time.Clock | None = None
+        self._paused = False
+        self._should_quit = False
+        self._pinned: int | None = None
+        self._fps = 5
+
+    def setup(self, view: BattleView) -> None:
+        super().setup(view)
+        self._fps = int(view.metadata.get("render_fps", 5))
+        if self._window is None:
+            pygame.init()
+            pygame.display.init()
+            self._window = pygame.display.set_mode(
+                (self._window_w, self._window_h), pygame.RESIZABLE
+            )
+            pygame.display.set_caption("Wargame (v2)")
+        else:
+            self._window = pygame.display.set_mode(
+                (self._window_w, self._window_h), pygame.RESIZABLE
+            )
+        if self._clock is None:
+            self._clock = pygame.time.Clock()
+
+    def _is_paused(self) -> bool:
+        return self._paused
+
+    def render(self, view: BattleView) -> None:
+        self._process_events(view)
+        if self._should_quit:
+            raise QuitRequested()
+        self._present(self._compose_with_tooltip(view))
+        while self._paused:
+            self._process_events(view)
+            if self._should_quit:
+                raise QuitRequested()
+            self._present(self._compose_with_tooltip(view))
+
+    def _compose_with_tooltip(self, view: BattleView) -> Canvas:
+        frame = self._compose(view)
+        index = self._pinned if self._pinned is not None else self._hovered(view)
+        if index is not None:
+            self._draw_tooltip(frame, view, index)
+        return frame
+
+    def _present(self, frame: Canvas) -> None:
+        if self._window is None or self._clock is None:
+            return
+        self._window.blit(frame, (0, 0))
+        pygame.event.pump()
+        pygame.display.update()
+        self._clock.tick(self._fps)
+
+    # -- events --------------------------------------------------------------
+
+    def _process_events(self, view: BattleView) -> None:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                self._should_quit = True
+            elif event.type == pygame.VIDEORESIZE:
+                self._fit_to_window(view, event.w, event.h)
+            elif event.type == pygame.KEYDOWN:
+                if event.key == pygame.K_SPACE:
+                    self._paused = not self._paused
+                elif event.key == pygame.K_ESCAPE:
+                    self._should_quit = True
+                elif event.key == pygame.K_l:
+                    self._debug_los = not self._debug_los
+            elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+                self._pinned = self._model_index_at(view, event.pos[0], event.pos[1])
+
+    def _fit_to_window(self, view: BattleView, w: int, h: int) -> None:
+        north = self._theme.north_panel_h
+        south = self._theme.south_panel_rows * north
+        new_w = max(1, w)
+        new_h = max(north + south + 1, h)
+        if self._window is not None and (new_w, new_h) == self._window.get_size():
+            return
+        self._window = pygame.display.set_mode((new_w, new_h), pygame.RESIZABLE)
+        available_h = max(1, new_h - north - south)
+        self._scale = min(new_w / self._board_w, available_h / self._board_h)
+        import math
+
+        self._canvas_w = math.ceil(self._scale * self._board_w)
+        self._canvas_h = math.ceil(self._scale * self._board_h)
+        self._window_w = new_w
+        self._window_h = new_h
+        self._offset_x = (new_w - self._canvas_w) // 2
+        self._offset_y = north + (available_h - self._canvas_h) // 2
+
+    # -- tooltip -------------------------------------------------------------
+
+    def _model_index_at(self, view: BattleView, mx: int, my: int) -> int | None:
+        if not (
+            self._offset_x <= mx < self._offset_x + self._canvas_w
+            and self._offset_y <= my < self._offset_y + self._canvas_h
+        ):
+            return None
+        canvas_x = float(mx - self._offset_x)
+        canvas_y = float(my - self._offset_y)
+        hit_radius = max(self._scale / 2, 12.0)
+        for i, model in enumerate(view.player_models):
+            cx = model.location[0] * self._scale
+            cy = model.location[1] * self._scale
+            if (canvas_x - cx) ** 2 + (canvas_y - cy) ** 2 <= hit_radius**2:
+                return i
+        return None
+
+    def _hovered(self, view: BattleView) -> int | None:
+        mx, my = pygame.mouse.get_pos()
+        return self._model_index_at(view, mx, my)
+
+    def _draw_tooltip(self, frame: Canvas, view: BattleView, index: int) -> None:
+        model = view.player_models[index]
+        latest = (
+            model.model_rewards_history[-1] if model.model_rewards_history else None
+        )
+        lines = [
+            f"Location: ({model.location[0]}, {model.location[1]})",
+            f"Group ID: {model.group_id}",
+        ]
+        if latest is not None:
+            lines += [
+                f"Closest objective reward: {latest.closest_objective_reward:.3f}",
+                f"Group distance penalty: {latest.group_distance_violation_penalty:.3f}",
+                f"Total reward: {latest.total_reward:.3f}",
+            ]
+        pal = self._theme.palette
+        size = 22
+        line_h = self._backend.text_size("Xg", size)[1]
+        pad = 6
+        box_w = max(self._backend.text_size(line, size)[0] for line in lines) + 2 * pad
+        box_h = len(lines) * line_h + 2 * pad
+        cx = self._offset_x + model.location[0] * self._scale
+        cy = self._offset_y + model.location[1] * self._scale
+        x = int(max(4, min(cx + 14, self._window_w - box_w - 4)))
+        y = int(max(4, min(cy - box_h - 10, self._window_h - box_h - 4)))
+        self._backend.fill_rect(
+            frame, (x - 1, y - 1, box_w + 2, box_h + 2), pal.panel_line
+        )
+        self._backend.fill_rect(frame, (x, y, box_w, box_h), pal.panel_bg)
+        for j, line in enumerate(lines):
+            self._backend.draw_text(
+                frame,
+                line,
+                (x + pad, y + pad + j * line_h + line_h // 2),
+                size,
+                pal.text,
+                "midleft",
+            )
+
+    def close(self) -> None:
+        if self._window is not None:
+            pygame.display.quit()
+            pygame.quit()
+            self._window = None

--- a/wargame_rl/wargame/envs/renders/v2/presenters/recording.py
+++ b/wargame_rl/wargame/envs/renders/v2/presenters/recording.py
@@ -1,0 +1,30 @@
+"""Headless presenter for video capture.
+
+Holds the last composed frame and hands it back via `get_frame_array`, so it
+satisfies the `FrameSource` protocol the recording callback depends on. The
+caller sets `SDL_VIDEODRIVER=dummy` before import for headless pygame, exactly as
+the training recording path already does.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from wargame_rl.wargame.envs.renders.v2.backend import Canvas
+from wargame_rl.wargame.envs.renders.v2.presenters.base import BasePresenter
+
+
+class RecordingRenderer(BasePresenter):
+    """Renders frames to memory for MP4 export; no window."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)  # type: ignore[arg-type]
+        self._last_frame: Canvas | None = None
+
+    def _present(self, frame: Canvas) -> None:
+        self._last_frame = frame
+
+    def get_frame_array(self) -> np.ndarray:
+        if self._last_frame is None:
+            raise ValueError("No frame rendered yet; call render() first")
+        return self._backend.to_rgb_array(self._last_frame)

--- a/wargame_rl/wargame/envs/renders/v2/scene.py
+++ b/wargame_rl/wargame/envs/renders/v2/scene.py
@@ -1,0 +1,319 @@
+"""The Scene: a backend- and source-independent description of one frame.
+
+Primitives are plain dataclasses holding board-unit *positions* and pixel-space
+*sizes* (stroke widths, radii-in-fallback, font sizes). A backend rasterises
+them; a `Camera` maps positions to pixels. `build_scene` reads only the
+read-only `BattleView` surface, so a snapshot-driven builder (Phase 3) can emit
+the identical `Scene` type without an env.
+
+Sizes are pixels because the legacy renderer's legibility floors (`max(3, ...)`,
+the third-of-a-cell dead token) are pixel decisions; positions and base radii
+stay in board units so the `Camera` owns the board→pixel scale. `build_scene`
+therefore takes the current `scale` to resolve those pixel sizes.
+"""
+
+from __future__ import annotations
+
+import enum
+import math
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from wargame_rl.wargame.envs.renders.v2.theme import DEFAULT_THEME, RGB, RGBA, Theme
+
+if TYPE_CHECKING:
+    from wargame_rl.wargame.envs.domain.battle_view import BattleView
+    from wargame_rl.wargame.envs.renders.v2.control import LosResult
+
+
+class Control(enum.Enum):
+    """Which side holds an objective. Values match snapshot `objective_control`."""
+
+    NEUTRAL = "none"
+    PLAYER = "player"
+    OPPONENT = "opponent"
+
+
+# --- primitives -------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Disc:
+    """Filled/outlined circle. `radius` is in board units; the rest are pixels."""
+
+    center: tuple[float, float]
+    radius: float
+    fill: RGBA | None
+    outline: RGB | None
+    outline_w: int
+
+
+@dataclass(frozen=True)
+class Poly:
+    """Filled/outlined polygon in board-unit vertices."""
+
+    points: tuple[tuple[float, float], ...]
+    fill: RGBA | None
+    outline: RGB | None
+    outline_w: int
+
+
+@dataclass(frozen=True)
+class Seg:
+    """A single line segment, board-unit endpoints, pixel width."""
+
+    a: tuple[float, float]
+    b: tuple[float, float]
+    color: RGB
+    width: int
+
+
+@dataclass(frozen=True)
+class Label:
+    """Centred text at a board-unit anchor, pixel font size."""
+
+    text: str
+    center: tuple[float, float]
+    size: int
+    color: RGB
+
+
+Primitive = Disc | Poly | Seg | Label
+
+
+@dataclass(frozen=True)
+class HudData:
+    """Scalar state the presenter draws into the panels."""
+
+    round: int
+    n_rounds: int
+    phase: str
+    step: int
+    reward: float | None
+    epoch: int | None
+    player_vp: int
+    player_vp_delta: int
+    opponent_vp: int
+    opponent_vp_delta: int
+
+
+@dataclass(frozen=True)
+class Scene:
+    """One frame: board size, background, ordered primitives, HUD data."""
+
+    board_width: int
+    board_height: int
+    board_bg: RGB
+    primitives: tuple[Primitive, ...]
+    hud: HudData
+
+
+# --- builders ---------------------------------------------------------------
+
+
+def _faded(color: RGB) -> RGB:
+    """Legacy movement-arrow fade: halve the distance from each channel to 255."""
+    return (
+        color[0] + (255 - color[0]) // 2,
+        color[1] + (255 - color[1]) // 2,
+        color[2] + (255 - color[2]) // 2,
+    )
+
+
+def _base_radius(model: object, fallback: float = 1.0 / 3.0) -> float:
+    """Board-unit radius: the real base when present, else a third-cell token."""
+    radius = float(getattr(model, "base_radius", 0.0))
+    return radius if radius > 0.0 else fallback
+
+
+def _dead_marker(cx: float, cy: float, color: RGB) -> list[Seg]:
+    """The two-stroke X drawn over a dead model (half-length 0.25 board units)."""
+    xr = 0.25
+    return [
+        Seg((cx - xr, cy - xr), (cx + xr, cy + xr), color, 2),
+        Seg((cx + xr, cy - xr), (cx - xr, cy + xr), color, 2),
+    ]
+
+
+def _arrow(
+    prims: list[Primitive],
+    models: Sequence[object],
+    color_of: Callable[[int], RGB],
+    scale: float,
+) -> None:
+    """Emit a faded shaft + filled head for each model that moved."""
+    for model in models:
+        if not getattr(model, "is_alive", True):
+            continue
+        prev = getattr(model, "previous_location", None)
+        if prev is None:
+            continue
+        curr = model.location  # type: ignore[attr-defined]
+        px, py = float(prev[0]), float(prev[1])
+        cx, cy = float(curr[0]), float(curr[1])
+        if px == cx and py == cy:
+            continue
+        faded = _faded(color_of(model.group_id))  # type: ignore[attr-defined]
+        prims.append(Seg((px, py), (cx, cy), faded, max(3, int(scale / 4))))
+
+        dx, dy = cx - px, cy - py
+        length = math.hypot(dx, dy)
+        if length < 1e-9:
+            continue
+        ux, uy = dx / length, dy / length
+        head_len = min(0.45, length * 0.4)
+        head_w = head_len * 0.5
+        left = (cx - ux * head_len - uy * head_w, cy - uy * head_len + ux * head_w)
+        right = (cx - ux * head_len + uy * head_w, cy - uy * head_len - ux * head_w)
+        prims.append(Poly(((cx, cy), left, right), (*faded, 255), None, 0))
+
+
+def _players(prims: list[Primitive], models: Sequence[object], theme: Theme) -> None:
+    pal = theme.palette
+    for model in models:
+        cx, cy = float(model.location[0]), float(model.location[1])  # type: ignore[attr-defined]
+        radius = _base_radius(model)
+        if not getattr(model, "is_alive", True):
+            prims.append(Disc((cx, cy), radius, (*pal.dead_fill, 255), None, 0))
+            prims.extend(_dead_marker(cx, cy, pal.dead_mark))
+            continue
+        color = theme.player_color(model.group_id)  # type: ignore[attr-defined]
+        prims.append(Disc((cx, cy), radius, (*color, 255), pal.model_rim, 1))
+
+
+def _opponents(prims: list[Primitive], models: Sequence[object], theme: Theme) -> None:
+    pal = theme.palette
+    for model in models:
+        cx, cy = float(model.location[0]), float(model.location[1])  # type: ignore[attr-defined]
+        r = _base_radius(model)
+        triangle = ((cx - r, cy - r * 0.6), (cx + r, cy - r * 0.6), (cx, cy + r * 0.8))
+        if not getattr(model, "is_alive", True):
+            prims.append(Poly(triangle, (*pal.dead_fill, 255), None, 0))
+            prims.extend(_dead_marker(cx, cy, pal.dead_mark))
+            continue
+        color = theme.opponent_color(model.group_id)  # type: ignore[attr-defined]
+        prims.append(Poly(triangle, (*color, 255), None, 0))
+
+
+def build_scene(
+    view: "BattleView",
+    control: Sequence[Control],
+    *,
+    scale: float,
+    theme: Theme = DEFAULT_THEME,
+    debug_los: "LosResult | None" = None,
+    show_grid: bool = True,
+) -> Scene:
+    """Assemble the ordered primitives for one live frame from a `BattleView`."""
+    pal = theme.palette
+    prims: list[Primitive] = []
+    board_w = view.config.board_width
+    board_h = view.config.board_height
+
+    # Deployment zones (drawn first, under everything).
+    for zone, color, label in (
+        (view.deployment_zone, pal.deployment_zone, "Deployment Zone"),
+        (view.opponent_deployment_zone, pal.opponent_zone, "Opponent Zone"),
+    ):
+        x0, y0, x1, y1 = (
+            float(zone[0]),
+            float(zone[1]),
+            float(zone[2]),
+            float(zone[3]),
+        )
+        prims.append(
+            Poly(((x0, y0), (x1, y0), (x1, y1), (x0, y1)), (*color, 255), None, 0)
+        )
+        cx = max(x0 + (x1 - x0) / 2, x0)
+        cy = max(y0 + (y1 - y0) / 2, y0)
+        prims.append(Label(label, (cx, cy), 48, pal.zone_label))
+
+    # Terrain: real outline + translucent fill, "OBJECTIVE" when it is one.
+    objective_outlines = {
+        obj.area.vertices.tobytes() for obj in view.objectives if obj.area is not None
+    }
+    terrain_font = max(16, int(scale * 0.8))
+    for fp in view.terrain.footprints:
+        points = tuple((float(x), float(y)) for x, y in fp.polygon.vertices)
+        prims.append(Poly(points, pal.terrain_fill, pal.terrain_outline, 2))
+        is_objective = fp.polygon.vertices.tobytes() in objective_outlines
+        centroid = fp.polygon.centroid
+        prims.append(
+            Label(
+                "OBJECTIVE" if is_objective else "Ruin",
+                (float(centroid[0]), float(centroid[1])),
+                terrain_font,
+                pal.terrain_label,
+            )
+        )
+
+    # Objectives with ownership fill / wash.
+    base_width = max(2, int(round(scale / 8)))
+    for i, objective in enumerate(view.objectives):
+        ctrl = control[i] if i < len(control) else Control.NEUTRAL
+        fill_rgb = (
+            pal.player_control
+            if ctrl is Control.PLAYER
+            else pal.opponent_control
+            if ctrl is Control.OPPONENT
+            else None
+        )
+        if objective.area is not None:
+            wash = fill_rgb if fill_rgb is not None else pal.objective_rim
+            points = tuple((float(x), float(y)) for x, y in objective.area.vertices)
+            prims.append(
+                Poly(
+                    points,
+                    (*wash, pal.area_wash_alpha),
+                    pal.objective_rim,
+                    max(3, int(scale / 6)),
+                )
+            )
+            continue
+        cx, cy = float(objective.location[0]), float(objective.location[1])
+        radius_board = float(objective.radius_size)
+        radius_px = max(1, int(round(radius_board * scale)))
+        rim_width = min(base_width, max(1, radius_px // 2))
+        fill_rgba = (*fill_rgb, 255) if fill_rgb is not None else None
+        prims.append(
+            Disc((cx, cy), radius_board, fill_rgba, pal.objective_rim, rim_width)
+        )
+
+    # Movement arrows, then models (opponents under players, matching legacy).
+    _arrow(prims, view.player_models, theme.player_color, scale)
+    if view.opponent_models:
+        _arrow(prims, view.opponent_models, theme.opponent_color, scale)
+        _opponents(prims, view.opponent_models, theme)
+    _players(prims, view.player_models, theme)
+
+    if debug_los is not None:
+        prims.append(
+            Seg(
+                debug_los.a,
+                debug_los.b,
+                pal.los_clear if debug_los.clear else pal.los_blocked,
+                max(1, int(scale * 0.08)),
+            )
+        )
+
+    if show_grid:
+        for y in range(board_h + 1):
+            prims.append(Seg((0.0, float(y)), (float(board_w), float(y)), pal.grid, 1))
+        for x in range(board_w + 1):
+            prims.append(Seg((float(x), 0.0), (float(x), float(board_h)), pal.grid, 1))
+
+    clock = view.game_clock_state
+    hud = HudData(
+        round=clock.battle_round or 0,
+        n_rounds=view.n_rounds,
+        phase=clock.phase.value.title() if clock.phase else "—",
+        step=view.current_turn,
+        reward=view.last_reward,
+        epoch=None,
+        player_vp=view.player_vp,
+        player_vp_delta=view.player_vp_delta,
+        opponent_vp=view.opponent_vp,
+        opponent_vp_delta=view.opponent_vp_delta,
+    )
+    return Scene(board_w, board_h, pal.board_bg, tuple(prims), hud)

--- a/wargame_rl/wargame/envs/renders/v2/theme.py
+++ b/wargame_rl/wargame/envs/renders/v2/theme.py
@@ -1,0 +1,89 @@
+"""Colours and layout metrics for the v2 renderer.
+
+Everything the legacy `HumanRender` scattered as inline literals and the two
+`_GROUP_COLORS` / `_OPPONENT_COLORS` class lists lives here as one `Theme`, so a
+future look is one object to edit rather than a hunt through draw methods.
+`DEFAULT_THEME` reproduces the legacy colours exactly, so v2 starts visually
+identical and any divergence is a deliberate theme change.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+RGB = tuple[int, int, int]
+RGBA = tuple[int, int, int, int]
+
+# Cool palette for player groups, warm for opponents (legacy order preserved).
+_PLAYER_GROUPS: tuple[RGB, ...] = (
+    (0, 0, 255),
+    (60, 180, 80),
+    (255, 180, 0),
+    (180, 80, 220),
+    (0, 200, 200),
+    (200, 100, 0),
+    (220, 100, 180),
+    (220, 80, 60),
+)
+_OPPONENT_GROUPS: tuple[RGB, ...] = (
+    (200, 40, 40),
+    (220, 100, 30),
+    (180, 30, 80),
+    (160, 60, 140),
+    (200, 80, 80),
+    (180, 100, 20),
+    (140, 30, 50),
+    (210, 60, 100),
+)
+
+
+@dataclass(frozen=True)
+class Palette:
+    """Every colour the board and HUD use."""
+
+    window_bg: RGB = (45, 45, 48)
+    board_bg: RGB = (255, 255, 255)
+    grid: RGB = (210, 210, 210)
+    player_groups: tuple[RGB, ...] = _PLAYER_GROUPS
+    opponent_groups: tuple[RGB, ...] = _OPPONENT_GROUPS
+    dead_fill: RGB = (180, 180, 180)
+    dead_mark: RGB = (120, 120, 120)
+    model_rim: RGB = (30, 30, 30)
+    deployment_zone: RGB = (200, 200, 200)
+    opponent_zone: RGB = (220, 200, 200)
+    zone_label: RGB = (240, 240, 240)
+    terrain_fill: RGBA = (140, 120, 90, 90)
+    terrain_outline: RGB = (100, 80, 60)
+    terrain_label: RGB = (60, 50, 40)
+    objective_rim: RGB = (90, 90, 90)
+    player_control: RGB = (120, 220, 140)
+    opponent_control: RGB = (255, 105, 180)
+    area_wash_alpha: int = 120
+    los_clear: RGB = (80, 200, 80)
+    los_blocked: RGB = (255, 80, 80)
+    panel_bg: RGB = (45, 45, 48)
+    panel_line: RGB = (80, 80, 84)
+    text: RGB = (220, 220, 220)
+
+
+@dataclass(frozen=True)
+class Theme:
+    """A palette plus the panel layout metrics."""
+
+    palette: Palette = field(default_factory=Palette)
+    north_panel_h: int = 36
+    south_panel_rows: int = 2
+    show_grid: bool = True
+
+    def player_color(self, group_id: int) -> RGB:
+        """Distinct colour for a player group, cycling the palette."""
+        groups = self.palette.player_groups
+        return groups[group_id % len(groups)]
+
+    def opponent_color(self, group_id: int) -> RGB:
+        """Distinct colour for an opponent group, cycling the palette."""
+        groups = self.palette.opponent_groups
+        return groups[group_id % len(groups)]
+
+
+DEFAULT_THEME = Theme()

--- a/wargame_rl/wargame/model/common/record_episode_callback.py
+++ b/wargame_rl/wargame/model/common/record_episode_callback.py
@@ -30,26 +30,34 @@ def _run_recording(
     checkpoint_dir: str,
     render_fps: int,
     filename_prefix: str,
+    renderer_name: str = "legacy",
+    backend: str = "pygame",
 ) -> None:
-    """Run in a separate process: create env with human renderer, run one episode, save MP4.
+    """Run in a separate process: create env with a renderer, run one episode, save MP4.
     Must set SDL_VIDEODRIVER=dummy before any pygame import to avoid EGL conflicts with PyTorch.
     """
     os.environ["SDL_VIDEODRIVER"] = "dummy"
+
+    from typing import cast
 
     import imageio  # type: ignore[import-untyped]
     import numpy as np
     import torch
 
-    from wargame_rl.wargame.envs.renders.human import HumanRender
+    from wargame_rl.wargame.envs.renders.renderer import FrameSource
+    from wargame_rl.wargame.envs.renders.v2 import build_renderer
     from wargame_rl.wargame.envs.types import WargameEnvAction
     from wargame_rl.wargame.model.common.factory import create_environment
     from wargame_rl.wargame.model.net import TransformerNetwork
 
-    # Build env with human renderer (same config as training)
-    renderer = HumanRender()
+    # Build env with the chosen renderer in headless recording mode. `setup`/`close`
+    # come from the Renderer base; `epoch`/`get_frame_array` from the FrameSource
+    # protocol both legacy and v2 satisfy.
+    renderer = build_renderer(renderer_name, "recording", backend=backend)
     env = create_environment(env_config=env_config, renderer=renderer)
     renderer.setup(env)
-    renderer.epoch = epoch
+    frame_source = cast(FrameSource, renderer)
+    frame_source.epoch = epoch
 
     # Load snapshot from file (avoids pickling tensors across processes)
     policy_state_dict = torch.load(
@@ -79,7 +87,7 @@ def _run_recording(
             observation, _reward, terminated, truncated, _info = env.step(action)
             done = terminated or truncated
             env.render()
-            frame = renderer.get_frame_array()
+            frame = frame_source.get_frame_array()
             frames.append(frame)
 
         out_dir = Path(checkpoint_dir)
@@ -122,6 +130,8 @@ class RecordEpisodeCallback(Callback):
         record_after_epoch: int = 20,
         record_every_n_epochs: int = 20,
         filename_prefix: str = "ppo",
+        renderer_name: str = "legacy",
+        backend: str = "pygame",
     ) -> None:
         self.run_name = run_name
         self.env_config = env_config
@@ -129,6 +139,8 @@ class RecordEpisodeCallback(Callback):
         self.record_after_epoch = record_after_epoch
         self.record_every_n_epochs = max(1, record_every_n_epochs)
         self.filename_prefix = filename_prefix
+        self.renderer_name = renderer_name
+        self.backend = backend
         self._checkpoint_dir = f"./checkpoints/{run_name}"
         self._pending_proc: BaseProcess | None = None
         self._pending_filepath: Path | None = None
@@ -234,6 +246,8 @@ class RecordEpisodeCallback(Callback):
                 "checkpoint_dir": checkpoint_dir,
                 "render_fps": render_fps,
                 "filename_prefix": filename_prefix,
+                "renderer_name": self.renderer_name,
+                "backend": self.backend,
             },
             daemon=True,
         )


### PR DESCRIPTION
## Summary

Phase 1 of the renderer-v2 work (per the approved plan): a second renderer alongside the legacy `HumanRender`, split into three layers so the visuals can be iterated on and a non-pygame backend swapped in without a rewrite, with **interactive** and **recording** as first-class modes. Everything new lives under `renders/v2/`; the legacy renderer is untouched and stays the default, so v2 is opt-in and A/B-able.

Follow-ups (separate PRs): Phase 2 backend bake-off (pygame-AA / Pillow), Phase 3 replay (builds on the terrain-in-recordings PR #160), Phase 4 visual/UX polish + pan/zoom.

## Architecture

Board state → **Scene** (pure primitives, board coords) → **Backend** (rasterises to pixels) → **Presenter** (window or headless). `Scene` imports neither pygame nor domain, so a snapshot-driven builder (Phase 3) can emit the same type.

- `renders/v2/theme.py` — `Palette`/`Theme`; `DEFAULT_THEME` mirrors the legacy colours exactly.
- `renders/v2/scene.py` — `Disc`/`Poly`/`Seg`/`Label` + `build_scene`, owning the board math (the no-`+0.5` rule, base-radius rule).
- `renders/v2/control.py` — the two domain-embedding draw methods (objective ownership, debug LOS) extracted to plain data, reusing the exact legacy functions.
- `renders/v2/camera.py` — board→pixel `fit`; `pan`/`zoom_at` stubbed for Phase 4.
- `renders/v2/backend.py` + `backends/pygame_backend.py` — `RenderBackend` protocol + shared `rasterize`.
- `renders/v2/presenters/` — `base` (compose board + HUD panels), `interactive` (window, events, legacy-parity controls), `recording` (headless, `FrameSource`).
- `renders/v2/factory.py` — `build_renderer(name, mode, backend=...)`, `legacy` default.

## Minimal edits to existing files

- `renders/renderer.py` — **additive** `FrameSource` protocol (`epoch` + `get_frame_array`); the `Renderer` ABC is byte-for-byte unchanged, so `HumanRender` and every test still bind.
- `renders/human.py` — untouched (the A/B baseline).
- `simulate.py` — `--renderer` / `--mode` / `--backend`; a renderer is built only when rendering.
- `record_episode_callback.py` — threads `renderer_name`/`backend`, depends on `FrameSource` not a concrete class. Default `legacy` keeps recorded MP4s identical.

## Verification

- **Headless A/B**: v2 reproduces the legacy frame (deployment zones, polygon terrain, objective ownership, models, grid, both HUD panels) within ~0.001% of non-white coverage; same frame shape.
- **New tests** (`tests/test_renderer_v2.py`): scene purity (coordinate conventions, base-radius, grid toggle), control extraction behaviour, `FrameSource` for both v2-recording and legacy, and the legacy A/B (shape + coverage + player colour).
- `tests/test_terrain_render.py` (legacy) stays green untouched. Golden gates (`test_reward_golden`, `test_observation_golden`) unaffected — the renderer is off the reward/observation path and `control.py` reuses the same domain functions.
- `just format` / `just lint` (ruff + mypy strict) clean.
