### PR TITLE
docs: warn at the top of the three superseded coherency reports

### DIFF
--- a/reports/2026-08-14-coherency-is-a-symptom.md
+++ b/reports/2026-08-14-coherency-is-a-symptom.md
@@ -1,5 +1,29 @@
 # Coherency is a symptom: the adrift models are defecting
 
+> ## ⚠ SUPERSEDED — 2026-08-16
+>
+> **Read [Enforcement is a referee, not a teacher](2026-08-16-enforcement-is-a-referee.md)
+> instead. This report's conclusions and every number in it are void**, for two
+> independent reasons:
+>
+> 1. **Every compliance figure was sampled after the enforcement fixed point.**
+>    Under `coherency.enforce_move`, `eval/coherency_rate` is 1.000 by
+>    construction whatever the policy does, so it measures the referee and not
+>    the agent. Measured with the referee *off*, the same weights intend 0.630.
+> 2. **A geometry fix (#193) then moved line of sight on these maps by 22.6%**,
+>    voiding every eval-map number measured before it.
+>
+> The settled answer: train with `objective_hold.require_coherent`, never train
+> under `enforce_move`, and switch enforcement on for play.
+> `configs/golden/25v25_maps_coherency.yaml` is that configuration.
+>
+> **Kept, not deleted, because the reasoning and the retractions are the
+> reusable part** — this is a record of how a wrong conclusion was reached, and
+> rewriting it with the answer in hand would destroy that.
+
+---
+
+
 2026-08-14. Real-maps scenario (`configs/experiments/25v25_maps_coherent.yaml`
 and arms), post-#182 and post-#186.
 

--- a/reports/2026-08-14-coherency-what-it-costs.md
+++ b/reports/2026-08-14-coherency-what-it-costs.md
@@ -1,5 +1,29 @@
 # Coherency: what it costs, and the one lever that moved it
 
+> ## ⚠ SUPERSEDED — 2026-08-16
+>
+> **Read [Enforcement is a referee, not a teacher](2026-08-16-enforcement-is-a-referee.md)
+> instead. This report's conclusions and every number in it are void**, for two
+> independent reasons:
+>
+> 1. **Every compliance figure was sampled after the enforcement fixed point.**
+>    Under `coherency.enforce_move`, `eval/coherency_rate` is 1.000 by
+>    construction whatever the policy does, so it measures the referee and not
+>    the agent. Measured with the referee *off*, the same weights intend 0.630.
+> 2. **A geometry fix (#193) then moved line of sight on these maps by 22.6%**,
+>    voiding every eval-map number measured before it.
+>
+> The settled answer: train with `objective_hold.require_coherent`, never train
+> under `enforce_move`, and switch enforcement on for play.
+> `configs/golden/25v25_maps_coherency.yaml` is that configuration.
+>
+> **Kept, not deleted, because the reasoning and the retractions are the
+> reusable part** — this is a record of how a wrong conclusion was reached, and
+> rewriting it with the answer in hand would destroy that.
+
+---
+
+
 **2026-08-14.** Follow-up to
 [coherency is a symptom](2026-08-14-coherency-is-a-symptom.md), which this report
 partly retracts. Everything here is the real-tables scenario

--- a/reports/2026-08-15-coherency-the-verdict.md
+++ b/reports/2026-08-15-coherency-the-verdict.md
@@ -1,5 +1,29 @@
 # Coherency: the verdict
 
+> ## ⚠ SUPERSEDED — 2026-08-16
+>
+> **Read [Enforcement is a referee, not a teacher](2026-08-16-enforcement-is-a-referee.md)
+> instead. This report's conclusions and every number in it are void**, for two
+> independent reasons:
+>
+> 1. **Every compliance figure was sampled after the enforcement fixed point.**
+>    Under `coherency.enforce_move`, `eval/coherency_rate` is 1.000 by
+>    construction whatever the policy does, so it measures the referee and not
+>    the agent. Measured with the referee *off*, the same weights intend 0.630.
+> 2. **A geometry fix (#193) then moved line of sight on these maps by 22.6%**,
+>    voiding every eval-map number measured before it.
+>
+> The settled answer: train with `objective_hold.require_coherent`, never train
+> under `enforce_move`, and switch enforcement on for play.
+> `configs/golden/25v25_maps_coherency.yaml` is that configuration.
+>
+> **Kept, not deleted, because the reasoning and the retractions are the
+> reusable part** — this is a record of how a wrong conclusion was reached, and
+> rewriting it with the answer in hand would destroy that.
+
+---
+
+
 **2026-08-15.** Closes the question opened by
 [coherency is a symptom](2026-08-14-coherency-is-a-symptom.md) and continued in
 [what it costs](2026-08-14-coherency-what-it-costs.md), **both of which this

--- a/reports/2026-08-16-enforcement-is-a-referee.md
+++ b/reports/2026-08-16-enforcement-is-a-referee.md
@@ -1,5 +1,41 @@
 # Enforcement is a referee, not a teacher
 
+## In short, without the jargon
+
+There is a rule in the game that soldiers in a squad have to stay near each
+other. We wanted the AI to actually play that way. There were two ways to get
+it: **pay the AI** for keeping its squads together, or **have a referee** undo
+any move that breaks a squad apart.
+
+**Paying works. The referee does not teach — and using it while the AI is
+learning makes it worse.** An AI trained with the referee switched on gets
+lazy: it stops trying to stay together, because the referee tidies up after it
+anyway. Turn the referee off afterwards and it is *sloppier* than an AI that
+was never forced at all. It also loses more games on maps it has not seen
+before.
+
+So: **pay during training, and switch the referee on only for real games.**
+The referee still earns its place — it is the only thing that guarantees the
+army is actually legal — but it is a rule of the game, not a teaching aid.
+
+**We had also been measuring it wrong, and that is the more useful lesson.**
+We were checking whether the squads were together *after* the referee had
+already fixed them. Of course they were — that was the referee's doing, not the
+AI's. It looked like a perfect score. Measured properly, the AI was much
+sloppier than we had been reporting, and three earlier write-ups had to be
+withdrawn. The general form of the mistake: **if something guarantees an
+outcome, measuring that outcome tells you nothing about what caused it.**
+
+**One thing we still cannot explain.** Training doesn't start from scratch — it
+continues from an AI that already knows how to play. We used two such starting
+points. Both were equally bad at keeping squads together. Yet every AI grown
+from the first ended up sloppy, and every one grown from the second ended up
+tidy — eight for eight, with no overlap. Same lesson, same settings, roughly
+double the benefit for one group. Something about where you start decides which
+habit sticks, and we do not know what.
+
+---
+
 **2026-08-16.** Supersedes
 [coherency: the verdict](2026-08-15-coherency-the-verdict.md),
 [what it costs](2026-08-14-coherency-what-it-costs.md) and


### PR DESCRIPTION
The index said SUPERSEDED; the files themselves did not. A search result or a direct link opens the file, not the index — so all three still presented a confident wrong verdict with no warning, including one whose headline claim had already been retracted once.

Each now carries a banner under its own title naming the replacement and both independent reasons its numbers are void.

## Why not consolidate into one report

Asked and considered. Kept as separate documents because:

- **The error sequence is the reusable part.** This repo's convention is already to keep corrections as their own documents — `CLAUDE.md` tells you to *start* with the 2026-08-04 correction.
- **Rewriting them with the answer in hand would smooth away the mistakes**, which is the opposite of what `reports/` is for.
- **The consolidated version already exists** — `2026-08-16-enforcement-is-a-referee.md` carries the answer, the lever table and the lessons.

## Changes

- `reports/2026-08-14-coherency-is-a-symptom.md`
- `reports/2026-08-14-coherency-what-it-costs.md`
- `reports/2026-08-15-coherency-the-verdict.md`

Docs only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)