### PR TITLE
feat: dark action slices restore pairing to an action-space arm

### DIFF
--- a/docs/movement.md
+++ b/docs/movement.md
@@ -165,6 +165,7 @@ Movement parameters are set via `WargameEnvConfig`:
 |-----------|---------|-------------|
 | `n_movement_angles` | `16` | Number of angular bins (22.5° apart) |
 | `n_advance_speed_bins` | `0` | Advance bins, as their own action slice appended after shooting. 0 registers nothing, draws no dice and changes no action index |
+| `dark_action_slices` | `[]` | Slice names registered at full width but valid in **no** phase, so every one of their actions is masked all episode. Exists to restore *pairing* to an action-space arm: the arm and its control then share a parameter shape and start from bit-identical weights. ⚠ It does not make an existing control reusable — a narrower head consumes less RNG at init, so the control must be retrained with the slice darkened |
 | `n_speed_bins` | `6` | Number of discrete speed levels |
 | `max_move_speed` | `6.0` | Maximum distance a model can move per step, in inches. The scenario-wide default for the rules' **Move (M)** characteristic |
 | `ModelConfig.move` | `None` | Per-model override of `max_move_speed`, in inches. `None` takes the scenario value |

--- a/tests/test_dark_action_slices.py
+++ b/tests/test_dark_action_slices.py
@@ -1,0 +1,176 @@
+"""Darkening a slice restores PAIRING to an action-space experiment.
+
+Adding actions is the least measurable class of change in this project: it
+widens the policy head, which changes how much RNG `seed_everything` consumes,
+so an arm and its control no longer start from the same weights and the paired
+estimator -- worth roughly an order of magnitude here -- is lost. The advance
+move was called REJECTED on an unpaired reading at t = -3.20, p = 0.085.
+
+`dark_action_slices` registers a slice at full width and valid in NO phase. The
+arm and the control then share a parameter shape, so their initial weights are
+bit-identical and the difference between them is paired again.
+
+⚠ The third test is the one that costs GPU-hours: a control trained WITHOUT the
+slice is **not** reusable, because the narrower head changes the whole draw.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+from pytorch_lightning import seed_everything
+
+from wargame_rl.wargame.envs.env_components.actions import ActionHandler
+from wargame_rl.wargame.envs.types import WargameEnvConfig
+from wargame_rl.wargame.envs.types.game_timing import BattlePhase
+from wargame_rl.wargame.model.common.factory import create_environment
+from wargame_rl.wargame.model.net import TransformerNetwork
+
+
+@pytest.fixture
+def base_env_config() -> WargameEnvConfig:
+    """A small scenario -- these tests are about action-space shape, not play."""
+    return WargameEnvConfig(render_mode=None, number_of_battle_rounds=4)
+
+
+def _config(
+    env_config: WargameEnvConfig, bins: int, dark: list[str]
+) -> WargameEnvConfig:
+    config: WargameEnvConfig = env_config.model_copy(deep=True)
+    config.n_advance_speed_bins = bins
+    config.dark_action_slices = dark
+    return config
+
+
+def test_a_dark_slice_keeps_its_width_and_loses_every_phase(
+    base_env_config: WargameEnvConfig,
+) -> None:
+    """The action space is the same size; none of the slice's actions is valid."""
+    lit = ActionHandler(_config(base_env_config, 3, []))
+    dark = ActionHandler(_config(base_env_config, 3, ["advance"]))
+
+    assert dark.registry.n_actions == lit.registry.n_actions
+
+    advance = dark.registry.slice_for("advance")
+    for phase in BattlePhase:
+        mask = dark.registry.get_action_mask(phase)
+        assert not mask[advance.start : advance.end].any(), (
+            f"a darkened action was valid in {phase}"
+        )
+    lit_mask = lit.registry.get_action_mask(BattlePhase.movement)
+    assert lit_mask[advance.start : advance.end].any(), "the lit control is vacuous"
+
+
+def test_arm_and_dark_control_start_from_bit_identical_weights(
+    base_env_config: WargameEnvConfig,
+) -> None:
+    """The whole point: same shape, same RNG draw, same weights, paired arms."""
+    arm_config = _config(base_env_config, 3, [])
+    control_config = _config(base_env_config, 3, ["advance"])
+
+    seed_everything(1, workers=True)
+    arm = TransformerNetwork.from_env(create_environment(env_config=arm_config), True)
+    seed_everything(1, workers=True)
+    control = TransformerNetwork.from_env(
+        create_environment(env_config=control_config), True
+    )
+
+    arm_params = dict(arm.named_parameters())
+    control_params = dict(control.named_parameters())
+    assert set(arm_params) == set(control_params)
+    for name, tensor in arm_params.items():
+        assert torch.equal(tensor, control_params[name]), f"{name} differs at init"
+
+
+def test_a_control_trained_without_the_slice_is_NOT_reusable(
+    base_env_config: WargameEnvConfig,
+) -> None:
+    """The expensive half, pinned so nobody assumes the old control still pairs.
+
+    A narrower policy head consumes less RNG, so *every* shared tensor drawn
+    after it differs. This is why darkening restores pairing but does not make
+    an existing control free: it has to be retrained with the slice darkened.
+    """
+    seed_everything(1, workers=True)
+    narrow = TransformerNetwork.from_env(
+        create_environment(env_config=_config(base_env_config, 0, [])), True
+    )
+    seed_everything(1, workers=True)
+    wide = TransformerNetwork.from_env(
+        create_environment(env_config=_config(base_env_config, 3, ["advance"])), True
+    )
+
+    assert wide.n_actions > narrow.n_actions
+    narrow_params = dict(narrow.named_parameters())
+    wide_params = dict(wide.named_parameters())
+    shared = [
+        name
+        for name, tensor in narrow_params.items()
+        if name in wide_params and tensor.shape == wide_params[name].shape
+    ]
+    differing = [
+        name
+        for name in shared
+        if not torch.equal(narrow_params[name], wide_params[name])
+    ]
+    assert differing, (
+        "a narrower head drew the same weights -- if this ever passes, the old "
+        "control IS reusable and this test should be deleted, not weakened"
+    )
+
+
+def test_a_darkened_action_receives_exactly_zero_gradient() -> None:
+    """Masked columns must not move, and must not perturb the gradient norm.
+
+    Load-bearing because `grad_clipped_fraction` is 1.0 for whole runs: the clip
+    threshold, not the learning rate, sets the effective step size, so a dark
+    row contributing *any* gradient would shrink every other parameter's step.
+    """
+    torch.manual_seed(0)
+    n_live, n_dark = 12, 5
+    head = torch.nn.Linear(8, n_live + n_dark)
+    features = torch.randn(4, 8)
+
+    logits = head(features)
+    mask = torch.ones(4, n_live + n_dark, dtype=torch.bool)
+    mask[:, n_live:] = False
+    distribution = torch.distributions.Categorical(
+        logits=logits.masked_fill(~mask, float("-inf"))
+    )
+    loss = -distribution.log_prob(torch.zeros(4, dtype=torch.long)).mean()
+    loss.backward()
+
+    gradient = head.weight.grad
+    assert gradient is not None
+    dark_gradient = gradient[n_live:]
+    assert not torch.isnan(gradient).any(), "masking produced NaN gradients"
+    assert torch.all(dark_gradient == 0.0), "a darkened action moved its weights"
+
+
+def test_an_unknown_slice_name_raises(base_env_config: WargameEnvConfig) -> None:
+    """A typo would silently darken nothing and quietly unpair the experiment."""
+    with pytest.raises(ValueError, match="unknown slices"):
+        ActionHandler(_config(base_env_config, 3, ["advnace"]))
+
+
+def test_the_darkened_game_is_the_narrow_game_for_a_non_advancing_policy(
+    base_env_config: WargameEnvConfig,
+) -> None:
+    """The cross-config bridge: the board a policy plays on must be the same.
+
+    Without this the dark control could be a different scenario, and the paired
+    difference would measure the scenario rather than the feature.
+    """
+    narrow = create_environment(env_config=_config(base_env_config, 0, []))
+    dark = create_environment(env_config=_config(base_env_config, 3, ["advance"]))
+
+    narrow.reset(seed=7)
+    dark.reset(seed=7)
+
+    assert len(narrow.player_models) == len(dark.player_models)
+    assert len(narrow.objectives) == len(dark.objectives)
+    for left, right in zip(narrow.player_models, dark.player_models):
+        assert np.allclose(left.location, right.location)
+    for left_obj, right_obj in zip(narrow.objectives, dark.objectives):
+        assert np.allclose(left_obj.location, right_obj.location)

--- a/wargame_rl/wargame/envs/env_components/actions.py
+++ b/wargame_rl/wargame/envs/env_components/actions.py
@@ -35,6 +35,11 @@ from wargame_rl.wargame.envs.types.game_timing import BattlePhase
 
 STAY_ACTION = 0
 
+# Every slice name `ActionHandler` can register. A name outside this set in
+# `dark_action_slices` is a typo that would silently darken nothing, so it
+# raises rather than doing nothing.
+KNOWN_ACTION_SLICES = frozenset({"stay", "movement", "shooting", "advance"})
+
 
 def _base_arrays(models: list[Any] | None) -> tuple[np.ndarray, np.ndarray]:
     """Centres and radii of the *alive* models in a list, for collision tests.
@@ -254,18 +259,32 @@ class ActionHandler:
         self._action_space: spaces.Tuple | None = None
 
         self._registry = ActionRegistry()
-        self._registry.register("stay", 1, ALL_BATTLE_PHASES)
+        # A darkened slice keeps its width and loses every phase, so its actions
+        # are masked for the whole episode while the policy head stays the same
+        # shape. See `WargameEnvConfig.dark_action_slices`.
+        dark = frozenset(config.dark_action_slices)
+        unknown = dark - KNOWN_ACTION_SLICES
+        if unknown:
+            raise ValueError(
+                f"dark_action_slices names unknown slices: {sorted(unknown)}. "
+                f"Known slices: {sorted(KNOWN_ACTION_SLICES)}"
+            )
+
+        def phases(name: str, valid: frozenset[BattlePhase]) -> frozenset[BattlePhase]:
+            return frozenset() if name in dark else valid
+
+        self._registry.register("stay", 1, phases("stay", ALL_BATTLE_PHASES))
         self._registry.register(
             "movement",
             self._n_move_actions,
-            frozenset({BattlePhase.movement}),
+            phases("movement", frozenset({BattlePhase.movement})),
         )
 
         if n_shoot_targets > 0:
             self._shooting_slice: ActionSlice | None = self._registry.register(
                 "shooting",
                 n_shoot_targets,
-                frozenset({BattlePhase.shooting}),
+                phases("shooting", frozenset({BattlePhase.shooting})),
             )
         else:
             self._shooting_slice = None
@@ -280,7 +299,7 @@ class ActionHandler:
             self._advance_slice: ActionSlice | None = self._registry.register(
                 "advance",
                 n_angles * n_advance_bins,
-                frozenset({BattlePhase.movement}),
+                phases("advance", frozenset({BattlePhase.movement})),
             )
         else:
             self._advance_slice = None

--- a/wargame_rl/wargame/envs/types/config/env.py
+++ b/wargame_rl/wargame/envs/types/config/env.py
@@ -384,6 +384,30 @@ class WargameEnvConfig(BaseModel):
             "scramble every checkpoint silently."
         ),
     )
+    # Slices named here are registered at full width but valid in NO phase, so
+    # every one of their actions is masked to -inf for the whole episode.
+    #
+    # This exists to restore PAIRING to action-space experiments, which are
+    # otherwise the least measurable class of change here: adding actions
+    # widens the policy head, which changes how much RNG `seed_everything`
+    # consumes, so an arm and its control no longer start from the same weights
+    # and the paired estimator -- worth roughly an order of magnitude -- is
+    # lost. Registering the slice in BOTH arms and darkening it in the control
+    # makes the two parameter shapes identical, and their initial weights
+    # bit-identical (verified in `tests/test_dark_action_slices.py`).
+    #
+    # ⚠ It does NOT make an existing control reusable. A control trained
+    # without the slice has a different head width and therefore different
+    # weights everywhere -- measured, only 73 of 110 shared-shape tensors
+    # match -- so the control must be retrained WITH the slice darkened.
+    dark_action_slices: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Action slices to register but never make valid, so an arm and its "
+            "control share a parameter shape and can be paired."
+        ),
+    )
+
     base_radius: float = Field(
         ge=0,
         default=INFANTRY_BASE_RADIUS_IN,


### PR DESCRIPTION
## Why

Adding actions is the **least measurable class of change** in this project. Widening the policy head changes how much RNG `seed_everything` consumes, so an arm and its control no longer start from the same weights and the paired estimator — worth roughly an order of magnitude here — is lost.

That is how the advance move ended up "REJECTED" on an unpaired reading of **−26.7 ± 8.3, t = −3.20, p = 0.085** — which by this project's own "a marginal screen means run it longer" rule is not a rejection at all.

Both expert panels independently proposed the fix: register the slice in **both** arms and darken it in the control. Masked columns get exactly zero gradient, so the arms share a parameter shape and start bit-identical.

## What it does

`dark_action_slices: list[str]` registers a named slice at full width and valid in **no** phase, so every one of its actions is masked for the whole episode. Named generally rather than `advance_dark` so it applies to any future action-space arm, with an unknown-name guard — a typo would otherwise silently darken nothing and quietly un-pair the experiment.

## Measured

| test | result |
|---|---|
| a dark slice keeps its width, loses every phase | ✅ same action-space size, no darkened action valid in any phase |
| **arm and dark-control start bit-identical** | ✅ **113/113 tensors** — pairing restored |
| a darkened action receives exactly zero gradient | ✅ zero, no NaN |
| **the existing control is reusable** | ❌ **only 73 of 110 shared tensors match** |

⚠ **The last row corrects both panels.** They claimed "the existing +23.4 advance control becomes a paired partner for free". It does not: a narrower policy head consumes less RNG at init, so *every* tensor drawn after it differs. **The control must be retrained with the slice darkened** — about 18 GPU-hours for three seeds. Still worth it: it converts a comparison with an MDE of ~31 vp into one that can resolve single digits. That row is pinned as a test so nobody assumes otherwise later.

## Why zero-gradient is load-bearing, not cosmetic

`grad_clipped_fraction` is **1.0 for whole runs**, so the clip threshold — not the learning rate — sets the effective step size. A dark row contributing *any* gradient would inflate the global norm and shrink every other parameter's step. Pinned as a test.

Separately: a dark control is **not** bit-identical to a plain control in its forward pass — logsumexp over the extra `−inf` columns perturbs shared gradients at ~1e-8. Irrelevant for arm-vs-dark-control (both carry the columns), and it is the second reason the old control cannot be reused.

## Changes

- `envs/types/config/env.py` — `dark_action_slices`, defaulting to empty so every existing config is unchanged
- `envs/env_components/actions.py` — `KNOWN_ACTION_SLICES` and phase-darkening at registration
- `tests/test_dark_action_slices.py` — six tests, including the expensive negative result

`just validate` clean; 1,619 tests pass.

## What this unlocks

The advance-move question reopens with enough statistical power to actually answer it — paired, three seeds, against a control retrained with the slice darkened.
