### PR TITLE
fix: restore the closing edge dropped from padded polygon outlines

### DIFF
--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -12,7 +12,12 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from wargame_rl.wargame.envs.types.geometry import Polygon, polygons_contain_points
+from wargame_rl.wargame.envs.types.geometry import (
+    Polygon,
+    closed_edge_ends,
+    polygons_contain_points,
+    polygons_distance_to_points,
+)
 
 # An L, wound anticlockwise. Concave, so a convex half-plane test gets it wrong.
 L_SHAPE = Polygon.from_points(
@@ -164,3 +169,61 @@ class TestPadding:
         """Silently dropping vertices would turn a ruin into a smaller ruin."""
         with pytest.raises(ValueError, match="Cannot pad"):
             L_SHAPE.padded_to(4)
+
+
+class TestPaddedBatchMatchesTheSingleShape:
+    """A batch is padded to its widest outline; the narrower ones must not change.
+
+    `np.roll` puts each outline's closing edge in slot `V_max - 1`, which the
+    `real_edge` mask then discards as padding — so before `closed_edge_ends`,
+    every outline narrower than the batch was traced as an *open* polyline.
+    Measured on `configs/evaluation/maps/table_11.yaml`, that made 5.9% of
+    random sight queries wrong, always in the permissive direction, on 35 of the
+    36 pool maps.
+
+    Everything here needs **mixed** vertex counts. A batch of uniform-width
+    outlines has no padding, so it passes either way.
+    """
+
+    QUAD = Polygon.from_points([(0.0, 0.0), (6.0, 0.0), (6.0, 4.0), (0.0, 4.0)])
+    PROBES = [
+        (3.0, 2.0),  # interior
+        (0.5, 3.5),  # interior, nearest the closing edge
+        (3.0, -1.0),  # outside, below
+        (7.0, 2.0),  # outside, beyond the far edge
+        (-1.0, 2.0),  # outside, past the closing edge
+        (3.0, 5.0),  # outside, above
+    ]
+
+    def _batch(self) -> tuple[np.ndarray, np.ndarray]:
+        """The quad padded out to the L's width, exactly as `Terrain` stores it."""
+        budget = L_SHAPE.n_vertices
+        outlines = np.stack([self.QUAD.padded_to(budget), L_SHAPE.padded_to(budget)])
+        return outlines, np.array([self.QUAD.n_vertices, L_SHAPE.n_vertices])
+
+    @pytest.mark.parametrize("point", PROBES)
+    @pytest.mark.parametrize("include_boundary", [False, True])
+    def test_containment_survives_padding(
+        self, point: tuple[float, float], include_boundary: bool
+    ) -> None:
+        outlines, counts = self._batch()
+        batched = polygons_contain_points(
+            np.array([point]), outlines, counts, include_boundary=include_boundary
+        )[0, 0]
+
+        assert bool(batched) == self.QUAD.contains(*point)
+
+    @pytest.mark.parametrize("point", PROBES)
+    def test_distance_survives_padding(self, point: tuple[float, float]) -> None:
+        outlines, counts = self._batch()
+        batched = polygons_distance_to_points(np.array([point]), outlines, counts)[0, 0]
+
+        assert batched == pytest.approx(self.QUAD.distance_to_point(*point))
+
+    def test_the_closing_edge_is_the_one_that_was_dropped(self) -> None:
+        """Names the defect directly: the last real slot must close the outline."""
+        outlines, counts = self._batch()
+        ends = closed_edge_ends(outlines, counts)
+
+        assert ends[0, self.QUAD.n_vertices - 1].tolist() == [0.0, 0.0]
+        assert ends[1, L_SHAPE.n_vertices - 1].tolist() == [0.0, 0.0]

--- a/wargame_rl/wargame/envs/types/geometry.py
+++ b/wargame_rl/wargame/envs/types/geometry.py
@@ -243,6 +243,27 @@ def _has_separating_axis(
     return bool(separated.any())
 
 
+def closed_edge_ends(
+    outlines: npt.NDArray[np.float64], vertex_counts: npt.NDArray[np.intp]
+) -> npt.NDArray[np.float64]:
+    """Edge endpoints for padded outlines, with every closing edge restored.
+
+    Padding repeats the last real vertex, so a plain roll gives outline ``i`` a
+    last real edge of ``v_last -> v_last`` — zero length, and therefore inert —
+    while the true closing edge ``v_last -> v0`` lands in the slot the
+    ``real_edge`` mask discards as padding. Both consumers below would then
+    trace an *open* polyline: a crossing-number test gets the wrong parity in a
+    wedge of the plane, and a distance test ignores one whole side.
+
+    Only outlines shorter than the array's vertex budget are affected, which is
+    why a fixture of uniform-width shapes cannot catch it.
+    """
+    ends: npt.NDArray[np.float64] = np.roll(outlines, -1, axis=1)
+    if len(outlines):
+        ends[np.arange(len(outlines)), vertex_counts - 1] = outlines[:, 0]
+    return ends
+
+
 def polygons_distance_to_points(
     points: npt.NDArray[np.float64],
     outlines: npt.NDArray[np.float64],
@@ -262,7 +283,7 @@ def polygons_distance_to_points(
         return np.zeros((n_points, n_outlines), dtype=VERTEX_DTYPE)
 
     starts = outlines  # (N, V, 2)
-    ends = np.roll(outlines, -1, axis=1)
+    ends = closed_edge_ends(outlines, vertex_counts)
     edge = ends - starts  # (N, V, 2)
     length_sq = (edge**2).sum(axis=2)  # (N, V)
     safe_length = np.where(length_sq > 0, length_sq, 1.0)
@@ -276,9 +297,9 @@ def polygons_distance_to_points(
         closest - points[:, np.newaxis, np.newaxis, :], axis=3
     )  # (P, N, V)
 
-    # Padded edges are zero-length duplicates of a real vertex, so they never
-    # give a *smaller* distance than the edges meeting there -- but masking them
-    # explicitly keeps the reasoning local rather than resting on that.
+    # Slots at or past the vertex count are padding and carry no edge. The real
+    # edges are all below it *because* `closed_edge_ends` puts the closing edge
+    # in the last real slot; masking alone would drop it.
     edge_index = np.arange(outlines.shape[1])
     real_edge = edge_index[np.newaxis, :] < vertex_counts[:, np.newaxis]
     distances = np.where(real_edge[np.newaxis, :, :], distances, np.inf)
@@ -304,9 +325,9 @@ def polygons_contain_points(
         points: ``(P, 2)``.
         outlines: ``(N, V_max, 2)`` vertices, padded by repeating the last one.
         vertex_counts: ``(N,)`` real vertex count per outline, so the padded
-            edges can be excluded. A padded edge is zero-length and would never
-            be crossed anyway; excluding it explicitly costs one comparison and
-            removes the need to reason about that.
+            slots can be excluded. Pair it with `closed_edge_ends`, never with a
+            bare roll: the mask discards the slot a roll puts the closing edge
+            in, which traces the outline as an open polyline.
         include_boundary: also count points lying exactly on an edge. Off by
             default because sight *samples* are measure-zero and this doubles the
             work; on for anything where membership decides a rule, since a
@@ -350,7 +371,7 @@ def polygons_contain_points(
         return inside
 
     starts = outlines[outline_index]  # (K, V, 2)
-    ends = np.roll(starts, -1, axis=1)
+    ends = closed_edge_ends(starts, vertex_counts[outline_index])
     edge_index = np.arange(outlines.shape[1])
     real_edge = edge_index[np.newaxis, :] < vertex_counts[outline_index][:, np.newaxis]
 


### PR DESCRIPTION
Terrain under-blocked sight on 35 of the 36 pool maps, because any outline
narrower than its batch's vertex budget was traced as an **open polyline**.

## The defect

`polygons_contain_points` and `polygons_distance_to_points` take outlines padded
to a common `V_max` by repeating the last vertex, plus real `vertex_counts`.
Both built edges with `np.roll` and then masked them with
`real_edge = edge_index < vertex_counts`. For a 4-gon padded to `V_max = 5`:

| slot | edge | `real_edge` | |
|---|---|---|---|
| 3 | `v3 → v3` (zero length) | `3 < 4` → **tested** | contributes nothing |
| 4 | `v3 → v0` (**closing edge**) | `4 < 4` → **skipped** | never tested |

So the closing edge was discarded as padding and an inert zero-length edge was
tested in its place. The crossing-number parity is then wrong in a wedge of the
plane, and the distance test ignored one whole side of every padded shape.

Outlines at the full budget are unaffected, which is why no existing fixture
caught it — they are all uniform-width.

## The fix

`closed_edge_ends` writes each outline's true closing edge into its last *real*
slot before the mask is applied. It is a no-op for an unpadded outline, so
uniform batches are byte-identical.

## Measured

Reproduced from checked-in `configs/evaluation/maps/table_11.yaml`, against a
ground truth that tests each piece unpadded:

- sight queries wrong: **5.9% → 0.22%** over 4000 random point pairs, and the
  error was one-directional — terrain blocked *less* than it should
- one piece alone (true area 53.11 sq units): **50.46 false-outside, 30.56
  false-inside** before the fix
- the residual 0.22% is the documented `los_sample_step` resolution limit, not
  containment: refining the reference sampler to 0.005 leaves 3 of 4000, all
  rays grazing a blocker thinner than the 0.25 step

## Changes

- `envs/types/geometry.py` — add `closed_edge_ends`; use it in
  `polygons_contain_points` and `polygons_distance_to_points`. Both had the
  defect; the distance one feeds area objectives and terrain proximity. Also
  rewrites the two comments that asserted padded edges were harmless, since that
  reasoning is what hid this.
- `tests/test_geometry.py` — `TestPaddedBatchMatchesTheSingleShape`: a padded
  batch must agree with the single shape, for containment (both
  `include_boundary` settings) and distance, plus a test naming the closing edge
  directly. **Mixed vertex counts throughout** — a uniform fixture passes either
  way.

## Note for whoever reads a baseline next

This makes terrain block **more**, so it moves every number measured on the pool
maps. Re-measure before comparing across this commit.

Two things deliberately left alone:

- `tests/test_los.py::test_terrain_los_symmetry` fails on this branch and fails
  identically without it — a pre-existing, unrelated LOS asymmetry whose
  counterexample is a single unpadded rectangle.
- The see-out / see-into exemption is applied to *every* footprint, while
  `docs/rules/13-terrain.md` scopes it to **obscuring** areas and gives solid
  features none. That is a rules-alignment decision, already tracked as
  `partial` in `docs/rules/implementation-status.md`, and is not touched here.
