### PR TITLE
fix: sight is a property of the pair, not of the direction asked

### DIFF
--- a/docs/terrain.md
+++ b/docs/terrain.md
@@ -284,7 +284,7 @@ For a query from point `(x0, y0)` to point `(x1, y1)`:
 2. A **strictly interior** sample along the ray is blocking if (both endpoints are exempt, and models never occlude — only the static mask and footprints block):
    - `config.blocking_mask[y][x]` is True (legacy static blocking), **OR**
    - The sample lies inside any non-exempt outline. Sample membership is interior-only: it is measure-zero and on the hot path.
-3. Symmetry is exact by construction — the pair (A, B) and the pair (B, A) sample the same parametric positions on the same segment, so the same blockers are tested. `firepower_ratio` depends on it, reading an exposed model as one that can also fire.
+3. Symmetry is exact by construction — `segments_are_clear` orders each segment's endpoints canonically before sampling, so the pair (A, B) and the pair (B, A) sample the same parametric positions on the same segment and the same blockers are tested. `firepower_ratio` depends on it, reading an exposed model as one that can also fire. ⚠ Until 2026-08-19 this was asserted rather than implemented: samples were measured from whichever endpoint the caller passed first, and **0.097% of pairs in real play disagreed by direction**.
 
 The sampled-ray core in `domain/los.py` knows nothing about terrain: it takes padded outlines and traces segments against them, vectorised over segments *and* over shapes. Steps 1–3 above are `domain/sight.py`, which composes that primitive with the domain model (`terrain.py`) and the static mask.
 

--- a/tests/test_los.py
+++ b/tests/test_los.py
@@ -321,7 +321,11 @@ def test_terrain_los_blocking_mask_and_footprint_coexist() -> None:
     x1=st.integers(min_value=0, max_value=19),
     y1=st.integers(min_value=0, max_value=19),
 )
-@settings(max_examples=200, deadline=None)
+# `derandomize` because this is a REGRESSION gate, not an exploration run:
+# unseeded, it drew a fresh sample every run and so passed and failed on
+# identical code minutes apart, which is how the asymmetry below sat
+# undetected. CLAUDE.md: no randomness without a fixed seed.
+@settings(max_examples=200, deadline=None, derandomize=True)
 def test_terrain_los_symmetry(
     board_w: int,
     board_h: int,
@@ -356,6 +360,43 @@ def test_terrain_los_symmetry(
     forward = env.has_line_of_sight_between_points(x0, y0, x1, y1)
     backward = env.has_line_of_sight_between_points(x1, y1, x0, y0)
     assert forward == backward
+
+
+def test_the_found_asymmetry_stays_fixed() -> None:
+    """The exact counterexample hypothesis produced on 2026-08-19.
+
+    Samples sat at absolute distances from `starts`, so tracing A->B sampled
+    different points from B->A and the two disagreed whenever the segment
+    length was not a whole number of steps. This is that case, pinned
+    explicitly: the property test only finds it when its draw happens to
+    include it, and it had no fixed seed.
+    """
+    piece = TerrainPieceConfig(footprint=(0, 2, 2, 5))
+    env = _terrain_env([piece], board_width=11, board_height=9)
+
+    forward = env.has_line_of_sight_between_points(0, 8, 10, 1)
+    backward = env.has_line_of_sight_between_points(10, 1, 0, 8)
+
+    assert forward == backward, "sight must be a property of the pair"
+
+
+def test_sampling_does_not_depend_on_endpoint_order() -> None:
+    """Directly at the geometry primitive, over many lengths and angles.
+
+    Goes through `segments_are_clear` rather than the env so a future caller
+    that reverses endpoints cannot reintroduce this behind the composition.
+    """
+    outlines = np.array([[[3.0, 3.0], [5.0, 3.0], [5.0, 5.0], [3.0, 5.0]]])
+    counts = np.array([4])
+    rng = np.random.default_rng(20260819)
+    starts = rng.uniform(0.0, 10.0, size=(400, 2))
+    ends = rng.uniform(0.0, 10.0, size=(400, 2))
+
+    forward = segments_are_clear(starts, ends, outlines, counts, sample_step=0.5)
+    backward = segments_are_clear(ends, starts, outlines, counts, sample_step=0.5)
+
+    disagreed = int((forward != backward).sum())
+    assert disagreed == 0, f"{disagreed}/400 segments disagreed on direction"
 
 
 def test_a_pair_gets_the_same_answer_however_it_is_batched() -> None:

--- a/wargame_rl/wargame/envs/domain/los.py
+++ b/wargame_rl/wargame/envs/domain/los.py
@@ -42,6 +42,11 @@ def _interior_sample_offsets(
     or stop being blocked. That was a real defect, and it surfaced as two golden
     gates failing when a caller began tracing in two passes instead of one.
 
+    Absolute offsets alone are not enough to make the answer a property of the
+    pair: they are measured from the segment's *start*, so the caller's choice
+    of which endpoint comes first still moved the samples. `segments_are_clear`
+    orders the endpoints canonically before calling this, which closes that.
+
     The array is still rectangular, sized by the longest segment, with a mask
     marking the samples that fall inside each segment. Endpoints are excluded: a
     model standing on a blocker is handled by the see-out rule in `sight.py`,
@@ -87,6 +92,19 @@ def segments_are_clear(
     clear = np.ones(n_segments, dtype=bool)
     if n_segments == 0:
         return clear
+
+    # Sight is a property of the PAIR, and samples sit at absolute distances
+    # from the segment's start -- so tracing A->B and B->A sampled different
+    # points whenever the length was not a whole number of steps, and the two
+    # directions could disagree. Ordering the endpoints canonically makes the
+    # sample set independent of which one the caller passed first. The rest of
+    # the pass is direction-agnostic: `blocker_exempt` is per segment, and the
+    # result is a single "clear" flag, so swapping changes nothing else.
+    swap = (starts[:, 0] > ends[:, 0]) | (
+        (starts[:, 0] == ends[:, 0]) & (starts[:, 1] > ends[:, 1])
+    )
+    keep = swap[:, np.newaxis]
+    starts, ends = np.where(keep, ends, starts), np.where(keep, starts, ends)
 
     deltas = ends - starts
     lengths = np.linalg.norm(deltas, axis=1)


### PR DESCRIPTION
## Summary

Line of sight was not symmetric. `has_line_of_sight_between_points(A, B)` could disagree with `(B, A)`, so a model could see an enemy that could not see it back.

Found by `tests/test_los.py::test_terrain_los_symmetry` — but only because `hypothesis` happened to draw the counterexample that run. The test has no fixed seed, so it passed and failed on identical code minutes apart.

## The cause

Samples sit at absolute distances `k * sample_step` **from `starts`**. Tracing A→B and B→A therefore sampled *different point sets* whenever the segment length was not a whole number of steps, and a grazing ray could be blocked one way and clear the other.

Both docstrings already asserted the invariant. `sight.py`: *"Symmetry is exact by construction: the pair (a, b) and the pair (b, a) sample the same parametric positions."* **It was documented but never implemented.** `los.py` had reasoned halfway there — it chose absolute rather than batch-relative offsets precisely so "a pair's answer depends only on that pair", after an earlier batching defect — but the anchor is still whichever endpoint the caller passed first.

## The fix

Order each segment's endpoints canonically before sampling:

```python
swap = (starts[:, 0] > ends[:, 0]) | (
    (starts[:, 0] == ends[:, 0]) & (starts[:, 1] > ends[:, 1])
)
keep = swap[:, np.newaxis]
starts, ends = np.where(keep, ends, starts), np.where(keep, starts, ends)
```

Safe because the rest of the pass is direction-agnostic: `blocker_exempt` is per *segment* (and already computed as `starts | ends`), and the result is a single clear/blocked flag.

## Measured

Real play, nine held-out tables, **488,300 pairs**, both directions of every pair:

| | asymmetric |
|---|---|
| before | 474 (**0.097%**) |
| after | **0 (0.000%)** |

Score impact, held-out nine, three seeds, n=30, paired — measured in isolation on `main` *before* #210:

| arm | delta | coherency |
|---|---|---|
| argmax | **+0.0** (sd 0.5, signs mixed) | unchanged |
| verified decode | **+0.1** (sd 0.6, signs mixed) | unchanged |

**A measured null on score.** This is a correctness fix, and it does **not** void baselines — unlike #210, which does.

Both golden gates pass unchanged, even though canonicalisation moves the sampling anchor for **50.1%** of segments: sight is robust to sample positions when blockers are wider than the step, which the config validator enforces.

## Tests

- `test_the_found_asymmetry_stays_fixed` — the exact counterexample (board 11×9, footprint (0,2)-(2,5), ray (0,8)→(10,1)).
- `test_sampling_does_not_depend_on_endpoint_order` — direct on the geometry primitive, 400 seeded random segments, so a future caller cannot reintroduce this behind the composition layer.
- `test_terrain_los_symmetry` — now `derandomize=True`, per CLAUDE.md's "no randomness without a fixed seed".

⚠ Being explicit about the tradeoff: **the derandomized draw does not include the counterexample**, so that test alone would still not catch this bug. Determinism buys reproducibility, not coverage — which is why the two explicit tests sit beside it. The property test explores; the explicit tests pin.

Closes #141.
