### PR TITLE
fix: a dead model no longer keeps yours from shooting

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -416,7 +416,7 @@ Same numbers appear as `exposure` / `terrain_d` / `alive` columns in
 4. **It is not the same quantity as the shooting mask.** `exposure_rate`
    deliberately ignores the engagement-range and advanced gating that
    `compute_shooting_masks` applies for real shots. A shooter within
-   `engagement_range` of any enemy cannot fire at all, so including that gate
+   `engagement_range` of any **living** enemy cannot fire at all, so including that gate
    would score a headlong charge as cover.
 
 `terrain_proximity` is the check against reading 2 backwards: a policy that is

--- a/docs/shooting.md
+++ b/docs/shooting.md
@@ -71,7 +71,7 @@ During the shooting phase, a per-model **unit**-target validity mask is overlaid
 
 1. **Model M is alive** — dead models get `STAY_ACTION` only
 2. **M did not advance this turn** — `advanced_this_turn` gate. Dormant: nothing in the env ever sets the flag True (only `load_state` restores it from a snapshot), so today this never masks anything. See [rules/09-movement-phase.md](rules/09-movement-phase.md#advance-move) for the rule it will enforce.
-3. **M is not locked in engagement** — masked out entirely if the nearest enemy is within `engagement_range` (config, authored in inches and resolved into board units by `domain/rules_quantities.py`; defaults to 1, against the rules' 2 — see `docs/rules/implementation-status.md`)
+3. **M is not locked in engagement** — masked out entirely if the nearest **living** enemy is within `engagement_range` (casualties are excluded before the minimum is taken; a corpse engages nobody, and a model with no living enemy left is not engaged) (config, authored in inches and resolved into board units by `domain/rules_quantities.py`; defaults to 1, against the rules' 2 — see `docs/rules/implementation-status.md`)
 4. **Unit U has a living model** — a unit is a legal target while any model in it survives, so killing one model closes nothing
 5. **Some model of U is in range** — Euclidean distance from M ≤ max weapon range of M
 6. **Some model of U is visible** to M

--- a/docs/terrain.md
+++ b/docs/terrain.md
@@ -211,7 +211,7 @@ but symmetry is *pairwise* — it does not equalise the counts, which is precise
 cover worth using: it lets you choose the exchange ratio.
 
 Both deliberately **ignore** the engagement-range and advanced gating that the real shooting
-mask applies. A shooter within `engagement_range` of any enemy cannot fire at all, so folding
+mask applies. A shooter within `engagement_range` of any **living** enemy cannot fire at all, so folding
 that in would score a headlong charge as if it were cover.
 
 See [metrics.md](metrics.md#cover-metrics) for the reading rules — in particular that

--- a/tests/test_shooting_resolution.py
+++ b/tests/test_shooting_resolution.py
@@ -787,6 +787,53 @@ class TestShootingMaskExtensions:
         assert not m[0, 0], "Model within engagement range should be masked"
         assert m[1, 0], "Model outside engagement range should shoot"
 
+    def test_a_dead_enemy_does_not_keep_a_model_engaged(self) -> None:
+        """A corpse must not lock a model out of shooting.
+
+        The gate took `distances.min()` over *every* opponent and applied
+        `opponent_alive` only afterwards, so a casualty lying next to a model
+        went on pinning it for the rest of the episode. The rule is about being
+        engaged by an enemy, and a dead model engages nobody.
+        """
+        pp = np.array([[0.0, 0.0]])
+        op = np.array([[1.0, 0.0], [10.0, 0.0]])  # corpse adjacent, live one far
+        pa = np.array([True])
+        oa = np.array([False, True])
+        pr = np.array([50.0])
+        m = compute_shooting_masks(
+            pp, op, pa, oa, pr, _all_visible, engagement_range=2.0
+        )
+        assert m[0, 1], "a corpse within engagement range must not pin the shooter"
+
+    def test_a_live_enemy_still_engages(self) -> None:
+        """The companion case: the gate must still fire on a living enemy."""
+        pp = np.array([[0.0, 0.0]])
+        op = np.array([[1.0, 0.0], [10.0, 0.0]])
+        pa = np.array([True])
+        oa = np.array([True, True])
+        pr = np.array([50.0])
+        m = compute_shooting_masks(
+            pp, op, pa, oa, pr, _all_visible, engagement_range=2.0
+        )
+        assert not m[0, 1], "a living adjacent enemy must still pin the shooter"
+
+    def test_every_enemy_dead_leaves_nobody_engaged(self) -> None:
+        """The empty-set edge case the fix introduces.
+
+        Masking the dead out before the minimum means a model with no living
+        enemy at all reduces over an empty set. It must read as "not engaged",
+        not as a crash or as engaged-by-default.
+        """
+        pp = np.array([[0.0, 0.0]])
+        op = np.array([[1.0, 0.0]])
+        pa = np.array([True])
+        oa = np.array([False])
+        pr = np.array([50.0])
+        m = compute_shooting_masks(
+            pp, op, pa, oa, pr, _all_visible, engagement_range=2.0
+        )
+        assert not m.any(), "no living target, so no shot -- but no crash either"
+
     def test_backward_compat_no_new_params(self) -> None:
         pp = np.array([[0, 0]])
         op = np.array([[5, 0]])

--- a/wargame_rl/wargame/envs/env_components/shooting_masks.py
+++ b/wargame_rl/wargame/envs/env_components/shooting_masks.py
@@ -60,14 +60,22 @@ def compute_shooting_masks(
     shooters = np.asarray(player_alive, dtype=bool) & (player_max_ranges > 0)
     if player_advanced is not None:
         shooters &= ~np.asarray(player_advanced, dtype=bool)
+    alive_targets = np.asarray(opponent_alive, dtype=bool)
     if engagement_range > 0:
         # Engagement is measured base to base, not centre to centre: two models
         # with `r`-radius bases are `2r` closer than their centres suggest.
-        shooters &= distances.min(axis=1) - base_diameter > engagement_range
+        # Only LIVING enemies engage: casualties are masked to infinity before
+        # the minimum, so a corpse lying next to a model cannot go on pinning
+        # it, and a model with no living enemy left reduces over an empty set
+        # to infinity -- not engaged, which is the right answer.
+        nearest_live = np.where(alive_targets[np.newaxis, :], distances, np.inf).min(
+            axis=1
+        )
+        shooters &= nearest_live - base_diameter > engagement_range
 
     candidates = (
         shooters[:, np.newaxis]
-        & np.asarray(opponent_alive, dtype=bool)[np.newaxis, :]
+        & alive_targets[np.newaxis, :]
         & (distances <= player_max_ranges[:, np.newaxis])
     )
     if not candidates.any():
@@ -308,7 +316,11 @@ def compute_unit_shooting_masks(
     if player_advanced is not None:
         shooters &= ~np.asarray(player_advanced, dtype=bool)
     if engagement_range > 0:
-        shooters &= distances.min(axis=1) - base_diameter > engagement_range
+        # Only living enemies engage -- see `compute_shooting_masks`.
+        nearest_live = np.where(alive_targets[np.newaxis, :], distances, np.inf).min(
+            axis=1
+        )
+        shooters &= nearest_live - base_diameter > engagement_range
     if not shooters.any():
         return mask
 


### PR DESCRIPTION
## Summary

The engagement gate counted **corpses**. `shooting_masks.py` took `distances.min(axis=1)` over *every* opponent and applied `opponent_alive` only afterwards, so a dead model lying next to yours went on locking it out of shooting for the rest of the episode.

`engagement_range` defaults to `1.0` and is `gt=0`, so this was active in **every config** — it was in the action mask of every result this project has measured.

## How often it fired

Nine held-out tables, 63,170 model-steps:

| | steps | share |
|---|---|---|
| pinned by a **living** enemy (correct) | 507 | **0.80%** |
| pinned **only by a corpse** (the bug) | 5,521 | **8.74%** |

**92% of every engagement suppression was spurious.** In practice the rule was mostly a corpse rule.

## What it is worth

Held-out nine, three seeds, n=30, shipped (verified) decode. Paired — same weights, same layouts, same episode seeds, one flag of difference:

| seed | pre-fix | post-fix | delta |
|---|---|---|---|
| s1 | +11.9 | **+19.7** | +7.8 |
| s2 | −2.4 | **+1.6** | +4.1 |
| s3 | −6.1 | **+3.0** | +9.1 |
| **mean** | **+1.1** | **+8.1** | **+7.0** (sd 2.6, 3/3 same sign) |

All three seeds are now positive, where two were negative. The gain appears on every decode arm (+4.1 argmax, +5.5 relaxed, +7.0 verified), so it is not an artefact of the decode.

**Coherency is untouched** — 0.955 → 0.956, 0.944 → 0.943, 0.910 → 0.911. This is a shooting change and it correctly did not move formation.

## ⚠ This is a scenario change, not a free win

The same mask path serves the opponent, so **both sides now shoot more freely** — same shape as the LOS change and the coherency referee. Baselines re-measured on the same config, held-out nine, n=30:

| policy | vp margin | coherent |
|---|---|---|
| `squad_march_deny` (best script) | −6.4 | 0.896 |
| `squad_march_take` | −6.5 | 0.892 |
| `squad_march_shoot` | −34.7 | 0.799 |
| `contest_and_spread` | −47.6 | 0.840 |

**Every baseline measured before this commit is void on any config with `engagement_range > 0`.**

## The fix

Both sites mask the dead to infinity before the minimum:

```python
nearest_live = np.where(alive_targets[np.newaxis, :], distances, np.inf).min(axis=1)
shooters &= nearest_live - base_diameter > engagement_range
```

`np.inf` also settles the edge case this introduces: a model with no living enemy at all reduces over an empty set and reads as *not engaged*, which is correct and neither a crash nor engaged-by-default.

Three regression tests: the corpse case (fails before, passes after), the living-enemy companion so the gate cannot be silently disabled in the other direction, and the all-dead edge case.

## Note on test coverage

`test_reward_golden` and `test_observation_golden` were **green throughout** — their pinned scenarios never had a corpse inside engagement range. A defect touching 8.7% of real model-steps was invisible to the tests that pin combat behaviour bit-identically.

## Unrelated failure found

`tests/test_los.py::test_terrain_los_symmetry` fails on a genuine LOS asymmetry (board 11×9, footprint (0,2)-(2,5), ray (0,8)→(10,1)). **Pre-existing** — reproduced with this change stashed. It is a `hypothesis` test with no fixed seed, so it surfaces at random. Filed separately as task #141; not addressed here.
