### PR TITLE
feat: scenario overrides from the command line, and a floor in the baselines table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,15 +105,15 @@ wargame_rl/
 | Analyse a log | `just analyze <file>` · `just analyze-compare <files...>` |
 | Inspect a Wandb run | `just run-summary <run_id> [bucket]` |
 | Measure reward-phase gates | `just measure-phase-gates <ckpt> <config.yaml> [n_episodes]` |
-| Scripted baselines (floor + bar) | `just measure-baselines <config.yaml> [n_episodes] [record] [seed_base]` |
-| Score a checkpoint (baseline-comparable) | `just measure-checkpoint <ckpt> <config.yaml> [n_episodes] [record]` |
-| Score on the real table layouts | `just measure-maps <policy\|ckpt> <config.yaml> [n_episodes] [maps_dir] [decode_topk]` |
+| Scripted baselines (floor + bar) | `just measure-baselines <config.yaml> [n_episodes] [record] [seed_base] [key=value...]` |
+| Score a checkpoint (baseline-comparable) | `just measure-checkpoint <ckpt> <config.yaml> [n_episodes] [record] [decode_topk] [key=value...]` |
+| Score on the real table layouts | `just measure-maps <policy\|ckpt> <config.yaml> [n_episodes] [maps_dir] [decode_topk] [key=value...]` |
 | Why an objective was not held | `just measure-objective-split <policy\|ckpt> <config.yaml> [n_episodes]` |
 | How often a policy is in unit coherency | `just measure-coherency <policy\|ckpt> <config.yaml> [n_episodes]` |
 | Which calculator pays, and how much is global | `just measure-income-share <policy\|ckpt> <config.yaml> [n_episodes]` |
 | Clone a scripted policy into the network (warm-start checkpoint) | `just behaviour-clone <policy> <config.yaml> [n_episodes] [epochs] [out]` |
-| Two policies on identical layouts, paired per episode | `just measure-paired <policy\|ckpt> <policy\|ckpt> <config.yaml> [n_episodes] [seed_base]` |
-| Dice-vs-scenario noise floor | `just measure-noise-floor <config.yaml> [n_layouts] [n_combat_seeds] [policy]` |
+| Two policies on identical layouts, paired per episode | `just measure-paired <policy\|ckpt> <policy\|ckpt> <config.yaml> [n_episodes] [seed_base] [key=value...]` |
+| Dice-vs-scenario noise floor | `just measure-noise-floor <config.yaml> [n_layouts] [n_combat_seeds] [policy] [key=value...]` |
 | Terrain-profile statistics | `just measure-terrain <config.yaml> [n_layouts]` |
 | Where epoch time goes | `just measure-throughput <config.yaml> [n_steps] [engaged]` |
 | Profile | `just profile <config.yaml> [max_epochs]` |
@@ -406,6 +406,13 @@ paid for.
   for exactly this.
 - **Quote a t AND a sign count on the map pool.** Per-table differences are
   heavy-tailed and the two disagree often enough that either alone misleads.
+- **Every `measure-*` recipe takes trailing `key=value` scenario overrides** —
+  `rounds=5`, `weapon_range=24`, `turn_order=player` — so one config can be scored
+  at several settings of one number without copying it (`scripts/scenario_overrides.py`).
+  With no override token the load is exactly a plain parse, so every existing
+  invocation is unchanged. The printed header names the overrides, because a
+  table that does not say which scenario it measured gets compared to the wrong
+  one.
 - **n=100.** `measure-checkpoint` and `measure-baselines` default there, not 30:
   per-episode `vp_margin` sd is ~45–50, so n=30 gives SE ~8–9, larger than most
   arm differences ever measured here.

--- a/Justfile
+++ b/Justfile
@@ -252,8 +252,13 @@ measure-phase-gates checkpoint env_config n_episodes='30':
 # n=100 to match measure-checkpoint's default: an agent row and a baseline row
 # must be drawn from the same layout set *and* the same number of episodes, or
 # the comparison inherits the larger of the two error bars.
-measure-baselines env_config n_episodes='100' record='' seed_base='':
-	@uv run python -m scripts.measure_baselines {{env_config}} {{n_episodes}} "{{record}}" "{{seed_base}}"
+#
+# Every measure-* recipe takes trailing `key=value` scenario overrides --
+# `rounds=5`, `weapon_range=24`, `turn_order=player` -- so one config can be
+# scored at several settings of one number without copying it. See
+# scripts/scenario_overrides.py for why they are not positional.
+measure-baselines env_config n_episodes='100' record='' seed_base='' *overrides:
+	@uv run python -m scripts.measure_baselines {{env_config}} {{n_episodes}} "{{record}}" "{{seed_base}}" {{overrides}}
 
 # Score a checkpoint on held-out seeds through the same code path as the baselines,
 # so the two are directly comparable. Pass `record` as the fourth argument for a trace.
@@ -264,8 +269,8 @@ measure-baselines env_config n_episodes='100' record='' seed_base='':
 # to resolve what it was measuring. n=100 halves that to ~4.5 and costs minutes
 # against the hours a training run costs. Scoring was the cheap half being
 # under-sampled while the expensive half was over-sampled.
-measure-checkpoint checkpoint env_config n_episodes='100' record='' decode_topk='1':
-	@uv run python -m scripts.measure_checkpoint {{checkpoint}} {{env_config}} {{n_episodes}} "{{record}}" {{decode_topk}}
+measure-checkpoint checkpoint env_config n_episodes='100' record='' decode_topk='1' *overrides:
+	@uv run python -m scripts.measure_checkpoint {{checkpoint}} {{env_config}} {{n_episodes}} "{{record}}" {{decode_topk}} {{overrides}}
 
 # Final evaluation: score a policy on the real table layouts, one row per map.
 # Training uses `random_terrain`, so this is the only thing that asks how the
@@ -274,8 +279,8 @@ measure-checkpoint checkpoint env_config n_episodes='100' record='' decode_topk=
 # what was trained. Takes a baseline name or a checkpoint, like
 # measure-objective-split.
 # Use it like: just measure-maps <ckpt> configs/golden/25v25_shooting_opponent.yaml
-measure-maps policy env_config n_episodes='100' maps_dir='' decode_topk='1' decode_stay='':
-	@uv run python -m scripts.measure_maps {{policy}} {{env_config}} {{n_episodes}} "{{maps_dir}}" "{{decode_topk}}" "{{decode_stay}}"
+measure-maps policy env_config n_episodes='100' maps_dir='' decode_topk='1' decode_stay='' *overrides:
+	@uv run python -m scripts.measure_maps {{policy}} {{env_config}} {{n_episodes}} "{{maps_dir}}" "{{decode_topk}}" "{{decode_stay}}" {{overrides}}
 
 # Regenerate every evaluation table from the public layout API. The tables were
 # originally traced by hand from this same source and the tracing lost detail;
@@ -322,8 +327,8 @@ measure-income-share policy env_config n_episodes='30':
 # at n=100; the first number was noise. Read the win count beside the mean -- a
 # positive mean with a losing win count is a heavy tail, not an improvement.
 # Use: just measure-paired squad_march_shoot contest_and_spread <config> 100
-measure-paired policy_a policy_b env_config n_episodes='100' seed_base='700000':
-	@uv run python -m scripts.measure_paired_policies {{policy_a}} {{policy_b}} {{env_config}} {{n_episodes}} {{seed_base}}
+measure-paired policy_a policy_b env_config n_episodes='100' seed_base='700000' *overrides:
+	@uv run python -m scripts.measure_paired_policies {{policy_a}} {{policy_b}} {{env_config}} {{n_episodes}} {{seed_base}} {{overrides}}
 
 # Why an objective was not held: abandoned, narrowly lost, or lost by a mile.
 # `held` alone cannot separate those, and they call for different fixes. Also
@@ -350,8 +355,8 @@ render-coherency-figure env_config ckpt out seed='700000' step='20':
 # How much of a config's outcome spread is dice rather than policy. Holds the
 # layouts fixed and varies only the combat seed, so the within-layout spread is
 # the noise floor any arm-to-arm difference has to clear.
-measure-noise-floor env_config n_layouts='10' n_combat_seeds='10' policy='':
-	@uv run python -m scripts.measure_noise_floor {{env_config}} {{n_layouts}} {{n_combat_seeds}} "{{policy}}"
+measure-noise-floor env_config n_layouts='10' n_combat_seeds='10' policy='' *overrides:
+	@uv run python -m scripts.measure_noise_floor {{env_config}} {{n_layouts}} {{n_combat_seeds}} "{{policy}}" {{overrides}}
 
 # Terrain-layout statistics for a random_terrain config: coverage, how often a
 # sightline is blocked, and how much of the board is genuinely out of sight.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -146,7 +146,12 @@ Each baseline emits `_win_rate` (0–100), `_vp_margin`, `_at_objectives` (a
 fraction), `_fraction_alive` (a fraction), and `_exposure` when the config sets
 `track_exposure`. `random`, `squad_march` and `squad_march_shoot` are logged
 during training (`lightning_base.py:BASELINE_POLICIES`); the remaining rungs
-live in `scripts/measure_baselines.py`.
+live in `scripts/measure_baselines.py`, which scores nine policies —
+`hold_deployment` (the floor), `random`, `greedy_nearest`, `split_evenly`,
+`squad_march`, `squad_march_shoot`, `squad_march_deny`, `squad_march_take` and
+`contest_and_spread`. Its table prints **`vp_margin` and its standard error**
+beside the two VP columns, so a difference between two rows can be read against
+its own error bar rather than eyeballed.
 
 **Always read a number against the baselines.** Measured once per run at
 `on_train_start` over 20 held-out seeds, and constant thereafter. Every

--- a/scripts/measure_baselines.py
+++ b/scripts/measure_baselines.py
@@ -16,15 +16,13 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-from pydantic_yaml import parse_yaml_raw_as
-
+from scripts.scenario_overrides import describe, load_env_config, parse_overrides
 from wargame_rl.wargame.envs.baseline.evaluate import (
     evaluate_baseline,
     format_optional_metric,
     record_baseline_episode,
 )
 from wargame_rl.wargame.envs.baseline.registry import build_baseline_policy
-from wargame_rl.wargame.envs.types.config import WargameEnvConfig
 from wargame_rl.wargame.model.common.factory import create_environment
 
 # Ordered weakest to strongest so the printed table reads as a scale.
@@ -36,12 +34,24 @@ from wargame_rl.wargame.model.common.factory import create_environment
 # nearest-first, ignoring both an opponent that stops moving by round 9 and the
 # fact that a second shot on a one-wound target is usually discarded. Quoting a
 # learned policy only against the weaker bar overstates it.
+#
+# `hold_deployment` is the FLOOR and belongs in every table: on the real layouts
+# a third of the objectives sit inside a player's own zone, so standing still
+# already holds 1.27 of them and scores 121 VP. A scenario where it comes close
+# to the best script is a scenario that cannot be won by playing, and this table
+# is where that has to be visible. `squad_march_take` and `squad_march_deny` are
+# here because they, not `squad_march_shoot`, are the strongest scripts on the
+# generated tables — quoting a learned policy against the weaker bar overstates
+# it, which is the same mistake `contest_and_spread` was added to stop.
 BASELINES = (
+    "hold_deployment",
     "random",
     "greedy_nearest",
     "split_evenly",
     "squad_march",
     "squad_march_shoot",
+    "squad_march_deny",
+    "squad_march_take",
     "contest_and_spread",
 )
 
@@ -51,31 +61,41 @@ EVAL_SEED_BASE = 10_000
 
 def main() -> None:
     """Print a table of baseline results for the given env config."""
-    if len(sys.argv) < 2:
+    argv, overrides = parse_overrides(sys.argv)
+    if len(argv) < 2:
         print(__doc__)
         raise SystemExit(1)
 
-    config_path = sys.argv[1]
-    n_episodes = int(sys.argv[2]) if len(sys.argv) > 2 else 25
-    record = len(sys.argv) > 3 and sys.argv[3].lower() in {"record", "true", "1"}
+    config_path = argv[1]
+    n_episodes = int(argv[2]) if len(argv) > 2 else 25
+    record = len(argv) > 3 and argv[3].lower() in {"record", "true", "1"}
     # Pass the checkpoint script's base to put an agent and the baselines on
     # identical layouts; objective placement dominates episode variance, so an
     # unpaired comparison spends several VP of it on which maps each drew.
     # Empty means "not given" — the recipe passes every optional argument
     # through, so an omitted one arrives as "" rather than being absent.
-    seed_base = (
-        int(sys.argv[4]) if len(sys.argv) > 4 and sys.argv[4] else EVAL_SEED_BASE
-    )
+    seed_base = int(argv[4]) if len(argv) > 4 and argv[4] else EVAL_SEED_BASE
 
-    with open(config_path) as handle:
-        env_config = parse_yaml_raw_as(WargameEnvConfig, handle.read())
+    env_config = load_env_config(config_path, **overrides)
 
     env = create_environment(env_config=env_config)
     seeds = [seed_base + i for i in range(n_episodes)]
 
-    print(f"\n{config_path}  ({n_episodes} episodes, seeds {seeds[0]}-{seeds[-1]})\n")
+    print(
+        f"\n{config_path}{describe(overrides)}  ({n_episodes} episodes, "
+        f"seeds {seeds[0]}-{seeds[-1]})\n"
+    )
+    # `vp_margin` and its standard error, because the question this table is
+    # usually asked is whether two policies differ and by how much. The margin
+    # had to be computed by hand from the two VP columns, and the error bar was
+    # computed on `BaselineResult` and then discarded here -- so a table that
+    # looks like a comparison carried nothing to compare against. Per-episode
+    # `vp_margin` sd is 45-50 on 25v25, so at the recipe's n=100 the bar is
+    # ~4.5-5.0 and at n=30 it is ~8-9, wider than most differences ever
+    # measured here.
     header = (
-        f"{'baseline':<18}{'on_obj':>9}{'win':>8}{'player_vp':>11}"
+        f"{'baseline':<18}{'on_obj':>9}{'win':>8}{'vp_margin':>11}{'+/-':>7}"
+        f"{'player_vp':>11}"
         f"{'opp_vp':>9}{'held':>7}{'alive':>8}{'coherent':>10}{'adrift':>8}"
         f"{'exposure':>10}{'terrain_d':>11}{'firepower':>12}"
     )
@@ -90,6 +110,8 @@ def main() -> None:
             f"{name:<18}"
             f"{result.final_fraction_at_objectives:>9.3f}"
             f"{result.win_rate:>8.2f}"
+            f"{result.vp_margin:>11.1f}"
+            f"{format_optional_metric(result.vp_margin_se, 1):>7}"
             f"{result.player_vp:>11.1f}"
             f"{result.opponent_vp:>9.1f}"
             f"{result.objectives_held:>7.2f}"

--- a/scripts/measure_checkpoint.py
+++ b/scripts/measure_checkpoint.py
@@ -20,8 +20,8 @@ import sys
 from pathlib import Path
 
 import torch
-from pydantic_yaml import parse_yaml_raw_as
 
+from scripts.scenario_overrides import describe, load_env_config, parse_overrides
 from wargame_rl.wargame.envs.baseline.evaluate import (
     ActionSelector,
     BaselineResult,
@@ -29,11 +29,7 @@ from wargame_rl.wargame.envs.baseline.evaluate import (
     format_optional_metric,
     record_episode,
 )
-from wargame_rl.wargame.envs.types import (
-    WargameEnvAction,
-    WargameEnvConfig,
-    WargameEnvObservation,
-)
+from wargame_rl.wargame.envs.types import WargameEnvAction, WargameEnvObservation
 from wargame_rl.wargame.envs.wargame import WargameEnv
 from wargame_rl.wargame.model.common.decoding import decode_joint_coherent
 from wargame_rl.wargame.model.common.factory import create_environment
@@ -125,22 +121,22 @@ def format_result(result: BaselineResult) -> str:
 
 def main() -> None:
     """Score one checkpoint and print its row of the baseline table."""
-    if len(sys.argv) < 3:
+    argv, overrides = parse_overrides(sys.argv)
+    if len(argv) < 3:
         print(__doc__)
         raise SystemExit(1)
 
-    checkpoint_path = sys.argv[1]
-    config_path = sys.argv[2]
-    n_episodes = int(sys.argv[3]) if len(sys.argv) > 3 else 30
-    record = len(sys.argv) > 4 and sys.argv[4].lower() in {"record", "true", "1"}
+    checkpoint_path = argv[1]
+    config_path = argv[2]
+    n_episodes = int(argv[3]) if len(argv) > 3 else 30
+    record = len(argv) > 4 and argv[4].lower() in {"record", "true", "1"}
     # Joint constrained decoding, off by default so every historical row here
     # reproduces. It matters most for `record`: a recording made at K=1 shows
     # the referee cancelling a third of the unit-moves, which is the play the
     # decoder exists to replace, and is not what the checkpoint would do now.
-    decode_topk = int(sys.argv[5]) if len(sys.argv) > 5 else 1
+    decode_topk = int(argv[5]) if len(argv) > 5 else 1
 
-    with open(config_path) as handle:
-        env_config = parse_yaml_raw_as(WargameEnvConfig, handle.read())
+    env_config = load_env_config(config_path, **overrides)
     env_config.render_mode = None
 
     env = create_environment(env_config=env_config)
@@ -149,7 +145,10 @@ def main() -> None:
 
     name = label_for(checkpoint_path)
     print(f"\n{checkpoint_path}")
-    print(f"{config_path}  ({n_episodes} episodes, seeds {seeds[0]}-{seeds[-1]})\n")
+    print(
+        f"{config_path}{describe(overrides)}  ({n_episodes} episodes, "
+        f"seeds {seeds[0]}-{seeds[-1]})\n"
+    )
     header = (
         f"{'policy':<28}{'on obj':>10}{'win':>9}{'player VP':>12}"
         f"{'opp VP':>10}{'VP margin':>11}{'±SE':>8}{'held':>7}{'alive':>8}"

--- a/scripts/measure_maps.py
+++ b/scripts/measure_maps.py
@@ -31,6 +31,7 @@ from typing import cast
 from pydantic_yaml import parse_yaml_raw_as
 
 from scripts.measure_checkpoint import HELDOUT_SEED_BASE, build_selector, label_for
+from scripts.scenario_overrides import describe, load_env_config, parse_overrides
 from wargame_rl.wargame.envs.baseline.evaluate import (
     ActionSelector,
     BaselineResult,
@@ -156,27 +157,26 @@ def format_row(label: str, result: BaselineResult) -> str:
 
 def main() -> None:
     """Score one policy across every real map and print the per-map table."""
-    if len(sys.argv) < 3:
+    argv, overrides = parse_overrides(sys.argv)
+    if len(argv) < 3:
         print(__doc__)
         raise SystemExit(1)
 
-    policy_or_checkpoint = sys.argv[1]
-    config_path = sys.argv[2]
-    n_episodes = int(sys.argv[3]) if len(sys.argv) > 3 else 100
+    policy_or_checkpoint = argv[1]
+    config_path = argv[2]
+    n_episodes = int(argv[3]) if len(argv) > 3 else 100
     # Quoted in the recipe so an omitted `maps_dir` arrives as an empty
     # positional rather than collapsing and shifting `decode_topk` into its
     # place -- which made `just measure-maps <p> <cfg> <n>` fail outright.
-    maps_dir = (
-        Path(sys.argv[4]) if len(sys.argv) > 4 and sys.argv[4] else DEFAULT_MAPS_DIR
-    )
+    maps_dir = Path(argv[4]) if len(argv) > 4 and argv[4] else DEFAULT_MAPS_DIR
     # Joint constrained decoding: 1 keeps the historical independent argmax, so
     # every number measured before this existed still reproduces.
-    decode_topk = int(sys.argv[5]) if len(sys.argv) > 5 and sys.argv[5] else 1
+    decode_topk = int(argv[5]) if len(argv) > 5 and argv[5] else 1
     # Stand a unit still when the decoder finds nothing legal, instead of
     # letting the referee revert it and cascade onto its neighbours.
-    decode_stay = len(sys.argv) > 6 and sys.argv[6] not in ("", "0", "false")
+    decode_stay = len(argv) > 6 and argv[6] not in ("", "0", "false")
 
-    base_config = parse_yaml_raw_as(WargameEnvConfig, Path(config_path).read_text())
+    base_config = load_env_config(config_path, **overrides)
     maps = load_maps(maps_dir)
     # The same seeds on every map, so a difference between rows is the layout
     # and not the draw. Disjoint from training and model selection.
@@ -184,8 +184,8 @@ def main() -> None:
 
     print(f"\n{policy_or_checkpoint}")
     print(
-        f"{config_path}  ({len(maps)} maps x {n_episodes} episodes, "
-        f"seeds {seeds[0]}-{seeds[-1]})\n"
+        f"{config_path}{describe(overrides)}  ({len(maps)} maps x "
+        f"{n_episodes} episodes, seeds {seeds[0]}-{seeds[-1]})\n"
     )
     # `player VP` and `opp VP` are split out because the margin alone cannot say
     # which half moved, and under this mission they move for different reasons:

--- a/scripts/measure_noise_floor.py
+++ b/scripts/measure_noise_floor.py
@@ -22,11 +22,9 @@ from __future__ import annotations
 import statistics
 import sys
 
-from pydantic_yaml import parse_yaml_raw_as
-
+from scripts.scenario_overrides import describe, load_env_config, parse_overrides
 from wargame_rl.wargame.envs.baseline.evaluate import evaluate_baseline
 from wargame_rl.wargame.envs.baseline.registry import build_baseline_policy
-from wargame_rl.wargame.envs.types.config import WargameEnvConfig
 from wargame_rl.wargame.model.common.factory import create_environment
 
 # Held out from the training seed space, matching measure_baselines.
@@ -38,26 +36,26 @@ COMBAT_SEED_BASE = 900_000
 DEFAULT_POLICY = "squad_march_shoot"
 
 
-def _argument(index: int, default: str) -> str:
+def _argument(argv: list[str], index: int, default: str) -> str:
     """Read a positional argument. Recipes pass omitted ones through as ''."""
-    if len(sys.argv) > index and sys.argv[index]:
-        return sys.argv[index]
+    if len(argv) > index and argv[index]:
+        return argv[index]
     return default
 
 
 def main() -> None:
     """Print per-layout and aggregate outcome spread for one config."""
-    if len(sys.argv) < 2:
+    argv, overrides = parse_overrides(sys.argv)
+    if len(argv) < 2:
         print(__doc__)
         raise SystemExit(1)
 
-    config_path = sys.argv[1]
-    n_layouts = int(_argument(2, "10"))
-    n_combat_seeds = int(_argument(3, "10"))
-    policy_name = _argument(4, DEFAULT_POLICY)
+    config_path = argv[1]
+    n_layouts = int(_argument(argv, 2, "10"))
+    n_combat_seeds = int(_argument(argv, 3, "10"))
+    policy_name = _argument(argv, 4, DEFAULT_POLICY)
 
-    with open(config_path) as handle:
-        env_config = parse_yaml_raw_as(WargameEnvConfig, handle.read())
+    env_config = load_env_config(config_path, **overrides)
 
     env = create_environment(env_config=env_config)
     combat_seeds = [COMBAT_SEED_BASE + j for j in range(n_combat_seeds)]
@@ -106,7 +104,7 @@ def main() -> None:
     )
     within_sd = statistics.fmean(within_layout_sds)
 
-    print(f"\n{policy_name} on {config_path}")
+    print(f"\n{policy_name} on {config_path}{describe(overrides)}")
     print(f"  overall win rate                 {overall_win:.3f}")
     print(f"  vp_margin sd within a layout     {within_sd:.1f}   <- the dice")
     print(f"  vp_margin sd between layouts     {between_sd:.1f}   <- the scenario")

--- a/scripts/measure_paired_policies.py
+++ b/scripts/measure_paired_policies.py
@@ -32,9 +32,9 @@ from __future__ import annotations
 import sys
 
 import numpy as np
-from pydantic_yaml import parse_yaml_raw_as
 
 from scripts.measure_checkpoint import build_selector
+from scripts.scenario_overrides import describe, load_env_config, parse_overrides
 from wargame_rl.wargame.envs.baseline.evaluate import (
     ActionSelector,
     evaluate_selector,
@@ -86,22 +86,22 @@ def episode_margins(
 
 def main() -> None:
     """Print both arms' marginal means and the paired difference between them."""
-    if len(sys.argv) < 4:
+    argv, overrides = parse_overrides(sys.argv)
+    if len(argv) < 4:
         print(__doc__)
         raise SystemExit(1)
 
-    name_a, name_b, config_path = sys.argv[1], sys.argv[2], sys.argv[3]
+    name_a, name_b, config_path = argv[1], argv[2], argv[3]
     # A checkpoint path is far too long for a table column, and its basename is
     # what identifies the run anyway.
     label_a, label_b = (
         name.split("/")[-1][:30] if "/" in name else name for name in (name_a, name_b)
     )
-    n_episodes = int(sys.argv[4]) if len(sys.argv) > 4 else 100
-    seed_base = int(sys.argv[5]) if len(sys.argv) > 5 else HELDOUT_SEED_BASE
+    n_episodes = int(argv[4]) if len(argv) > 4 else 100
+    seed_base = int(argv[5]) if len(argv) > 5 else HELDOUT_SEED_BASE
     seeds = [seed_base + index for index in range(n_episodes)]
 
-    with open(config_path) as handle:
-        env_config = parse_yaml_raw_as(WargameEnvConfig, handle.read())
+    env_config = load_env_config(config_path, **overrides)
 
     margins_a = episode_margins(name_a, env_config, seeds)
     margins_b = episode_margins(name_b, env_config, seeds)
@@ -109,7 +109,10 @@ def main() -> None:
     stderr = float(delta.std(ddof=1) / np.sqrt(len(delta))) or float("inf")
     decided = int((delta != 0).sum())
 
-    print(f"\n{config_path}   {n_episodes} episodes, seeds {seed_base}+\n")
+    print(
+        f"\n{config_path}{describe(overrides)}   {n_episodes} episodes, "
+        f"seeds {seed_base}+\n"
+    )
     print(f"{label_a:<32}{margins_a.mean():>9.1f}   (sd {margins_a.std():.1f})")
     print(f"{label_b:<32}{margins_b.mean():>9.1f}   (sd {margins_b.std():.1f})")
     print(f"\npaired difference       {delta.mean():>9.1f}   +/- {stderr:.1f} (1 se)")

--- a/scripts/scenario_overrides.py
+++ b/scripts/scenario_overrides.py
@@ -1,0 +1,126 @@
+"""Load an env config with a scenario scalar overridden, from the command line.
+
+Two questions want the *same* scenario at several settings of one number — does
+the game survive the tabletop's five battle rounds, and what does a longer weapon
+range do — and until now neither could be asked. Every measurement script parses
+argv positionally and hands the YAML straight to `parse_yaml_raw_as`, and
+`train.py` exposes no env-scenario option at all, so a comparison meant copying a
+13 KB golden config and editing one line.
+
+`measure_maps.config_for_map` already refused that trade for terrain, and its
+reasoning transfers verbatim: copying a scenario per variation means every future
+reward change has to be applied N times, and **the first one that is missed makes
+the comparison measure a different game, silently**. So the variation is a
+`model_copy` of one config, exactly as it is there.
+
+## Why `key=value` rather than another positional
+
+`measure_maps` shipped a bug where an omitted `maps_dir` collapsed and shifted
+`decode_topk` into its place, which made `just measure-maps <p> <cfg> <n>` fail
+outright. Five scripts already carry four or five optional positionals each;
+adding a sixth to every one of them would be the same trap five more times.
+
+An override is therefore any argv token containing `=`. It can sit anywhere,
+positional arguments keep their positions whatever is passed, and a script that
+receives none behaves exactly as it did.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+from pydantic_yaml import parse_yaml_raw_as
+
+from wargame_rl.wargame.envs.types.config import TurnOrder, WargameEnvConfig
+
+# Every override is a scenario *scalar*: one number, one meaning, no derived
+# state to keep in step. Anything that would need a second field updated with it
+# belongs in a config file, where it can be reviewed.
+KNOWN_OVERRIDES = ("rounds", "weapon_range", "turn_order")
+
+
+def parse_overrides(argv: list[str]) -> tuple[list[str], dict[str, str]]:
+    """Split argv into positional arguments and `key=value` overrides.
+
+    Returns the positionals in their original order, so a caller's existing
+    indexing is unchanged, and the overrides as a plain string mapping — the
+    values are typed by `apply_overrides`, which knows what each one is.
+
+    An unknown key is an error rather than a silently ignored token: a
+    misspelled override that read as "no override" would score the wrong
+    scenario and look exactly like a real result.
+    """
+    positional: list[str] = []
+    overrides: dict[str, str] = {}
+    for token in argv:
+        if "=" not in token:
+            positional.append(token)
+            continue
+        key, _, value = token.partition("=")
+        if key not in KNOWN_OVERRIDES:
+            raise SystemExit(
+                f"unknown override '{key}'. Known: {', '.join(KNOWN_OVERRIDES)}"
+            )
+        overrides[key] = value
+    return positional, overrides
+
+
+def apply_overrides(config: WargameEnvConfig, **overrides: str) -> WargameEnvConfig:
+    """Return a deep copy of `config` with the named scenario scalars replaced.
+
+    The copy is deep because `weapon_range` reaches into every model's weapon
+    list, and mutating those in place would edit the caller's config — which,
+    for a script that loads one config and scores several policies against it,
+    would make the second policy play a different game from the first.
+    """
+    varied = cast(WargameEnvConfig, config.model_copy(deep=True))
+
+    if "rounds" in overrides:
+        varied.number_of_battle_rounds = int(overrides["rounds"])
+
+    if "turn_order" in overrides:
+        # Pinnable because `turn_order: random` is drawn from the *layout* RNG,
+        # so `measure-noise-floor` books first-player advantage under "the
+        # scenario" rather than "the dice". At four scoring events instead of
+        # nineteen that draw is a far larger share of the outcome, so the two
+        # horizons cannot be compared without holding it still.
+        varied.turn_order = TurnOrder(overrides["turn_order"])
+
+    if "weapon_range" in overrides:
+        weapon_range = int(overrides["weapon_range"])
+        # Both armies. Reaching only `models` would set up an asymmetric
+        # firefight while the caller believes it changed one number.
+        for model in list(varied.models or ()) + list(varied.opponent_models or ()):
+            for weapon in model.weapons:
+                weapon.range = weapon_range
+
+    return varied
+
+
+def load_env_config(path: str | Path, **overrides: str) -> WargameEnvConfig:
+    """Parse the config at `path`, applying any scenario overrides.
+
+    With no overrides this is exactly `parse_yaml_raw_as(WargameEnvConfig, ...)`,
+    which is what keeps every existing invocation of every measurement script
+    byte-identical.
+    """
+    config = cast(
+        WargameEnvConfig, parse_yaml_raw_as(WargameEnvConfig, Path(path).read_text())
+    )
+    if not overrides:
+        return config
+    return apply_overrides(config, **overrides)
+
+
+def describe(overrides: dict[str, str]) -> str:
+    """A short suffix naming the overrides, for a result table's header line.
+
+    Empty when there are none. Printed rather than assumed because a table whose
+    header does not say which scenario it measured is a table that will later be
+    compared against the wrong one.
+    """
+    if not overrides:
+        return ""
+    named = ", ".join(f"{key}={value}" for key, value in sorted(overrides.items()))
+    return f"  [{named}]"

--- a/tests/test_scenario_overrides.py
+++ b/tests/test_scenario_overrides.py
@@ -1,0 +1,108 @@
+"""Scenario scalars set from the command line, without copying a config.
+
+Two questions want the same scenario at several settings of one number — the
+tabletop's five battle rounds, and a longer weapon range — and neither could be
+asked, because every measurement script parsed argv positionally and handed the
+YAML straight to the parser.
+
+The failure this guards against is not an exception. It is a comparison that
+silently measures a different game: a copied 13 KB config that missed a later
+reward change, or an override token swallowed as a positional so the run scores
+the *unmodified* scenario and prints a plausible table. Hence the two properties
+pinned hardest here — no overrides is exactly a plain parse, and an override is
+recognised wherever it appears in argv.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic_yaml import parse_yaml_raw_as
+
+from scripts.scenario_overrides import (
+    apply_overrides,
+    describe,
+    load_env_config,
+    parse_overrides,
+)
+from wargame_rl.wargame.envs.types.config import TurnOrder, WargameEnvConfig
+
+GOLDEN = "configs/golden/25v25_maps_two_mode.yaml"
+
+
+class TestParsing:
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["prog", "cfg.yaml", "100", "rounds=5"],
+            ["prog", "rounds=5", "cfg.yaml", "100"],
+            ["prog", "cfg.yaml", "rounds=5", "100"],
+        ],
+        ids=["trailing", "leading", "middle"],
+    )
+    def test_an_override_is_found_wherever_it_sits(self, argv: list[str]) -> None:
+        """Position must not matter — that is the whole reason it is not one."""
+        positional, overrides = parse_overrides(argv)
+        assert positional == ["prog", "cfg.yaml", "100"]
+        assert overrides == {"rounds": "5"}
+
+    def test_argv_without_overrides_is_returned_unchanged(self) -> None:
+        argv = ["prog", "cfg.yaml", "100", "", "700000"]
+        positional, overrides = parse_overrides(argv)
+        assert positional == argv
+        assert overrides == {}
+
+    def test_an_unknown_key_is_refused_rather_than_ignored(self) -> None:
+        """Silently ignoring it would score the unmodified scenario."""
+        with pytest.raises(SystemExit, match="unknown override 'round'"):
+            parse_overrides(["prog", "cfg.yaml", "round=5"])
+
+    def test_a_bad_turn_order_is_refused_at_the_boundary(self) -> None:
+        config = parse_yaml_raw_as(WargameEnvConfig, open(GOLDEN).read())
+        with pytest.raises(ValueError):
+            apply_overrides(config, turn_order="whoever")
+
+
+class TestApplying:
+    def test_no_overrides_is_exactly_a_plain_parse(self) -> None:
+        """The property every existing invocation of every script relies on."""
+        plain = parse_yaml_raw_as(WargameEnvConfig, open(GOLDEN).read())
+        assert load_env_config(GOLDEN).model_dump() == plain.model_dump()
+
+    def test_rounds_changes_the_round_count_and_nothing_else(self) -> None:
+        plain = parse_yaml_raw_as(WargameEnvConfig, open(GOLDEN).read()).model_dump()
+        varied = load_env_config(GOLDEN, rounds="5").model_dump()
+        differing = {key for key in plain if plain[key] != varied[key]}
+        assert differing == {"number_of_battle_rounds"}
+        assert varied["number_of_battle_rounds"] == 5
+
+    def test_weapon_range_reaches_both_armies(self) -> None:
+        """Reaching only `models` would set up an asymmetric firefight."""
+        varied = load_env_config(GOLDEN, weapon_range="24")
+        assert varied.models is not None and varied.opponent_models is not None
+        for model in list(varied.models) + list(varied.opponent_models):
+            assert model.weapons, (
+                "fixture must arm its models for this to mean anything"
+            )
+            assert all(weapon.range == 24 for weapon in model.weapons)
+
+    def test_turn_order_can_be_pinned(self) -> None:
+        """measure-noise-floor books the random draw under 'the scenario'."""
+        assert (
+            load_env_config(GOLDEN, turn_order="player").turn_order is TurnOrder.player
+        )
+
+    def test_the_caller_s_config_is_not_mutated(self) -> None:
+        """A script loads one config and scores several policies against it."""
+        config = parse_yaml_raw_as(WargameEnvConfig, open(GOLDEN).read())
+        before = config.model_dump()
+        apply_overrides(config, rounds="5", weapon_range="24")
+        assert config.model_dump() == before
+
+
+def test_the_header_names_the_scenario_it_measured() -> None:
+    """A table that does not say which scenario it ran gets compared to another."""
+    assert describe({}) == ""
+    assert (
+        describe({"rounds": "5", "weapon_range": "24"})
+        == "  [rounds=5, weapon_range=24]"
+    )


### PR DESCRIPTION
Enabling work for the five-round and weapon-range questions. Two things were in the way, and both are small.

## You could not set a scenario scalar from the command line

Every measurement script parsed argv positionally and handed the YAML straight to `parse_yaml_raw_as`; `train.py` exposes no env-scenario option at all. So asking "what does this scenario look like at five rounds, or at weapon range 24" meant copying a 13 KB golden config and editing one line.

`measure_maps.config_for_map` already refused that trade for terrain, and its reasoning transfers verbatim — copying a scenario per variation means every future reward change has to be applied N times, and **the first one that is missed makes the comparison measure a different game, silently**. So `scripts/scenario_overrides.py` does the same thing: `model_copy(deep=True)` plus a targeted mutation.

**`key=value`, not another positional.** `measure_maps` shipped a bug where an omitted `maps_dir` collapsed and shifted `decode_topk` into its place, breaking `just measure-maps <p> <cfg> <n>` outright. These five scripts already carry four or five optional positionals each; a sixth on every one of them would be that trap five more times. An override is any argv token containing `=`, it can sit anywhere, and positional arguments keep their positions:

```
just measure-baselines <cfg> 100 "" 700000 rounds=5
just measure-maps <ckpt> <cfg> 100 <maps> 3 "" weapon_range=24
just measure-noise-floor <cfg> 10 10 squad_march_take rounds=5 turn_order=player
```

Three keys: `rounds`, `weapon_range` (walks both armies' weapon lists — reaching only `models` would set up an asymmetric firefight while the caller believes it changed one number), and `turn_order`. An unknown key is an error rather than an ignored token, because a misspelled override that read as "no override" would score the wrong scenario and look exactly like a real result.

`turn_order` is pinnable for a specific reason: it is drawn from the **layout** RNG, so `measure-noise-floor` books first-player advantage under "the scenario" rather than "the dice". At four scoring events instead of nineteen that draw is a far larger share of the outcome, so the two horizons cannot be compared without holding it still.

## The baselines table had no floor and no error bar

`BaselineResult.vp_margin_se` was computed and then discarded at the formatting layer, and `vp_margin` was not a column at all — you subtracted `player_vp - opp_vp` by hand. A table that looks like a comparison carried nothing to compare against.

And `BASELINES` was a hardcoded six that excluded the three policies that matter most: `hold_deployment` (the floor), `squad_march_take` and `squad_march_deny` (the two strongest scripts on the generated tables). The floor is the one that decides whether a scenario is worth training on at all — on the real layouts a third of the objectives sit inside a player's own zone, so standing still already holds 1.27 of them.

Both additive. Every pre-existing row keeps its numbers:

```
baseline             on_obj     win  vp_margin    +/-  player_vp   opp_vp   held   alive  coherent  adrift
hold_deployment       0.116    0.00     -226.0   14.5       48.0    274.0   0.40   0.512     0.963    0.22
random                0.042    0.00     -219.5    9.4       53.5    273.0   0.20   0.112     0.189   11.18
greedy_nearest        0.556    0.00     -178.5   10.8       95.5    274.0   0.70   0.428     0.951    0.48
...
```

## Verification

- **No-op on every existing invocation.** `load_env_config(path)` with no overrides is exactly `parse_yaml_raw_as`, pinned by a test that compares the two `model_dump()`s. `just measure-baselines <cfg> 10 "" 700000` reproduces every pre-existing row unchanged.
- `rounds=5` changes `number_of_battle_rounds` and **nothing else** — asserted as a set difference over the whole `model_dump()`, not a spot check.
- An override is found in leading, middle and trailing argv positions (parameterised), and argv with no override comes back identical.
- The caller's config is not mutated — a script loads one config and scores several policies against it, so in-place mutation would have the second policy play a different game from the first.
- 1484 tests pass; lint and mypy clean.

## Changes

- `scripts/scenario_overrides.py` — new: `parse_overrides`, `apply_overrides`, `load_env_config`, `describe`
- `scripts/measure_{baselines,maps,checkpoint,paired_policies,noise_floor}.py` — argv split, config load, and a header suffix naming the overrides
- `scripts/measure_baselines.py` — `vp_margin` + `+/-` columns; `hold_deployment`, `squad_march_deny`, `squad_march_take` added
- `Justfile` — `*overrides` passthrough on the five recipes
- `tests/test_scenario_overrides.py` — 12 tests
- `CLAUDE.md`, `docs/metrics.md` — recipe signatures and the baseline list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XAJMjm3331xXAh5qYFdCPh
