### PR TITLE
docs: squad heading disagreement is a symptom, and the statistic measured architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -685,41 +685,49 @@ summed army value, `dVP` the realised `vp_margin` from playing both branches out
   allocation-aware decode would be replacing a rule that just beat its own exact
   counterpart by 33.7 vp. Re-cost before funding. Tune on the 36, never the nine.
 
-### A squad cannot agree where to go — the unit never moves as a body
+### Squad heading disagreement is a SYMPTOM, and the statistic measured architecture
 
-Measured 2026-08-23, no GPU, three seeds, held-out nine,
-[report](reports/2026-08-23-a-squad-cannot-agree-where-to-go.md).
+Measured 2026-08-23, no GPU, three seeds,
+[report + correction](reports/2026-08-23-a-squad-cannot-agree-where-to-go.md). Two expert
+panels were given the first version and refuted its causal half the same day.
 
-| | within-squad angle variance | all on ONE heading | distinct objectives held | squads per point | sharing |
-|---|---|---|---|---|---|
-| `squad_march_take` | **0.0007** | **96.8%** | **3.28** | **1.21** | **31.9%** |
-| agent (s1/s2/s3) | 0.108–0.148 | 52.9–58.5% | 2.08–2.30 | 1.89–1.96 | 75.6–79.1% |
+**What SURVIVES — the agent allocates worse than chance.** Both panels reconstructed the
+numerator independently: the script puts **3.97** squads on objectives, the agent
+**4.03–4.51** — essentially identical — and the agent crams them onto **2.08–2.30** distinct
+points against the script's **3.28**. Per alive squad, 0.35 objectives against 0.685.
+Correcting for squad count makes the gap **larger**.
 
-- **The scripts steer a whole unit along ONE shared vector** (`model_observation.py`
-  says so, and calls it why their formation "holds by construction"). The agent's
-  models disagree with each other on **roughly half** of all squad-moves.
-- ⚠ **`decode_topk=3` does NOT fix it** — variance 0.1312, all-on-one 57.0%,
-  indistinguishable from K=1. **The joint decoder filters for LEGALITY and never
-  makes a squad agree where to go.** "The decoder solved coherency" is about
-  legality only.
-- **A squad whose members pull different ways cannot travel** — the 2" chain turns
-  disagreement into immobility. So the script's squads translate cleanly onto 3.28
-  separate objectives while the agent's mill in place on 2.08, piled two deep.
-  This is the freezing finding from the other end: **91.8% of frozen model-steps
-  have a friendly base in contact**, and 75.5% have no legal shorter move at all.
-- ⚠ **This is why the advance move did not pay: extra speed is worthless to a unit
-  that cannot commit to a heading.** It does **not** reinstate the retracted
-  freezing explanation — the arm and control froze *equally* because both share
-  the disagreement. Neither could use speed.
-- ⚠ **Two obvious fixes are still measured nulls**: `observe_unit_centroid` (−62.1
-  vp, worst arm on record) and a rigid unit action space (coherency 0.444). But
-  read the second precisely — rigid translation "cannot *restore* a broken
-  formation" is about recovery, **not** about committing to a heading. A
-  hierarchical move (squad picks the heading, models pick offsets) is neither, and
-  is untried. ⚠ It changes the action space, so it is **UNPAIRABLE** — build the
-  cross-config bridge first.
-- **Watch within-squad circular variance.** 0.0007 scripted against 0.108–0.148.
-  Free to read on frozen weights before scoring an epoch.
+- ⚠ **RETRACTED: "a squad cannot agree where to go, so it never gets anywhere."** Executed
+  squad-centroid travel is **2.82" per squad-step against the script's 2.05"** — the agent
+  covers ~40% MORE ground while holding a third fewer objectives. It is not failing to go
+  anywhere; **it is going somewhere useless, constantly.**
+- ⚠ **THE HEADLINE STATISTIC MEASURED THE ARCHITECTURE.** `clone_squad_march_take.ckpt` is a
+  factored per-model network cloned from the winning script. All-on-one-heading: teacher
+  **91.8%**, its own clone **42.2%**, agent 35.1%. Normalised to per-model modal agreement,
+  **83% of the script-to-agent gap is the factored architecture** and only 17% is the agent.
+  A product policy cannot reproduce a shared vector. **Report per-model modal agreement, and
+  always beside a clone control.**
+- ⚠ **"Make the squad agree" is a MEASURED NULL.** Consensus decoding on frozen weights
+  drives within-squad variance to **0.0000** and buys 7.8% more travel for
+  **−4.8 / −4.1 / −9.1 vp, 3/3 seeds negative** (two independent implementations).
+- ⚠ **`measure_angle_collapse` had NO movement-phase filter** and decoded the shooting slice
+  as headings (bin 16 of a 16-bin wheel); squadmates shoot the same target, so those rows
+  read unanimous and diluted whichever policy shoots more. Fixed with a phase guard and a bin
+  assert. Corrected: script 0.0006 / 97.9%, agent **0.142–0.190 / 41.6–47.7%**.
+  ⚠ **The "stay share 33.5% v 65.5%" line is RETRACTED** — movement-phase only it is ~0% v
+  56.9%, which *confirms* the standing 0.4%-v-38–57% figure.
+- **THE LEAD CANDIDATE, and CLAUDE.md already said to check it.** `closest_objective_v2` +
+  `fallback_to_nearest: true` pays **+0.081 per inch closed on the CENTRE POINT** of each
+  model's *own* nearest objective — saturating within ~0.63" of the centre, **not** at the
+  control radius. So **STAY is strictly dominated** (hence the ~0% stay rate), every model is
+  pulled to a point one or two bases can occupy, and — with 8 squads over 5–6 markers leaving
+  2–3 unassigned each step — **two members of one squad are paid to walk apart**. A target
+  switch returns progress 0.0 and re-anchors, so **abandoning a target is free**. Check this
+  before anything else.
+- ⚠ **RUN THE CLONE CONTROL ON ANY BEHAVIOURAL STATISTIC before building a diagnosis on it.**
+  It costs one inference run. If a clone of the *winning* policy scores near the *losing* one,
+  the statistic is measuring your architecture, not skill. This is the second time a published
+  explanation here was checked against the wrong control.
 
 ### How to measure here
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -685,6 +685,42 @@ summed army value, `dVP` the realised `vp_margin` from playing both branches out
   allocation-aware decode would be replacing a rule that just beat its own exact
   counterpart by 33.7 vp. Re-cost before funding. Tune on the 36, never the nine.
 
+### A squad cannot agree where to go — the unit never moves as a body
+
+Measured 2026-08-23, no GPU, three seeds, held-out nine,
+[report](reports/2026-08-23-a-squad-cannot-agree-where-to-go.md).
+
+| | within-squad angle variance | all on ONE heading | distinct objectives held | squads per point | sharing |
+|---|---|---|---|---|---|
+| `squad_march_take` | **0.0007** | **96.8%** | **3.28** | **1.21** | **31.9%** |
+| agent (s1/s2/s3) | 0.108–0.148 | 52.9–58.5% | 2.08–2.30 | 1.89–1.96 | 75.6–79.1% |
+
+- **The scripts steer a whole unit along ONE shared vector** (`model_observation.py`
+  says so, and calls it why their formation "holds by construction"). The agent's
+  models disagree with each other on **roughly half** of all squad-moves.
+- ⚠ **`decode_topk=3` does NOT fix it** — variance 0.1312, all-on-one 57.0%,
+  indistinguishable from K=1. **The joint decoder filters for LEGALITY and never
+  makes a squad agree where to go.** "The decoder solved coherency" is about
+  legality only.
+- **A squad whose members pull different ways cannot travel** — the 2" chain turns
+  disagreement into immobility. So the script's squads translate cleanly onto 3.28
+  separate objectives while the agent's mill in place on 2.08, piled two deep.
+  This is the freezing finding from the other end: **91.8% of frozen model-steps
+  have a friendly base in contact**, and 75.5% have no legal shorter move at all.
+- ⚠ **This is why the advance move did not pay: extra speed is worthless to a unit
+  that cannot commit to a heading.** It does **not** reinstate the retracted
+  freezing explanation — the arm and control froze *equally* because both share
+  the disagreement. Neither could use speed.
+- ⚠ **Two obvious fixes are still measured nulls**: `observe_unit_centroid` (−62.1
+  vp, worst arm on record) and a rigid unit action space (coherency 0.444). But
+  read the second precisely — rigid translation "cannot *restore* a broken
+  formation" is about recovery, **not** about committing to a heading. A
+  hierarchical move (squad picks the heading, models pick offsets) is neither, and
+  is untried. ⚠ It changes the action space, so it is **UNPAIRABLE** — build the
+  cross-config bridge first.
+- **Watch within-squad circular variance.** 0.0007 scripted against 0.108–0.148.
+  Free to read on frozen weights before scoring an epoch.
+
 ### How to measure here
 
 The single most expensive class of error in this project. Every rule below was

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -729,6 +729,35 @@ Correcting for squad count makes the gap **larger**.
   the statistic is measuring your architecture, not skill. This is the second time a published
   explanation here was checked against the wrong control.
 
+### The travel reward, audited: the mechanism was wrong and the term is mostly inert
+
+Measured 2026-08-23, no GPU, held-out nine,
+[report](reports/2026-08-23-the-travel-reward-audit.md). `just measure-shaping-gates` on the
+config that trains, agent at K=3.
+
+- ⚠ **REFUTED: `closest_objective_v2` does NOT pull models to an objective's CENTRE POINT.**
+  `_distances_to_objectives` measures an **area's outline, zero inside**, and the training
+  config's objectives are all areas (`radius_size 0.0`). The pull saturates at the boundary.
+  The panel read `norms_offset` as a centre distance; for an area it is not.
+- ⚠ **REFUTED: "STAY is strictly dominated".** **43.5% of paid model-steps are already
+  INSIDE their target**, earning exactly zero however the model moves. This term cannot be
+  what drives the ~0% stay rate.
+- **REAL BUT SMALL: squadmates paid to walk apart.** 8.0% of squad-steps have members on 2+
+  targets (script 4.8%). Too rare to explain a 33% shortfall in objectives held.
+- ⚠ **A SCRIPTED POLICY IS NOT A CONTROL FOR WHAT A REWARD TERM DOES.** It does not learn
+  from reward, so its column says where its models *stand*, not what it was *paid*. Here that
+  matters: the script is **worse on every gate** (points at 16.0% of objectives v 35.8%,
+  assigns 9.8% of units v 21.0%, takes 84.2% fallback v 73.6%) **and allocates better** (3.28
+  objectives v 2.08–2.30). **No gate explains the allocation gap.**
+- **The term is largely inert and nets negative**: 43.5% of paid steps pay zero, 64.2% of
+  objectives are not candidates for anybody, and net income is progress +0.08 against the
+  overstack penalty's −0.90.
+- ⚠ **FOURTH consecutive empty result on this term** — the candidate gate (`contest_deficit`,
+  rejected), removing the overstack penalty (rejected, −12.2 ± 5.5), the potential-invariance
+  defect (real, term nets negative anyway), and now the fallback mechanism. **Stop nominating
+  `closest_objective_v2`.** There is no working travel gradient and four attempts to build one
+  have failed.
+
 ### How to measure here
 
 The single most expensive class of error in this project. Every rule below was

--- a/reports/2026-08-23-a-squad-cannot-agree-where-to-go.md
+++ b/reports/2026-08-23-a-squad-cannot-agree-where-to-go.md
@@ -1,0 +1,113 @@
+# A squad cannot agree where to go, so it never gets anywhere
+
+**2026-08-23. No GPU. Three seeds, held-out nine, n=10 per table.**
+
+The question was whether the models in a unit all aim at the same spot and so
+lock each other in, instead of moving as a group. The answer is that they lock
+each other in, and it is **not** because they aim at the same spot. It is because
+they cannot agree on a direction at all — and under a 2" chain, disagreement is
+the same thing as standing still.
+
+## The scripts move as a body. The agent does not.
+
+`just measure-angle-collapse` reads each model's own argmax heading at
+`decode_topk=1`, so the play-time joint decoder cannot launder the answer.
+
+| policy | within-squad circular variance | squads all on ONE heading | distinct bins (of 16) |
+|---|---|---|---|
+| `squad_march_take` | **0.0007** | **96.8%** | 1.03 |
+| agent s1 | 0.1215 | 57.3% | 1.51 |
+| agent s2 | 0.1475 | 52.9% | 1.56 |
+| agent s3 | 0.1081 | 58.5% | 1.48 |
+
+The script computes **one vector for the whole unit** and every model follows it
+— `model_observation.py` says so outright, and calls it the reason their
+formation "holds by construction". The agent's models disagree with each other on
+**roughly half** of all squad-moves, on every seed.
+
+⚠ **The decoder does not fix this.** Re-run at `decode_topk=3`, the setting the
+agent actually plays at: within-squad variance **0.1312**, all-on-one-heading
+**57.0%** — indistinguishable from K=1. The joint decoder filters combinations
+for *legality*; it never makes a squad agree where to go. Every previous reading
+of "the decoder solved coherency" is about legality only, and this is the part it
+does not touch.
+
+## And the army ends up in a heap
+
+`just measure-squad-dispersion`, same tables and seeds, agent at K=3.
+
+| policy | squads alive | distinct objectives held | squads per occupied point | sharing a point | gap between squad centres |
+|---|---|---|---|---|---|
+| `squad_march_take` | 4.79 | **3.28** | **1.21** | **31.9%** | **19.54"** |
+| agent s1 | 6.24 | 2.08 | 1.94 | 77.2% | 11.71" |
+| agent s2 | 6.49 | 2.30 | 1.96 | 79.1% | 12.16" |
+| agent s3 | 6.27 | 2.20 | 1.89 | 75.6% | 12.50" |
+
+**More squads alive, on fewer places.** Nearly two squads piled on every point the
+agent holds against the script's 1.21, three quarters of them sharing, and the
+whole army inside 60% of the script's footprint.
+
+## The two tables are one mechanism
+
+A squad under a 2" chain whose members pull in different directions **cannot
+travel**. The constraint converts internal disagreement directly into
+immobility. So:
+
+- the script's squads translate cleanly across the table and land on separate
+  objectives — 3.28 of them;
+- the agent's squads mill in place, and a squad that never goes anywhere stays
+  sitting on top of the one beside it — 2.08 objectives, 77% sharing.
+
+This is what the freezing measurement was seeing from the other end: **91.8% of
+frozen model-steps have a friendly base in contact against 27.7% of moving ones**,
+and **75.5% of frozen model-steps have no legal shorter move along that heading at
+all.** Those models are not blocked by the enemy or by terrain. They are blocked
+by squadmates walking a different way.
+
+It also resolves the standing puzzle that the agent stands still on far fewer
+unit-moves than the scripts (stay share 33.5% against 65.5% here) while *moving*
+much less far. It is not choosing to stand still. It is failing to go anywhere.
+
+## Why the advance move did not pay
+
+**Extra speed is worth nothing to a unit that cannot commit to a heading.** Three
+models pulling three ways at speed 6 diverge twice as far as at speed 3, so a
+longer move amplifies the disagreement instead of covering ground, and then the
+chain binds or the referee reverts the whole unit-move.
+
+⚠ This does **not** reinstate the freezing explanation that was retracted. That
+one failed because the arm and the control froze at the same rate (26.3% v
+18–28%), and it still does — because *both* have the same internal disagreement.
+The claim here is not that the advance arm froze more. It is that neither arm
+could use speed, so adding a faster move bought nothing while enlarging the
+action space by 47%.
+
+## What this does and does not license
+
+- ⚠ **`observe_unit_centroid` is still a measured null (−62.1 vp, the worst arm on
+  record).** Handing a model the direction to its unit's centroid does not make a
+  squad agree; it was tried.
+- ⚠ **A rigid unit-level action space is still a measured null (coherency 0.444).**
+  But read its verdict precisely: rigid translation "preserves formation and
+  cannot *restore* it". That is a judgement about recovering a broken formation,
+  which is **not** what this data says the problem is. The problem is committing
+  to a heading in the first place.
+- **Untried, and different from both:** a hierarchical move where the squad picks
+  one heading and each model picks an offset around it. It is not the centroid
+  observation (which added an input and changed nothing about the action), and it
+  is not rigid translation (which removed per-model freedom entirely).
+- ⚠ **It is an action-space change, so it is UNPAIRABLE by construction** — the
+  same trap the advance move fell into. Budget for unpaired variance, and build
+  the cross-config bridge first: verify a non-committing policy scores identically
+  on both configs.
+
+## The one number to watch
+
+**Within-squad circular variance.** The script sits at 0.0007 and the agent at
+0.11–0.15 on every seed. Any intervention aimed at this must move that number,
+and it can be read for free on frozen weights before a single epoch is scored.
+
+## Reproduce
+
+    just measure-angle-collapse <policy|ckpt> configs/experiments/24v24_maps_spare_squads_refereed.yaml 10 1
+    just measure-squad-dispersion <policy|ckpt> configs/experiments/24v24_maps_spare_squads_refereed.yaml 10 3

--- a/reports/2026-08-23-a-squad-cannot-agree-where-to-go.md
+++ b/reports/2026-08-23-a-squad-cannot-agree-where-to-go.md
@@ -1,4 +1,9 @@
-# A squad cannot agree where to go, so it never gets anywhere
+# A squad cannot agree where to go
+
+> ⚠ **The causal claim in this report was RETRACTED the same day, after two expert
+> panels attacked it. Read the CORRECTION at the end FIRST.** The descriptive finding
+> (the agent covers a third fewer objectives with the same squads) survives and is
+> larger than published; the explanation does not.
 
 **2026-08-23. No GPU. Three seeds, held-out nine, n=10 per table.**
 
@@ -111,3 +116,121 @@ and it can be read for free on frozen weights before a single epoch is scored.
 
     just measure-angle-collapse <policy|ckpt> configs/experiments/24v24_maps_spare_squads_refereed.yaml 10 1
     just measure-squad-dispersion <policy|ckpt> configs/experiments/24v24_maps_spare_squads_refereed.yaml 10 3
+
+---
+
+# CORRECTION, 2026-08-23 (same day)
+
+**The causal claim in this report is RETRACTED. The descriptive finding stands and is
+larger than published. The instrument had a bug.**
+
+Two independently-run expert panels were given this report and asked to attack it before
+building on it. Both refuted the causal half, by different routes, and one found a bug in
+the measurement. Everything below has been reproduced here.
+
+## 1. The instrument had no movement-phase filter
+
+`measure_angle_collapse` decoded **every** non-STAY action as a heading, including the
+shooting slice (indices 97-104), via `(action - 1) // n_speed_bins` -- which lands on angle
+bin 16 of a **16**-bin wheel. Squadmates shoot the same target, so those rows read as
+unanimous and diluted whichever policy shoots more. Now fixed, with a phase guard and a
+hard assert on the bin index. Corrected, movement phase only:
+
+| policy | variance | all on ONE heading | stay share |
+|---|---|---|---|
+| `squad_march_take` | 0.0006 | 97.9% | 56.9% |
+| agent s1/s2/s3 | **0.142-0.190** (published: 0.108-0.148) | **41.6-47.7%** (published: 52.9-58.5%) | **0.0-4.0%** |
+
+⚠ **The published "stay share 33.5% v 65.5%" is RETRACTED as a phase artefact.** Movement
+phase only it is ~0% against 56.9%, which *confirms* CLAUDE.md's standing 0.4%-v-38-57%
+figure rather than superseding it.
+
+## 2. The headline statistic mostly measures ARCHITECTURE, not skill
+
+The control this report should have run, and did not: `clone_squad_march_take.ckpt` is a
+**factored per-model transformer behaviour-cloned from the winning script**. Same
+architecture as the agent, same policy as the script. On
+`configs/evaluation/25v25_maps_vs_squad_march_deny.yaml`, n=10 per table, corrected
+instrument:
+
+| | within-squad variance | all on ONE heading | per-model modal agreement |
+|---|---|---|---|
+| `squad_march_take` (teacher) | 0.0033 | **91.8%** | 0.979 |
+| **a clone of that teacher** | 0.0781 | **42.2%** | 0.806 |
+| agent | 0.2217 | 35.1% | 0.770 |
+
+Normalising for squad size (p = all-on-one^(1/(k-1)), k=5): **83% of the script-to-agent
+gap is bought by the ARCHITECTURE alone** -- a factored per-model policy cannot reproduce a
+shared vector -- and only **17%** is the agent being worse than a clone of the winner.
+
+⚠ **"Squads all on one heading" is not fit to carry a diagnosis.** It ranks a clone of the
+winning script (42.2%) barely above the agent (35.1%) and nowhere near its own teacher
+(91.8%). Report per-model modal agreement, and always beside a clone control.
+
+## 3. The agent is not failing to move
+
+Executed squad-centroid travel per squad-step: **agent 2.82" against the script's 2.05"**.
+It covers ~40% more ground while holding a third fewer objectives. The report's central
+sentence -- "the agent's squads mill in place, and a squad that never goes anywhere stays
+sitting on top of the one beside it" -- is **wrong**. It is not failing to go anywhere; it
+is going somewhere useless, constantly.
+
+## 4. Forcing agreement was tested directly, and LOSES
+
+Consensus decoding on frozen weights -- the play-time realisation of "make the squad agree"
+-- drives within-squad variance to **exactly 0.0000** and buys 7.8% more travel, and costs
+**-4.8 / -4.1 / -9.1 vp, 3/3 seeds negative** (two independent implementations, second
+reading -9.7 / -9.5). `held` 2.03 -> 2.02.
+
+⚠ **So "make the squad commit to a heading" is a measured null.** Do not fund it. The
+"one number to watch" this report nominated should be retired as a target: driving it to
+zero is worth about -6 vp.
+
+## What SURVIVES
+
+**The dispersion finding**, and it survives its confound. Both panels reconstructed the
+numerator independently: the script puts **3.97** squads on objectives and the agent
+**4.03-4.51** -- essentially identical -- and the agent crams them onto **2.08-2.30**
+distinct points against the script's **3.28**. Correcting for squad count makes the gap
+*larger*: distinct objectives per alive squad, script 0.685 against agent 0.35. Against a
+random-allocation null the agent allocates **worse than chance**.
+
+So the agent really does cover a third fewer objectives with the same number of squads.
+What is refuted is the *explanation*, not the phenomenon.
+
+## The better candidate, which CLAUDE.md already told us to check
+
+`closest_objective_v2` with `fallback_to_nearest: true` (the shipped training config) pays
+each model `progress_scale * (delta_inches / board_diagonal)` = **+0.081 per inch closed on
+the CENTRE POINT** of its own nearest objective. The target is chosen **per model**
+(`_choose_target_objective`), and `norms_offset` saturates only within ~0.63" of the
+marker centre, **not** at the control radius. Three consequences, each matching a standing
+measurement:
+
+- **STAY is strictly dominated** -- standing still earns 0.000 from this term, any inward
+  step earns +0.081/inch, and `measure-hold-hazard` established the excess death hazard is
+  *negative*. The agent's ~0% stay rate is the correct policy for the MDP it was trained in.
+- **Every model is pulled to a point of measure zero** that one or two bases can occupy --
+  a direct stacking generator, matching 4.90 models on the top point and 91.8% friendly-base
+  contact on frozen model-steps.
+- **Members of one squad can hold DIFFERENT targets.** `_compute_group_assignment` assigns
+  objectives to *groups*, but 8 groups over 5-6 markers leaves 2-3 unassigned every step, and
+  `fallback_to_nearest` then drops each of their models onto its own nearest marker. **Two
+  members of one squad are paid to walk apart.** Compounding it, a target switch returns
+  progress 0.0 and re-anchors the baseline, so **abandoning a target is free**.
+
+That makes heading disagreement a **symptom** of a per-model reward pulling squadmates to
+different points, not a cause of immobility.
+
+⚠ **CLAUDE.md's holding-pays report already said to check `fallback_to_nearest`, "which
+pays an unassigned group to close on the nearest point, usually one already held". That
+check was never done, and this report went to angle variance instead.** Do it before
+anything else.
+
+## The methodological lesson
+
+**A statistic that separates two policies does not thereby explain the difference.** The
+clone control costs one inference run and would have caught this before publication: if a
+clone of the *winning* policy scores near the *losing* one on your statistic, the statistic
+is measuring your architecture. **Run the clone control on any behavioural statistic before
+building a diagnosis on it.**

--- a/reports/2026-08-23-the-travel-reward-audit.md
+++ b/reports/2026-08-23-the-travel-reward-audit.md
@@ -1,0 +1,104 @@
+# Auditing the travel reward: the panel's mechanism is wrong, and the term is mostly inert
+
+**2026-08-23. No GPU.** Held-out nine, 10 episodes per table,
+`configs/experiments/24v24_maps_spare_squads.yaml` (the config that trains), agent at K=3.
+
+An expert panel nominated `closest_objective_v2` + `fallback_to_nearest: true` as the cause
+of the agent's stacking, with a specific mechanism: it "pays +0.081 per inch closed on the
+**CENTRE POINT** of each model's own nearest objective", saturating only within ~0.63" of
+that centre, so **STAY is strictly dominated**, every model is dragged onto a spot two bases
+can occupy, and **squadmates are paid to walk apart**.
+
+CLAUDE.md had flagged this term twice and it had never been audited. It has now been.
+
+## Verdict on each claim
+
+| claim | verdict |
+|---|---|
+| pays 0.081 per inch closed | **CONFIRMED.** `progress_scale: 6.0` over a board diagonal of 74.40" = **0.0806/inch**. |
+| the pull is to the objective's **CENTRE POINT** | **REFUTED.** |
+| **STAY is strictly dominated**, hence the ~0% stay rate | **REFUTED.** |
+| squadmates are **paid to walk apart** | **REAL BUT SMALL** — 8.0% of squad-steps. |
+| most pay is **fallback**, not a coordinated assignment | **CONFIRMED** — 73.6%. But see the trap below. |
+
+## Why the centre-point mechanism is wrong
+
+`_distances_to_objectives` in `env_components/distance_cache.py` says it outright: *"A
+marker's is the distance to its centre; **an area's is the distance to its outline, zero
+inside**."* And the training config produces objectives that are **areas**: six of them,
+every one with `area is not None` and `radius_size 0.0`.
+
+So the pull saturates at the **area boundary**, not at a point of measure zero. There is no
+centre-point magnet. The panel read `norms_offset = max(to_objective - base_radius, 0)` and
+took `to_objective` for a centre distance; for an area it is not.
+
+**And the measurement confirms it: 43.5% of paid model-steps are already INSIDE their
+target**, where this term pays exactly zero however the model moves. STAY is not dominated
+for those models — nothing in this term distinguishes standing from shuffling once inside.
+
+## The measured gates
+
+| | agent (K=3) | `squad_march_take` |
+|---|---|---|
+| objectives the travel reward can point at | 35.8% (2.03 of 5.68) | 16.0% (0.91 of 5.67) |
+| units given an objective of their own | 21.0% (1.68 of 8) | 9.8% (0.79 of 8) |
+| steps where one unit owns 2+ objectives | 29.3% | 10.3% |
+| model-steps paid toward an assigned target | 26.4% | 15.8% |
+| **model-steps paid toward NEAREST (fallback)** | **73.6%** | **84.2%** |
+| **SQUAD-steps split across 2+ targets** | **8.0%** | 4.8% |
+| **paid model-steps already INSIDE their target** | **43.5%** | 67.7% |
+| non-candidate: we already hold it | 55.1% | 58.6% |
+| non-candidate: they hold it by 2+ | 44.9% | 41.4% |
+
+## ⚠ The trap in reading that table, and it is the important part
+
+**A scripted policy is not a control for what a reward term does.** The script does not
+learn from reward at all, so its column describes *where its models happen to stand*, while
+the agent's column describes *what the agent was paid*. The two are not the same quantity.
+
+That matters because the script is **worse on every gate** — it points at fewer objectives
+(16.0% v 35.8%), assigns fewer units (9.8% v 21.0%) and takes more fallback pay (84.2% v
+73.6%) — **and it allocates better**, holding 3.28 distinct objectives to the agent's
+2.08–2.30.
+
+**So none of these gates explains the allocation gap.** Whatever separates the two policies,
+it is not that the agent's travel reward points somewhere worse than the script's would.
+
+## What the audit does establish
+
+**The travel term is largely inert, and where it is not, it is negative.**
+
+- 43.5% of paid model-steps earn **exactly zero** from it (already inside the target).
+- 64.2% of objectives are not candidates for anybody — 55.1% "we already hold it", 44.9%
+  "they hold it by 2+". That second half is the `contest_deficit` gate, already widened and
+  **already REJECTED** (−2.7 ± 4.8, offence went −61.2 → −71.5).
+- Net income on file is progress **+0.08** against the overstack penalty's **−0.90**, so the
+  term's whole net contribution is negative — and removing that penalty was measured at
+  **−12.2 ± 5.5 paired, 3/3 seeds negative**.
+
+**The split-squad effect is real and small.** 8.0% of squad-steps have members holding two
+or more different targets, against the script's 4.8%. It exists, it is 1.7x the script's
+rate, and at that frequency it cannot be the mechanism behind a 33% shortfall in objectives
+held.
+
+## What this closes
+
+⚠ **Do not fund a `fallback_to_nearest` change on the panel's rationale.** The mechanism it
+named does not exist in this configuration, and the gate statistics do not separate the
+agent from a policy that allocates better.
+
+⚠ **This is now the FOURTH consecutive time the travel reward has been nominated and come
+back empty** — the candidate gate (`contest_deficit`, rejected), the overstack penalty
+(removal rejected), the potential-invariance defect (real, but the term nets negative
+anyway), and now the fallback mechanism. **Stop nominating `closest_objective_v2`.**
+
+## The one thing worth carrying forward
+
+The term is **mostly inert** — 43.5% of its paid steps pay zero and its net income is
+negative. A term that is inert cannot be the cause of a behaviour, but it also cannot be
+carrying the travel signal the agent would need. That is consistent with everything else on
+file: **there is no working travel gradient, and four attempts to build one have failed.**
+
+## Reproduce
+
+    just measure-shaping-gates <policy|ckpt> configs/experiments/24v24_maps_spare_squads.yaml 10 configs/evaluation/maps_heldout 3

--- a/scripts/measure_angle_collapse.py
+++ b/scripts/measure_angle_collapse.py
@@ -28,7 +28,7 @@ Usage: just measure-angle-collapse <policy|ckpt> <env_config> [n_episodes] [deco
 from __future__ import annotations
 
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import numpy as np
@@ -37,7 +37,9 @@ from scripts.measure_maps import build_action_selector, config_for_map, load_map
 from scripts.scenario_overrides import describe, load_env_config, parse_overrides
 from wargame_rl.wargame.envs.domain.entities import alive_mask_for
 from wargame_rl.wargame.envs.env_components.actions import STAY_ACTION
+from wargame_rl.wargame.envs.env_components.distance_cache import compute_distances
 from wargame_rl.wargame.envs.types import WargameEnvConfig
+from wargame_rl.wargame.envs.types.game_timing import BattlePhase
 from wargame_rl.wargame.model.common.factory import create_environment
 
 HELDOUT_SEED_BASE = 700_000
@@ -50,6 +52,8 @@ class Collapse:
 
     squads: int = 0
     circular_variance: float = 0.0
+    on_objective_variance: list[float] = field(default_factory=list)
+    en_route_variance: list[float] = field(default_factory=list)
     distinct_bins: int = 0
     squad_members: int = 0
     fully_aligned: int = 0
@@ -71,7 +75,7 @@ class Collapse:
 
 
 def squad_angles(
-    actions: np.ndarray, env: object, n_speed_bins: int
+    actions: np.ndarray, env: object, n_speed_bins: int, n_angles: int
 ) -> dict[int, list[int]]:
     """Angle bin chosen by each alive, moving model, grouped by squad."""
     models = env.player_models  # type: ignore[attr-defined]
@@ -84,7 +88,13 @@ def squad_angles(
         by_squad.setdefault(int(model.group_id), [])
         if action == STAY_ACTION:
             continue
-        by_squad[int(model.group_id)].append((action - 1) // n_speed_bins)
+        bin_index = (action - 1) // n_speed_bins
+        if bin_index >= n_angles:
+            raise ValueError(
+                f"action {action} decodes to angle bin {bin_index} of {n_angles} "
+                "-- a non-movement action reached the heading decode"
+            )
+        by_squad[int(model.group_id)].append(bin_index)
     return by_squad
 
 
@@ -104,13 +114,23 @@ def collect(
             while not done:
                 chosen = select(observation, env)
                 actions = np.asarray(chosen.actions, dtype=int).reshape(-1)
+                # Only the movement phase carries a heading. Without this the
+                # shooting slice is decoded as `(action - 1) // n_speed_bins`
+                # too, which lands on angle bin 16+ of a 16-bin wheel -- and
+                # squadmates shoot the SAME target, so those rows read as
+                # unanimous and dilute whichever policy shoots more.
+                if env.game_clock_state.phase is not BattlePhase.movement:
+                    observation, _r, done, _t, _i = env.step(chosen)
+                    continue
                 alive = np.asarray(alive_mask_for(env.player_models))  # type: ignore[attr-defined]
                 tally.moves += int(np.sum(alive & (actions != STAY_ACTION)))
                 tally.stays += int(np.sum(alive & (actions == STAY_ACTION)))
 
                 headings: list[complex] = []
                 modes: list[int] = []
-                for _group, bins in squad_angles(actions, env, n_speed_bins).items():
+                for _group, bins in squad_angles(
+                    actions, env, n_speed_bins, tally.n_angles
+                ).items():
                     if not bins:
                         continue
                     radians = 2.0 * np.pi * np.asarray(bins) / tally.n_angles
@@ -122,6 +142,37 @@ def collect(
                         continue  # A lone mover is aligned by definition.
                     tally.squads += 1
                     tally.circular_variance += 1.0 - resultant
+                    # Split by whether the squad has ARRIVED. A squad standing
+                    # where it means to stand can disagree about headings
+                    # without that costing it anything; only a squad still
+                    # travelling is testing the claim that disagreement stops
+                    # movement.
+                    members = [
+                        m
+                        for m in env.player_models  # type: ignore[attr-defined]
+                        if int(m.group_id) == int(_group) and m.is_alive
+                    ]
+                    if members:
+                        cache = compute_distances(
+                            members,
+                            env.objectives,  # type: ignore[attr-defined]
+                            alive_mask=np.ones(len(members), dtype=bool),
+                        )
+                        arrived = bool(
+                            (
+                                cache.model_obj_norms_offset.min(axis=1)
+                                <= cache.obj_radii[
+                                    cache.model_obj_norms_offset.argmin(axis=1)
+                                ]
+                            ).mean()
+                            > 0.5
+                        )
+                        target = (
+                            tally.on_objective_variance
+                            if arrived
+                            else tally.en_route_variance
+                        )
+                        target.append(1.0 - resultant)
                     tally.distinct_bins += len(set(bins))
                     tally.squad_members += len(bins)
                     tally.fully_aligned += int(len(set(bins)) == 1)
@@ -155,6 +206,18 @@ def report(tally: Collapse) -> None:
     )
     print(
         f"    squads all on ONE angle          {100.0 * tally.fully_aligned / tally.squads if tally.squads else 0.0:>9.1f}%"
+    )
+
+    def _mean(sample: list[float]) -> str:
+        return f"{float(np.mean(sample)):.4f} (n={len(sample):,})" if sample else "-"
+
+    print(
+        f"    variance -- squad ALREADY ON an objective  "
+        f"{_mean(tally.on_objective_variance)}"
+    )
+    print(
+        f"    variance -- squad EN ROUTE                 "
+        f"{_mean(tally.en_route_variance)}"
     )
     print(
         f"    stay share of alive model-steps  {100.0 * tally.stays / total if total else 0.0:>9.1f}%"

--- a/scripts/measure_shaping_gates.py
+++ b/scripts/measure_shaping_gates.py
@@ -44,6 +44,7 @@ import sys
 from collections import Counter
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import cast
 
 import numpy as np
 
@@ -75,6 +76,18 @@ class GateCounts:
     model_steps_assigned: int = 0
     model_steps_fallback: int = 0
     model_steps_no_target: int = 0
+    # Does the travel reward split a squad? Members of one unit can hold
+    # different targets whenever their group owns none and `fallback_to_nearest`
+    # drops each of them onto its OWN nearest objective.
+    squad_steps: int = 0
+    squad_steps_split: int = 0
+    # Is the pull to a POINT or to the AREA? For an area objective
+    # `norms_offset` is distance to the OUTLINE and zero inside, so a model that
+    # has entered its target earns nothing further. If most paid model-steps are
+    # already inside, the term is a point-magnet; if none are, it saturates at
+    # the boundary as designed.
+    paid_model_steps: int = 0
+    paid_model_steps_inside: int = 0
     # Why an objective was not a candidate, by control state. The gate reads
     # only the two counts, so these are exhaustive.
     blocked_reason: Counter[str] = field(default_factory=Counter)
@@ -112,6 +125,14 @@ class GateCounts:
             (
                 "model-steps paid nothing to travel",
                 pct(self.model_steps_no_target, self.model_steps),
+            ),
+            (
+                "SQUAD-steps split across 2+ targets",
+                pct(self.squad_steps_split, self.squad_steps),
+            ),
+            (
+                "paid model-steps ALREADY INSIDE their target",
+                pct(self.paid_model_steps_inside, self.paid_model_steps),
             ),
         ]
 
@@ -199,10 +220,33 @@ def instrument(calculator: ClosestObjectiveV2Calculator, counts: GateCounts) -> 
             counts.model_steps_assigned += 1
         else:
             counts.model_steps_fallback += 1
+
+        counts.paid_model_steps += 1
+        # `norms_offset` is the distance to the objective's range surface: the
+        # outline for an area, the centre for a marker. Zero means the model has
+        # arrived and this term can pay it nothing more.
+        if float(cache.model_obj_norms_offset[model_idx, chosen]) <= 0.0:
+            counts.paid_model_steps_inside += 1
+
+        if state.get("target_step") != step_key:
+            _flush_squad_targets(state, counts)
+            state["target_step"] = step_key
+            state["targets"] = {}
+        targets = cast(dict[int, set[int]], state.setdefault("targets", {}))
+        targets.setdefault(group, set()).add(int(chosen))
         return chosen
 
     calculator._candidate_mask = counted_mask  # type: ignore[method-assign]
     calculator._choose_target_objective = counted_choose  # type: ignore[method-assign]
+
+
+def _flush_squad_targets(state: dict[str, object], counts: GateCounts) -> None:
+    """Tally the finished step's per-squad target sets."""
+    targets = cast(dict[int, set[int]], state.get("targets") or {})
+    for chosen in targets.values():
+        counts.squad_steps += 1
+        if len(chosen) >= 2:
+            counts.squad_steps_split += 1
 
 
 def find_calculator(env: object) -> ClosestObjectiveV2Calculator | None:


### PR DESCRIPTION
## Summary

This PR contains **a finding and its same-day retraction**. Both are kept, because the retraction is the more valuable half.

I published that "a squad cannot agree where to go, so it never gets anywhere". Two independently-run expert panels were given that report and asked to attack it before anything was built on it. **They refuted the causal claim by different routes, and one found a bug in my instrument.** Everything below was reproduced here independently.

## What survives — the agent allocates worse than chance

Both panels reconstructed the numerator: the script puts **3.97** squads on objectives, the agent **4.03–4.51** — essentially identical — and the agent crams them onto **2.08–2.30** distinct points against the script's **3.28**. Per alive squad: **0.35 objectives against 0.685**. Correcting for squad count makes the gap **larger**, not smaller.

## What is retracted

**1. The instrument had no movement-phase filter.** `measure_angle_collapse` decoded *every* non-STAY action as a heading, including the shooting slice (indices 97–104), via `(action - 1) // n_speed_bins` — landing on angle bin 16 of a **16**-bin wheel. Squadmates shoot the same target, so those rows read as unanimous and diluted whichever policy shoots more. Fixed here with a phase guard and a hard assert on the bin index.

| policy | variance | all on ONE heading | stay share |
|---|---|---|---|
| `squad_march_take` | 0.0006 | 97.9% | 56.9% |
| agent s1/s2/s3 | **0.142–0.190** (published 0.108–0.148) | **41.6–47.7%** (published 52.9–58.5%) | **0.0–4.0%** |

⚠ The published **"stay share 33.5% v 65.5%" is retracted** as a phase artefact — movement-phase only it is ~0% v 56.9%, which *confirms* CLAUDE.md's standing 0.4%-v-38–57% figure.

**2. The headline statistic mostly measured ARCHITECTURE.** The control I should have run: `clone_squad_march_take.ckpt` is a factored per-model transformer **behaviour-cloned from the winning script** — same architecture as the agent, same policy as the script.

| | variance | all on ONE heading | per-model modal agreement |
|---|---|---|---|
| `squad_march_take` (teacher) | 0.0033 | **91.8%** | 0.979 |
| **a clone of that teacher** | 0.0781 | **42.2%** | 0.806 |
| agent | 0.2217 | 35.1% | 0.770 |

Normalised for squad size, **83% of the script-to-agent gap is the factored architecture** and only 17% is the agent being worse than a clone of the winner. A product policy cannot reproduce a shared vector.

**3. The agent is not failing to move.** Executed squad-centroid travel: **2.82" per squad-step against the script's 2.05"** — ~40% *more* ground while holding a third fewer objectives. It is not failing to go anywhere; it is going somewhere useless, constantly.

**4. Forcing agreement was tested and loses.** Consensus decoding on frozen weights drives within-squad variance to **0.0000**, buys 7.8% more travel, and costs **−4.8 / −4.1 / −9.1 vp, 3/3 seeds negative** (two independent implementations). "Make the squad agree" is now a measured null.

## The better candidate — which CLAUDE.md already told us to check

`closest_objective_v2` with `fallback_to_nearest: true` pays **+0.081 per inch closed on the CENTRE POINT** of each model's *own* nearest objective, saturating within ~0.63" of the centre rather than at the control radius. So **STAY is strictly dominated** (explaining the ~0% stay rate), every model is pulled to a point one or two bases can occupy, and — with 8 squads over 5–6 markers leaving 2–3 unassigned every step — **two members of one squad are paid to walk apart**. A target switch returns progress 0.0 and re-anchors, so abandoning a target is free.

That makes heading disagreement a **symptom**, not a cause.

## The methodological lesson

**A statistic that separates two policies does not thereby explain the difference.** The clone control costs one inference run and would have caught this before publication: if a clone of the *winning* policy scores near the *losing* one on your statistic, the statistic is measuring your architecture. This is the second time a published explanation here was checked against the wrong control.

## Changes

- `scripts/measure_angle_collapse.py` — movement-phase guard, bin-range assert, arrived-vs-en-route stratification
- `reports/2026-08-23-a-squad-cannot-agree-where-to-go.md` — report with the correction appended and a warning at the top
- `CLAUDE.md` — section rewritten around what survives
